### PR TITLE
[Cmake] use pch for sycl/sycl.hpp

### DIFF
--- a/.github/workflows/shamrock-dpcpp.yml
+++ b/.github/workflows/shamrock-dpcpp.yml
@@ -47,7 +47,7 @@ jobs:
       - name: configure Shamrock
         run: |
           python3 buildbot/configure.py --gen ninja --tests --build debug \
-            --outdir dpcpp_bare_debug --cxxpath dpcpp_compiler --compiler dpcpp --profile bare --cmakeargs="-DSHAMROCK_USE_PCH=On"
+            --outdir dpcpp_bare_debug --cxxpath dpcpp_compiler --compiler dpcpp --profile bare
 
       - name: compile Shamrock
         run: |
@@ -121,7 +121,7 @@ jobs:
         run: |
           python3 buildbot/configure.py --gen ninja --tests --build debug \
             --outdir dpcpp_bare_debug --cxxpath dpcpp_compiler --compiler dpcpp --profile cuda \
-            --cxxflags="--cuda-path=/home/docker/opt/cuda" --cmakeargs="-DSHAMROCK_USE_PCH=On"
+            --cxxflags="--cuda-path=/home/docker/opt/cuda"
 
       - name: compile Shamrock
         run: |
@@ -201,7 +201,7 @@ jobs:
         run: |
           python3 buildbot/configure.py --gen ninja --tests --build debug \
             --outdir dpcpp_bare_debug --cxxpath dpcpp_compiler --compiler dpcpp --profile hip-gfx906 \
-            --cxxflags="--rocm-path=/opt/rocm" --cmakeargs="-DSHAMROCK_USE_PCH=On"
+            --cxxflags="--rocm-path=/opt/rocm"
 
       - name: compile Shamrock
         run: |

--- a/.github/workflows/shamrock-opensycl.yml
+++ b/.github/workflows/shamrock-opensycl.yml
@@ -47,7 +47,7 @@ jobs:
       - name: configure Shamrock
         run: |
           python3 buildbot/configure.py --gen ninja --tests --build debug \
-            --outdir opensycl_omp_debug --cxxpath OpenSYCL_comp --compiler opensycl --profile omp_coverage --cmakeargs="-DSHAMROCK_USE_PCH=On"
+            --outdir opensycl_omp_debug --cxxpath OpenSYCL_comp --compiler opensycl --profile omp_coverage
 
       - name: compile Shamrock
         run: |
@@ -155,7 +155,7 @@ jobs:
       - name: configure Shamrock
         run: |
           python3 buildbot/configure.py --gen ninja --tests --build release \
-            --outdir build --cxxpath OpenSYCL_comp --compiler opensycl --profile omp --cmakeargs="-DSHAMROCK_USE_PCH=On"
+            --outdir build --cxxpath OpenSYCL_comp --compiler opensycl --profile omp
   
       - name: compile Shamrock
         run: |
@@ -241,7 +241,7 @@ jobs:
         run: |
           python3 buildbot/configure.py --gen ninja --tests --build release \
             --outdir build --cxxpath OpenSYCL_comp --compiler opensycl --profile cuda-sm70 \
-            --cxxflags="--opensycl-cuda-path=/home/docker/opt/cuda" --cmakeargs="-DSHAMROCK_USE_PCH=On"
+            --cxxflags="--opensycl-cuda-path=/home/docker/opt/cuda"
   
       - name: compile Shamrock
         run: |


### PR DESCRIPTION
Using -DSHAMROCK_USE_PCH=On in make enable precompiled sycl.hpp header