### PR TITLE
[Env] dgx env : add case for built from source OpenMPI & UCX

### DIFF
--- a/env/helpers/clone-intel-llvm.sh
+++ b/env/helpers/clone-intel-llvm.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+if [ -z ${INTELLLVM_GIT_DIR+x} ]; then echo "INTELLLVM_GIT_DIR is unset"; return; fi
+
+if [ ! -f "$INTELLLVM_GIT_DIR/README.md" ]; then
+    echo " ------ Clonning LLVM ------ "
+
+    if [ -z ${INTEL_LLVM_VERSION+x} ]
+    then
+        git clone -b sycl https://github.com/intel/llvm.git $INTELLLVM_GIT_DIR
+        (cd $INTELLLVM_GIT_DIR && git checkout $INTEL_LLVM_VERSION)
+    else
+        git clone -b sycl https://github.com/intel/llvm.git $INTELLLVM_GIT_DIR
+    fi
+    echo " ------  LLVM Cloned  ------ "
+
+fi

--- a/env/helpers/setup_mpi.sh
+++ b/env/helpers/setup_mpi.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+if [ -z ${UCX_INSTALL_PATH+x} ]; then echo "UCX_INSTALL_PATH is unset"; return; fi
+if [ -z ${OMPI_INSTALL_PATH+x} ]; then echo "OMPI_INSTALL_PATH is unset"; return; fi
+if [ -z ${OMPI_SOURCE_DIR+x} ]; then echo "OMPI_SOURCE_DIR is unset"; return; fi
+if [ -z ${CUDA_PATH+x} ]; then echo "CUDA_PATH is unset"; return; fi
+
+if [ -z ${UCX_URL+x} ]; then echo "UCX_URL is unset"; return; fi
+if [ -z ${OMPI_URL+x} ]; then echo "OMPI_URL is unset"; return; fi
+
+export PATH=$OMPI_INSTALL_PATH/bin${PATH:+:${PATH}}
+export LD_LIBRARY_PATH=$OMPI_INSTALL_PATH/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+export PATH=$UCX_INSTALL_PATH/bin${PATH:+:${PATH}}
+export LD_LIBRARY_PATH=$UCX_INSTALL_PATH/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+mkdir -p $OMPI_SOURCE_DIR
+
+function buildinstall_ucx {
+
+    ### UCX section
+    wget -O ucx.tar.gz $UCX_URL
+    tar -xf ucx.tar.gz
+    rm ucx.tar.gz
+    mv ucx $OMPI_SOURCE_DIR/ucx
+
+    cd $OMPI_SOURCE_DIR/ucx
+
+    ./configure --prefix=$UCX_INSTALL_PATH --with-cuda=$CUDA_PATH --without-go
+
+    make -j64
+    make install
+}
+
+function buildinstall_ompi {
+
+    ### Ompi section
+    wget -O openmpi.tar.gz $OMPI_URL
+    tar -xf openmpi.tar.gz
+    rm openmpi.tar.gz
+    mv openmpi $OMPI_SOURCE_DIR/openmpi
+
+    cd $OMPI_SOURCE_DIR/openmpi
+
+    ./configure --prefix=$OMPI_INSTALL_PATH --with-cuda=$CUDA_PATH --with-ucx=$UCX_INSTALL_PATH
+
+    make -j64
+    make install
+}
+
+if [ ! -f "$UCX_INSTALL_PATH/ucx_info" ]; then
+    echo " ------ Building UCX ------ "
+    buildinstall_ucx
+fi
+
+if [ ! -f "$OMPI_INSTALL_PATH/ompi_info" ]; then
+    echo " ------ Building OpenMPI ------ "
+    buildinstall_ompi
+fi

--- a/env/machine/dgx-cbp/intel-llvm/setup-env.py
+++ b/env/machine/dgx-cbp/intel-llvm/setup-env.py
@@ -6,6 +6,7 @@ import utils.envscript
 import utils.cuda_arch
 import utils.amd_arch
 from utils.setuparg import *
+from utils.oscmd import *
 
 NAME = "CBP Nvidia DGX A100 Intel LLVM CUDA"
 PATH = "machine/debian-generic/intel-llvm"
@@ -33,14 +34,16 @@ def setup(arg : SetupArg):
 
     parser.add_argument("--gen", action='store', help="generator to use (ninja or make)")
 
