### PR TITLE
[Test] add a latency benchmark

### DIFF
--- a/env/machine/debian-generic/acpp/env_built_acpp.sh
+++ b/env/machine/debian-generic/acpp/env_built_acpp.sh
@@ -18,6 +18,7 @@ function shamconfigure {
         -DSHAMROCK_ENABLE_BACKEND=SYCL \
         -DSYCL_IMPLEMENTATION=ACPPDirect \
         -DCMAKE_CXX_COMPILER="${ACPP_INSTALL_DIR}/bin/acpp" \
+        -DCMAKE_CXX_FLAGS="${SHAMROCK_CXX_FLAGS}" \
         -DACPP_PATH="${ACPP_INSTALL_DIR}" \
         -DCMAKE_BUILD_TYPE="${SHAMROCK_BUILD_TYPE}" \
         -DBUILD_TEST=Yes

--- a/env/machine/debian-generic/acpp/setup-env.py
+++ b/env/machine/debian-generic/acpp/setup-env.py
@@ -51,10 +51,6 @@ def setup(argv,builddir, shamrockdir,buildtype):
     ENV_SCRIPT_HEADER += "export ACPP_BUILD_DIR="+ACPP_BUILD_DIR+"\n"
     ENV_SCRIPT_HEADER += "export ACPP_INSTALL_DIR="+ACPP_INSTALL_DIR+"\n"
 
-    if not (acpp_target == None):
-        ENV_SCRIPT_HEADER += "export ACPP_TARGETS=\""+acpp_target+"\"\n"
-    else:
-        ENV_SCRIPT_HEADER += "unset -f ACPP_TARGETS\n"
 
     ENV_SCRIPT_HEADER += "\n"
     ENV_SCRIPT_HEADER += "export CMAKE_GENERATOR=\""+cmake_gen+"\"\n"
@@ -63,6 +59,7 @@ def setup(argv,builddir, shamrockdir,buildtype):
     ENV_SCRIPT_HEADER += "export MAKE_OPT=("+gen_opt+")\n"
 
     ENV_SCRIPT_HEADER += "export SHAMROCK_BUILD_TYPE=\""+cmake_build_type+"\"\n"
+    ENV_SCRIPT_HEADER += "export SHAMROCK_CXX_FLAGS=\" --acpp-targets='"+acpp_target+"'\"\n"
 
     # Get current file path
     cur_file = os.path.realpath(os.path.expanduser(__file__))

--- a/src/tests/shambackends/latency_test.cpp
+++ b/src/tests/shambackends/latency_test.cpp
@@ -1,0 +1,299 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright(C) 2021-2023 Timothée David--Cléris <timothee.david--cleris@ens-lyon.fr>
+// Licensed under CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#include "shambase/stacktrace.hpp"
+#include "shambase/time.hpp"
+
+#include "shambackends/sycl.hpp"
+#include "shamcomm/logs.hpp"
+#include "shamsys/NodeInstance.hpp"
+#include "shamtest/details/TestResult.hpp"
+#include "shamtest/shamtest.hpp"
+
+#include <memory>
+#include <vector>
+
+f64 test_buffer_out_of_order(u32 buf_size, u32 stream_count, u32 repeat_count) {
+    StackEntry stack_loc{};
+
+    std::vector<std::unique_ptr<sycl::buffer<f64>>> bufs{};
+
+    // allocate and init
+    for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+        std::unique_ptr<sycl::buffer<f64>> buf = std::make_unique<sycl::buffer<f64>>(buf_size);
+
+        shamsys::instance::get_compute_queue()
+            .submit([&](sycl::handler &cgh) {
+                sycl::accessor acc{*buf, cgh, sycl::write_only, sycl::no_init};
+
+                cgh.parallel_for(sycl::range<1>{buf_size}, [=](sycl::item<1> id) {
+                    u32 gid = id.get_linear_id();
+
+                    acc[gid] = gid;
+                });
+            })
+            .wait();
+
+        bufs.push_back(std::move(buf));
+    }
+
+    shambase::Timer timer;
+    timer.start();
+
+    for (u32 irepeat = 0; irepeat < repeat_count; irepeat++) {
+        for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+            shamsys::instance::get_compute_queue().submit([&](sycl::handler &cgh) {
+                sycl::accessor acc{*bufs[ibuf], cgh, sycl::read_write};
+
+                cgh.parallel_for(sycl::range<1>{buf_size}, [=](sycl::item<1> id) {
+                    u32 gid = id.get_linear_id();
+
+                    acc[gid] = acc[gid] * f64(1.1);
+                });
+            });
+        }
+    }
+
+    shamsys::instance::get_compute_queue().wait();
+
+    timer.end();
+    return timer.elasped_sec();
+}
+
+f64 test_buffer_in_order(u32 buf_size, u32 stream_count, u32 repeat_count) {
+    StackEntry stack_loc{};
+
+    sycl::queue q = sycl::queue{
+        shamsys::instance::get_compute_scheduler().ctx->ctx,
+        shamsys::instance::get_compute_scheduler().ctx->device->dev,
+        sycl::property::queue::in_order{}};
+
+    std::vector<std::unique_ptr<sycl::buffer<f64>>> bufs{};
+
+    // allocate and init
+    for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+        std::unique_ptr<sycl::buffer<f64>> buf = std::make_unique<sycl::buffer<f64>>(buf_size);
+
+        q.submit([&](sycl::handler &cgh) {
+             sycl::accessor acc{*buf, cgh, sycl::write_only, sycl::no_init};
+
+             cgh.parallel_for(sycl::range<1>{buf_size}, [=](sycl::item<1> id) {
+                 u32 gid = id.get_linear_id();
+
+                 acc[gid] = gid;
+             });
+         }).wait();
+
+        bufs.push_back(std::move(buf));
+    }
+
+    shambase::Timer timer;
+    timer.start();
+
+    for (u32 irepeat = 0; irepeat < repeat_count; irepeat++) {
+        for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+            q.submit([&](sycl::handler &cgh) {
+                sycl::accessor acc{*bufs[ibuf], cgh, sycl::read_write};
+
+                cgh.parallel_for(sycl::range<1>{buf_size}, [=](sycl::item<1> id) {
+                    u32 gid = id.get_linear_id();
+
+                    acc[gid] = acc[gid] * f64(1.1);
+                });
+            });
+        }
+    }
+
+    q.wait();
+
+    timer.end();
+    return timer.elasped_sec();
+}
+
+f64 test_buffer_in_order_multi_queue(u32 buf_size, u32 stream_count, u32 repeat_count) {
+    StackEntry stack_loc{};
+
+    std::vector<std::unique_ptr<sycl::queue>> queues{};
+    for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+        queues.push_back(std::make_unique<sycl::queue>(sycl::queue{
+            shamsys::instance::get_compute_scheduler().ctx->ctx,
+            shamsys::instance::get_compute_scheduler().ctx->device->dev,
+            sycl::property::queue::in_order{}}));
+    }
+
+    std::vector<std::unique_ptr<sycl::buffer<f64>>> bufs{};
+
+    // allocate and init
+    for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+        std::unique_ptr<sycl::buffer<f64>> buf = std::make_unique<sycl::buffer<f64>>(buf_size);
+
+        queues[ibuf]
+            ->submit([&](sycl::handler &cgh) {
+                sycl::accessor acc{*buf, cgh, sycl::write_only, sycl::no_init};
+
+                cgh.parallel_for(sycl::range<1>{buf_size}, [=](sycl::item<1> id) {
+                    u32 gid = id.get_linear_id();
+
+                    acc[gid] = gid;
+                });
+            })
+            .wait();
+
+        bufs.push_back(std::move(buf));
+    }
+
+    shambase::Timer timer;
+    timer.start();
+
+    for (u32 irepeat = 0; irepeat < repeat_count; irepeat++) {
+        for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+            queues[ibuf]->submit([&](sycl::handler &cgh) {
+                sycl::accessor acc{*bufs[ibuf], cgh, sycl::read_write};
+
+                cgh.parallel_for(sycl::range<1>{buf_size}, [=](sycl::item<1> id) {
+                    u32 gid = id.get_linear_id();
+
+                    acc[gid] = acc[gid] * f64(1.1);
+                });
+            });
+        }
+    }
+
+    for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+        queues[ibuf]->wait();
+    }
+    timer.end();
+    return timer.elasped_sec();
+}
+
+
+
+f64 test_usm_in_order(u32 buf_size, u32 stream_count, u32 repeat_count) {
+
+    StackEntry stack_loc{};
+
+    
+    sycl::queue q = sycl::queue{
+        shamsys::instance::get_compute_scheduler().ctx->ctx,
+        shamsys::instance::get_compute_scheduler().ctx->device->dev,
+        sycl::property::queue::in_order{}};
+
+    std::vector<f64*> bufs{};
+
+    // allocate and init
+    for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+        f64* buf = sycl::malloc_device<f64>(buf_size, q);
+
+        q.submit([&](sycl::handler &cgh) {
+
+                cgh.parallel_for(sycl::range<1>{buf_size}, [=](sycl::item<1> id) {
+                    u32 gid = id.get_linear_id();
+
+                    buf[gid] = gid;
+                });
+            })
+            .wait();
+
+        bufs.push_back(std::move(buf));
+    }
+
+    shambase::Timer timer;
+    timer.start();
+
+    for (u32 irepeat = 0; irepeat < repeat_count; irepeat++) {
+        for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+            f64* buf = bufs[ibuf];
+            q.submit([&](sycl::handler &cgh) {
+
+                cgh.parallel_for(sycl::range<1>{buf_size}, [=](sycl::item<1> id) {
+                    u32 gid = id.get_linear_id();
+
+                    buf[gid] = buf[gid] * f64(1.1);
+                });
+            });
+        }
+    }
+
+    q.wait();
+    timer.end();
+
+    for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+        f64* buf = bufs[ibuf];
+        sycl::free(buf, q);
+    }
+    return timer.elasped_sec();
+}
+
+f64 test_usm_in_order_multi_queue(u32 buf_size, u32 stream_count, u32 repeat_count) {
+
+    StackEntry stack_loc{};
+
+    std::vector<std::unique_ptr<sycl::queue>> queues{};
+    for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+        queues.push_back(std::make_unique<sycl::queue>(sycl::queue{
+            shamsys::instance::get_compute_scheduler().ctx->ctx,
+            shamsys::instance::get_compute_scheduler().ctx->device->dev,
+            sycl::property::queue::in_order{}}));
+    }
+
+    std::vector<f64*> bufs{};
+
+    // allocate and init
+    for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+        f64* buf = sycl::malloc_device<f64>(buf_size, *queues[ibuf]);
+
+        queues[ibuf]
+            ->submit([&](sycl::handler &cgh) {
+
+                cgh.parallel_for(sycl::range<1>{buf_size}, [=](sycl::item<1> id) {
+                    u32 gid = id.get_linear_id();
+
+                    buf[gid] = gid;
+                });
+            })
+            .wait();
+
+        bufs.push_back(std::move(buf));
+    }
+
+    shambase::Timer timer;
+    timer.start();
+
+    for (u32 irepeat = 0; irepeat < repeat_count; irepeat++) {
+        for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+            f64* buf = bufs[ibuf];
+            queues[ibuf]->submit([&](sycl::handler &cgh) {
+
+                cgh.parallel_for(sycl::range<1>{buf_size}, [=](sycl::item<1> id) {
+                    u32 gid = id.get_linear_id();
+
+                    buf[gid] = buf[gid] * f64(1.1);
+                });
+            });
+        }
+    }
+
+    for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+        queues[ibuf]->wait();
+    }
+    timer.end();
+
+    for (u32 ibuf = 0; ibuf < stream_count; ibuf++) {
+        f64* buf = bufs[ibuf];
+        sycl::free(buf, *queues[ibuf]);
+    }
+    return timer.elasped_sec();
+}
+
+TestStart(Benchmark, "latency_sycl", latency_sycl, 1) {
+    shamcomm::logs::raw_ln(test_buffer_out_of_order(1e4, 10, 1000));
+    shamcomm::logs::raw_ln(test_buffer_in_order(1e4, 10, 1000));
+    shamcomm::logs::raw_ln(test_buffer_in_order_multi_queue(1e4, 10, 1000));
+    shamcomm::logs::raw_ln(test_usm_in_order(1e4, 10, 1000));
+    shamcomm::logs::raw_ln(test_usm_in_order_multi_queue(1e4, 10, 1000));
+}


