### PR TITLE
[Backend] Buffer class to handle allocation

### DIFF
--- a/src/shambackends/include/shambackends/Buffer.hpp
+++ b/src/shambackends/include/shambackends/Buffer.hpp
@@ -15,6 +15,7 @@
  *
  */
 #include "shambackends/queues.hpp"
+#include "shamcomm/logs.hpp"
 
 namespace sham::buffer::details {
 
@@ -23,14 +24,20 @@ namespace sham::buffer::details {
 
         QueueId queue_id;
         std::unique_ptr<sycl::buffer<T>> storage;
+        u64 size;
 
         public:
         inline QueueId get_queue_id() { return queue_id; }
 
         inline sycl::queue &get_queue() { queue_id.get_queue(); }
 
-        BufferAllocBasic(u64 size, QueueId qid) : queue_id(qid) {
+        BufferAllocBasic(u64 sz, QueueId qid) : queue_id(qid), size(sz) {
+            shamcomm::logs::debug_alloc_ln("BufferImpl Basic", "alloc size =",sz);
             storage = std::make_unique<sycl::buffer<T>>(size);
+        }
+
+        ~BufferAllocBasic() noexcept {
+            shamcomm::logs::debug_alloc_ln("BufferImpl Basic", "free size =",size);
         }
 
         inline sycl::buffer<T> &get_buf() const { return *storage; }

--- a/src/shambackends/include/shambackends/queues.hpp
+++ b/src/shambackends/include/shambackends/queues.hpp
@@ -80,4 +80,8 @@ namespace sham {
         return id.get_queue_details();
     }
 
+    inline QueueId get_queue_id(u32 id = 0, queues::QueueKind kind = queues::Compute){
+        return {id, kind};
+    }
+
 } // namespace sham

--- a/src/tests/shambackends/Buffer_test.cpp
+++ b/src/tests/shambackends/Buffer_test.cpp
@@ -19,17 +19,7 @@
 
 TestStart(Unittest, "sham::Buffer", sham_buffer, 1){
 
-    sham::Buffer<f64> buf;
+    sham::Buffer<f64> buf(1000, sham::get_queue_id());
 
-    _Assert(buf.get_capacity() == 0)
-    _Assert(buf.is_allocated() == false)
-    buf.alloc(1000);
-
-    _Assert(buf.get_capacity() >= 1000)
-    _Assert(buf.is_allocated() == true)
-
-    buf.free();
-    _Assert(buf.get_capacity() == 0)
-    _Assert(buf.is_allocated() == false)
 
 }


### PR DESCRIPTION
add `sham::Buffer`, which handle all allocation/free mechanism and memory op on the base storage. By modifying the impl of `ResizableBuffer`; it is possible to modify the allocation behavior without any changes in solvers

Buffer Impl :
- [ ] Base buffer (`sycl::buffer<T>`)
- [ ] Reinterpret buffer (`sycl::buffer<u8>`) (test perf impact of reinterpret)
- [ ] Reinterpret buffer pool (use pool of old `sycl::buffer<u8>` to reduce allocation latency)