### PR TITLE
[Backends] add fpe exception catch

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "shambase/stacktrace.hpp"
 #include "shambase/time.hpp"
 #include "shambackends/comm/CommunicationBuffer.hpp"
+#include "shambackends/fpe_except.hpp"
 #include "shambindings/pybindaliases.hpp"
 #include "shambindings/start_python.hpp"
 #include "shamcmdopt/cmdopt.hpp"
@@ -68,6 +69,8 @@ int main(int argc, char *argv[]) {
         opts::register_opt("--force-dgpu-on", {}, "for direct mpi comm on");
         opts::register_opt("--force-dgpu-off", {}, "for direct mpi comm off");
 
+        shamcmdopt::register_opt("--feenableexcept", "", "Enable FPE exceptions");
+
         shamcmdopt::register_env_var_doc(
             "SHAMLOGFORMATTER", "Change the log formatter (values :0-3)");
 
@@ -84,6 +87,10 @@ int main(int argc, char *argv[]) {
 
         if (opts::is_help_mode()) {
             return 0;
+        }
+
+        if (opts::has_option("--feenableexcept")) {
+            sham::enable_fpe_exceptions();
         }
 
         if (opts::has_option("--loglevel")) {

--- a/src/main_test.cpp
+++ b/src/main_test.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "shambackends/comm/CommunicationBuffer.hpp"
+#include "shambackends/fpe_except.hpp"
 #include "shamcmdopt/cmdopt.hpp"
 #include "shamcmdopt/env.hpp"
 #include "shamcomm/worldInfo.hpp"
@@ -45,6 +46,8 @@ int main(int argc, char *argv[]) {
 
     opts::register_opt("-o", {"(filepath)"}, "output test report in that file");
 
+    shamcmdopt::register_opt("--feenableexcept", "", "Enable FPE exceptions");
+
     opts::register_env_var_doc("REF_FILES_PATH", "reference test files path");
     shamcmdopt::register_env_var_doc("SHAMLOGFORMATTER", "Change the log formatter (values :0-3)");
 
@@ -60,6 +63,10 @@ int main(int argc, char *argv[]) {
     opts::init(argc, argv);
     if (opts::is_help_mode()) {
         return 0;
+    }
+
+    if (opts::has_option("--feenableexcept")) {
+        sham::enable_fpe_exceptions();
     }
 
     if (opts::has_option("--gen-test-list")) {

--- a/src/shambackends/include/shambackends/fpe_except.hpp
+++ b/src/shambackends/include/shambackends/fpe_except.hpp
@@ -1,0 +1,46 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2024 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file fpe_except.hpp
+ * @author Timothée David--Cléris (tim.shamrock@proton.me)
+ * @brief
+ *
+ */
+
+#include "shamcomm/logs.hpp"
+#include <fenv.h>
+
+namespace sham {
+
+    /**
+     * @brief Enable floating point exceptions.
+     *
+     * This function enables all floating point exceptions using the fenv.h
+     * header. This is useful for catching and handling floating point errors
+     * that could lead to NaN or Inf values during computation.
+     *
+     * @note This function is only available on platforms that support the
+     *       fenv.h header.
+     *
+     */
+    inline void enable_fpe_exceptions() {
+#ifdef __USE_GNU
+        // we do not enable FE_INVALID as well as FE_UNDERFLOW
+        // since they trigger exceptions in python lib ... like come on ...
+        feenableexcept(FE_DIVBYZERO | FE_INVALID);
+#else
+        shamcomm::logs::warn_ln(
+            "Backends", "Floating point exceptions are not supported on this platform.");
+#endif
+    }
+
+} // namespace sham

--- a/src/shamrock/scheduler/HilbertLoadBalance.cpp
+++ b/src/shamrock/scheduler/HilbertLoadBalance.cpp
@@ -149,8 +149,12 @@ namespace shamrock::scheduler {
                 str += shambase::format("    min = {}\n", min);
                 str += shambase::format("    max = {}\n", max);
                 str += shambase::format("    avg = {}\n", avg);
-                str += shambase::format(
-                    "    efficiency = {:.2f}%", 100 - (100 * (max - min) / max));
+                if (max == 0) {
+                    str += "    efficiency = ???%";
+                } else {
+                    str += shambase::format(
+                        "    efficiency = {:.2f}%", 100 - (100 * (max - min) / max));
+                }
                 logger::info_ln("LoadBalance", str);
             }
         }

--- a/src/shamrock/scheduler/loadbalance/LoadBalanceStrategy.hpp
+++ b/src/shamrock/scheduler/loadbalance/LoadBalanceStrategy.hpp
@@ -80,7 +80,10 @@ namespace shamrock::scheduler::details {
 
         for (LBTileResult &tile : res) {
             tile.new_owner
-                = sycl::clamp(i32(tile.accumulated_load_value / target_datacnt), 0, wsize - 1);
+                = (target_datacnt == 0)
+                      ? 0
+                      : sycl::clamp(
+                            i32(tile.accumulated_load_value / target_datacnt), 0, wsize - 1);
         }
 
         if (shamcomm::world_rank() == 0) {
@@ -90,8 +93,11 @@ namespace shamrock::scheduler::details {
                     t.ordering_val,
                     t.accumulated_load_value,
                     t.index,
-                    sycl::clamp(i32(t.accumulated_load_value / target_datacnt), 0, i32(wsize) - 1),
-                    (t.accumulated_load_value / target_datacnt));
+                    (target_datacnt == 0)
+                        ? 0
+                        : sycl::clamp(
+                              i32(t.accumulated_load_value / target_datacnt), 0, i32(wsize) - 1),
+                    (target_datacnt == 0) ? 0 : (t.accumulated_load_value / target_datacnt));
             }
         }
 
@@ -131,7 +137,10 @@ namespace shamrock::scheduler::details {
 
         for (LBTileResult &tile : res) {
             tile.new_owner
-                = sycl::clamp(i32(tile.accumulated_load_value / target_datacnt), 0, wsize - 1);
+                = (target_datacnt == 0)
+                      ? 0
+                      : sycl::clamp(
+                            i32(tile.accumulated_load_value / target_datacnt), 0, wsize - 1);
         }
 
         if (shamcomm::world_rank() == 0) {
@@ -141,8 +150,11 @@ namespace shamrock::scheduler::details {
                     t.ordering_val,
                     t.accumulated_load_value,
                     t.index,
-                    sycl::clamp(i32(t.accumulated_load_value / target_datacnt), 0, i32(wsize) - 1),
-                    (t.accumulated_load_value / target_datacnt));
+                    (target_datacnt == 0)
+                        ? 0
+                        : sycl::clamp(
+                              i32(t.accumulated_load_value / target_datacnt), 0, i32(wsize) - 1),
+                    (target_datacnt == 0) ? 0 : (t.accumulated_load_value / target_datacnt));
             }
         }
 


### PR DESCRIPTION
# Floating point exception catch

This PR add the `--feenableexcept` flag to shamrock executable. 
When enabled every invalid or div by zero floating point operations will raise a `signal SIGFPE` which can be intercepted by a debugger. 
This will be useful to track floating point issues in shamrock.

For this feature to work properly you need to:

1. Compile Shamrock with omp backend on CPU (on GPU fpe signal are not raised)
2. Compile in debug mode (otherwise the compiler optimizations may add false positives)
3. Compile on a system with GNU c standard library (otherwise `feenableexcept` does not exist). This is checked at compile time using a `#ifdef __USE_GNU`. 
4. Launch Shamrock in a debugger, the program will stop on every signals