### PR DESCRIPTION

```c++
TestStart(Benchmark, "latency_sycl", latency_sycl, 1) {
    shamcomm::logs::raw_ln(test_buffer_out_of_order(1e4, 10, 1000));
    shamcomm::logs::raw_ln(test_buffer_in_order(1e4, 10, 1000));
    shamcomm::logs::raw_ln(test_buffer_in_order_multi_queue(1e4, 10, 1000));
    shamcomm::logs::raw_ln(test_usm_in_order(1e4, 10, 1000));
    shamcomm::logs::raw_ln(test_usm_in_order_multi_queue(1e4, 10, 1000));
}
```

Acpp generic : 
```bash
./shamrock_test --sycl-cfg 0:0 --benchmark --sycl-ls-map --run-only "latency_sycl"
```
result : 
0.070847993 
0.061088953 
0.065656644 
0.048299939 
0.052605223000000007 

Acpp cuda : 
```bash
./shamrock_test --sycl-cfg 0:0 --benchmark --sycl-ls-map --run-only "latency_sycl"
```
result : 
0.053051025 
0.044024394 
0.047571074000000005 
0.032104978 
0.03432607 


intel llvm cuda : 
```bash
./shamrock_test --sycl-cfg 1:1 --benchmark --sycl-ls-map --run-only "latency_sycl"
```
result : 
0.11991356600000001 
0.11678176800000001 
0.119054951 
0.09482852900000001 
0.09626036 