+    parser.add_argument("--custommpi", action='store_true', help="build shamrock with custom mpi support")
+    parser.add_argument("--ucxurl", action='store', help="ucx source url")
+    parser.add_argument("--ompiurl", action='store', help="ompi source url")
+
     args = parser.parse_args(argv)
 
     gen, gen_opt, cmake_gen, cmake_build_type = utils.sysinfo.select_generator(args, buildtype)
 
     INTELLLVM_GIT_DIR = builddir+"/.env/intel-llvm-git"
     INTELLLVM_INSTALL_DIR = builddir + "/.env/intel-llvm-installdir"
-
-    utils.intel_llvm.clone_intel_llvm(INTELLLVM_GIT_DIR)
 
     ENV_SCRIPT_PATH = builddir+"/activate"
 
@@ -49,6 +52,16 @@ def setup(arg : SetupArg):
     ENV_SCRIPT_HEADER += "export BUILD_DIR="+builddir+"\n"
     ENV_SCRIPT_HEADER += "export INTELLLVM_GIT_DIR="+INTELLLVM_GIT_DIR+"\n"
     ENV_SCRIPT_HEADER += "export INTELLLVM_INSTALL_DIR="+INTELLLVM_INSTALL_DIR+"\n"
+
+    run_cmd("mkdir -p "+builddir+"/.env")
+
+    INTEL_LLVM_CLONE_HELPER = builddir+"/.env/clone-llvm"
+    utils.envscript.write_env_file(
+        source_path = shamrockdir + "/env/helpers/clone-intel-llvm.sh",
+        header = "",
+        path_write = INTEL_LLVM_CLONE_HELPER)
+    ENV_SCRIPT_HEADER += ". "+INTEL_LLVM_CLONE_HELPER+"\n"
+
     ENV_SCRIPT_HEADER += "\n"
     ENV_SCRIPT_HEADER += "export CMAKE_GENERATOR=\""+cmake_gen+"\"\n"
     ENV_SCRIPT_HEADER += "\n"
@@ -58,6 +71,36 @@ def setup(arg : SetupArg):
     ENV_SCRIPT_HEADER += "export CMAKE_OPT=("+cmake_extra_args+")\n"
     ENV_SCRIPT_HEADER += "export SHAMROCK_BUILD_TYPE=\""+cmake_build_type+"\"\n"
     ENV_SCRIPT_HEADER += "\n"
+
+    if args.custommpi:
+
+        UCX_INSTALL_PATH = builddir + "/.env/ucx-install"
+        OMPI_INSTALL_PATH = builddir + "/.env/ompi-install"
+        OMPI_SOURCE_DIR = builddir+"/.env/ompi-sources"
+        CUDA_PATH = "/usr/lib/cuda"
+
+        MPI_ENV = builddir+"/.env/activate-ompi"
+
+        if args.ucxurl is None or args.ompiurl is None:
+            raise "ucxurl and ompiurl must be set if custom mpi on"
+
+        OMPI_HEADER = ""
+        ENV_SCRIPT_HEADER += "#### mpi setup ####\n"
+        ENV_SCRIPT_HEADER += "export UCX_URL=\""+args.ucxurl+"\"\n"
+        ENV_SCRIPT_HEADER += "export OMPI_URL=\""+args.ompiurl+"\"\n"
+        ENV_SCRIPT_HEADER += "export CUDA_PATH=\""+CUDA_PATH+"\"\n"
+
+        ENV_SCRIPT_HEADER += "export UCX_INSTALL_PATH=\""+UCX_INSTALL_PATH+"\"\n"
+        ENV_SCRIPT_HEADER += "export OMPI_INSTALL_PATH=\""+OMPI_INSTALL_PATH+"\"\n"
+        ENV_SCRIPT_HEADER += "export OMPI_SOURCE_DIR=\""+OMPI_SOURCE_DIR+"\"\n"
+        ENV_SCRIPT_HEADER += ". "+MPI_ENV+"\n"
+        ENV_SCRIPT_HEADER += "#### ######### ####\n"
+
+        utils.envscript.write_env_file(
+            source_path = shamrockdir + "/env/helpers/setup_mpi.sh",
+            header = "",
+            path_write = MPI_ENV)
+
 
     # Get current file path
     cur_file = os.path.realpath(os.path.expanduser(__file__))


### PR DESCRIPTION
Add the possibility to build MPI from source with cuda support on the DGX
```
./env/new-env --machine dgx-cbp.intel-llvm --builddir build_tmp \
  -- \
  --custommpi \
  --ucxurl https://github.com/openucx/ucx/releases/download/v1.15.0/ucx-1.15.0.tar.gz \
  --ompiurl https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.6.tar.gz
```