### PR TITLE
[PatchTree] fix parent id on split

### DIFF
--- a/src/shamrock/scheduler/PatchScheduler.cpp
+++ b/src/shamrock/scheduler/PatchScheduler.cpp
@@ -607,19 +607,16 @@ std::string PatchScheduler::dump_status() {
 
     for (auto &[k, pnode] : patch_tree.tree) {
         ss << shambase::format(
-            "      -> id : {} -> ({} {} {} {} {} {} {} {}) <=> {} [{}, {}]\n",
+            "      -> id : {} -> ({}) <=> {} [{}, {}] (cl={} il={} l={} pid={})\n",
             k,
-            pnode.tree_node.childs_nid[0],
-            pnode.tree_node.childs_nid[1],
-            pnode.tree_node.childs_nid[2],
-            pnode.tree_node.childs_nid[3],
-            pnode.tree_node.childs_nid[4],
-            pnode.tree_node.childs_nid[5],
-            pnode.tree_node.childs_nid[6],
-            pnode.tree_node.childs_nid[7],
+            pnode.tree_node.childs_nid,
             pnode.linked_patchid,
             pnode.patch_coord.coord_min,
-            pnode.patch_coord.coord_max);
+            pnode.patch_coord.coord_max,
+            pnode.tree_node.child_are_all_leafs,
+            pnode.tree_node.is_leaf,
+            pnode.tree_node.level,
+            pnode.tree_node.parent_nid);
     }
 
     return ss.str();

--- a/src/shamrock/scheduler/PatchTree.cpp
+++ b/src/shamrock/scheduler/PatchTree.cpp
@@ -47,7 +47,7 @@ namespace shamrock::scheduler {
         tree_node.is_leaf             = false;
         tree_node.child_are_all_leafs = true;
 
-        std::array<Node, Node::split_count> splitted_node = curr.get_split_nodes();
+        std::array<Node, Node::split_count> splitted_node = curr.get_split_nodes(id);
 
 #pragma unroll
         for (u32 i = 0; i < Node::split_count; i++) {

--- a/src/shamrock/scheduler/PatchTreeNode.hpp
+++ b/src/shamrock/scheduler/PatchTreeNode.hpp
@@ -79,7 +79,7 @@ namespace shamrock::scheduler {
         // patch fields
         u64 load_value = u64_max;
 
-        std::array<PatchTreeNode, split_count> get_split_nodes();
+        std::array<PatchTreeNode, split_count> get_split_nodes(u32 cur_id);
 
         bool is_leaf() { return tree_node.is_leaf; }
 
@@ -120,7 +120,8 @@ namespace shamrock::scheduler {
                && (lhs.linked_patchid == rhs.linked_patchid) && (lhs.load_value == rhs.load_value);
     }
 
-    inline auto PatchTreeNode::get_split_nodes() -> std::array<PatchTreeNode, split_count> {
+    inline auto
+    PatchTreeNode::get_split_nodes(u32 cur_id) -> std::array<PatchTreeNode, split_count> {
         std::array<PatchCoord, split_count> splt_coord = patch_coord.split();
 
         std::array<PatchTreeNode, split_count> ret;
@@ -129,7 +130,7 @@ namespace shamrock::scheduler {
         for (u32 i = 0; i < split_count; i++) {
             ret[i].patch_coord          = splt_coord[i];
             ret[i].tree_node.level      = tree_node.level + 1;
-            ret[i].tree_node.parent_nid = tree_node.parent_nid;
+            ret[i].tree_node.parent_nid = cur_id;
         }
 
         return ret;


### PR DESCRIPTION
Before the current id of an object in the patch tree was not propagated to the child parent id. 
However, this did not impact the code behaviour, but it's fixed by this PR nonetheless to avoid future issues.

Tested on sedov_taylor SPH setup with low split criteria to force large number of patch. The diff between the outputs of scheduler().dump_status() are identical before and after the fix except for the parent id as expected.