### PR TITLE
[CI] add filter to clang tidy job

### DIFF
--- a/buildbot/make_clang_tidy_db.py
+++ b/buildbot/make_clang_tidy_db.py
@@ -6,6 +6,23 @@ db = comp_db.read()
 db = db.replace("--acpp-targets='omp'","")
 #print(db)
 
+
+def remove_external_files():
+    global db
+    
+    import json
+    dic = json.loads(db)
+
+    ret_dic = []
+
+    for a in dic:
+        if not ("Shamrock/external" in a["file"]):
+            ret_dic.append(a)
+
+    db = json.dumps(ret_dic)
+
+remove_external_files()
+
 try:
     os.mkdir("build/clang-tidy.mod")
 except:


### PR DESCRIPTION
exclude files in ./external from clang-tidy job