### PR TITLE
[Dump] remove wrong offset in dump

### DIFF
--- a/exemples/ci_tests/reload_old_dump.py
+++ b/exemples/ci_tests/reload_old_dump.py
@@ -1,4 +1,7 @@
 import shamrock
+import os
+os.environ["SHAMDUMP_OFFSET_MODE_OLD"] = "1"
+
 
 ctx = shamrock.Context()
 ctx.pdata_layout_new()

--- a/src/shamrock/io/ShamrockDump.cpp
+++ b/src/shamrock/io/ShamrockDump.cpp
@@ -236,12 +236,8 @@ namespace shamrock {
             shamalgs::collective::read_at<u8>(
                 mfile, buf.get_ptr(), loc_file_info.bytecount, head_ptr + loc_file_info.offset);
 
-            logger::raw_ln("bytecount : ", loc_file_info.bytecount);
-
             std::unique_ptr<sycl::buffer<u8>> out = std::make_unique<sycl::buffer<u8>>(
                 shamcomm::CommunicationBuffer::convert(std::move(buf)));
-
-            logger::raw_ln("out size : ", out->size());
 
             shamalgs::SerializeHelper ser(
                 shamsys::instance::get_compute_scheduler_ptr(), std::move(out));


### PR DESCRIPTION
This pr remove the offset between the dump header and the content of the buffers. 
This was originally created by forgetting to reset the MPI file view before writing the buffers.
After this PR you can set the environment variable `SHAMDUMP_OFFSET_MODE_OLD=1` to fallback to the old mode