### PR TITLE
[Models] track mem usage in schemes

### DIFF
--- a/src/shammodels/amr/basegodunov/Solver.cpp
+++ b/src/shammodels/amr/basegodunov/Solver.cpp
@@ -29,14 +29,18 @@
 #include "shammodels/amr/basegodunov/modules/GhostZones.hpp"
 #include "shammodels/amr/basegodunov/modules/StencilGenerator.hpp"
 #include "shammodels/amr/basegodunov/modules/TimeIntegrator.hpp"
+#include "shammodels/timestep_report.hpp"
 #include "shamrock/io/LegacyVtkWritter.hpp"
 
 template<class Tvec, class TgridVec>
 void shammodels::basegodunov::Solver<Tvec, TgridVec>::evolve_once() {
-    Tscal t_current = solver_config.get_time();
-    Tscal dt_input  = solver_config.get_dt();
 
     StackEntry stack_loc{};
+
+    sham::MemPerfInfos mem_perf_infos_start = sham::details::get_mem_perf_info();
+
+    Tscal t_current = solver_config.get_time();
+    Tscal dt_input  = solver_config.get_dt();
 
     if (shamcomm::world_rank() == 0) {
         logger::normal_ln("amr::Godunov", shambase::format("t = {}, dt = {}", t_current, dt_input));
@@ -211,34 +215,30 @@ void shammodels::basegodunov::Solver<Tvec, TgridVec>::evolve_once() {
 
     tstep.end();
 
+    sham::MemPerfInfos mem_perf_infos_end = sham::details::get_mem_perf_info();
+
+    f64 t_dev_alloc
+        = (mem_perf_infos_end.time_alloc_device - mem_perf_infos_start.time_alloc_device)
+          + (mem_perf_infos_end.time_free_device - mem_perf_infos_start.time_free_device);
+
     u64 rank_count = scheduler().get_rank_count() * AMRBlock::block_size;
     f64 rate       = f64(rank_count) / tstep.elasped_sec();
 
-    std::string log_rank_rate = shambase::format(
-        "\n| {:<4} |    {:.4e}    | {:11} |   {:.3e}   |  {:3.0f} % | {:3.0f} % | {:3.0f} % |",
-        shamcomm::world_rank(),
+    std::string log_step = report_perf_timestep(
         rate,
         rank_count,
         tstep.elasped_sec(),
-        100 * (storage.timings_details.interface / tstep.elasped_sec()),
-        100 * (storage.timings_details.neighbors / tstep.elasped_sec()),
-        100 * (storage.timings_details.io / tstep.elasped_sec()));
-
-    std::string gathered = "";
-    shamcomm::gather_str(log_rank_rate, gathered);
+        storage.timings_details.interface,
+        t_dev_alloc,
+        mem_perf_infos_end.max_allocated_byte_device);
 
     if (shamcomm::world_rank() == 0) {
-        std::string print = "processing rate infos : \n";
-        print += ("--------------------------------------------------------------------------------"
-                  "-\n");
-        print += ("| rank |  rate  (N.s^-1)  |      N      | t compute (s) | interf | neigh |   io "
-                  " |\n");
-        print += ("--------------------------------------------------------------------------------"
-                  "-");
-        print += (gathered) + "\n";
-        print += ("--------------------------------------------------------------------------------"
-                  "-");
-        logger::info_ln("amr::Godunov", print);
+        logger::info_ln("amr::RAMSES", log_step);
+        logger::info_ln(
+            "amr::RAMSES",
+            "estimated rate :",
+            dt_input * (3600 / tstep.elasped_sec()),
+            "(tsim/hr)");
     }
 
     storage.timings_details.reset();

--- a/src/shammodels/timestep_report.hpp
+++ b/src/shammodels/timestep_report.hpp
@@ -1,0 +1,86 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2024 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file timestep_report.hpp
+ * @author Timothée David--Cléris (timothee.david--cleris@ens-lyon.fr)
+ * @brief
+ *
+ */
+
+#include "shambase/aliases_float.hpp"
+#include "shambase/aliases_int.hpp"
+#include "shambase/string.hpp"
+#include "shamalgs/collective/reduction.hpp"
+#include "shamcomm/collectives.hpp"
+#include "shamcomm/logs.hpp"
+#include "shamcomm/worldInfo.hpp"
+#include <string>
+
+namespace shammodels {
+
+    inline std::string report_perf_timestep(
+        f64 rate, u64 nobj, f64 tcompute, f64 interf_time, f64 alloc_time, size_t max_mem) {
+
+        std::string log_rank_rate = shambase::format(
+            "\n| {:<4} |    {:.4e}    | {:11} |   {:.3e}   |  {:3.0f} % | {:3.0f} % | {:>10s} |",
+            shamcomm::world_rank(),
+            rate,
+            nobj,
+            tcompute,
+            100 * (interf_time / tcompute),
+            100 * (alloc_time / tcompute),
+            shambase::readable_sizeof(max_mem));
+
+        std::string gathered = "";
+        shamcomm::gather_str(log_rank_rate, gathered);
+
+        u64 obj_total        = shamalgs::collective::allreduce_sum(nobj);
+        f64 max_t            = shamalgs::collective::allreduce_max(tcompute);
+        f64 sum_t            = shamalgs::collective::allreduce_sum(tcompute);
+        f64 sum_interf       = shamalgs::collective::allreduce_sum(interf_time);
+        f64 sum_alloc        = shamalgs::collective::allreduce_sum(alloc_time);
+        size_t sum_mem_total = shamalgs::collective::allreduce_sum(max_mem);
+
+        std::string log_all_rate = shambase::format(
+            "\n|  all |    {:.4e}    | {:11} |   {:.3e}   |  {:3.0f} % | {:3.0f} % | {:>10s} |",
+            f64(obj_total) / max_t,
+            obj_total,
+            max_t,
+            100 * (sum_interf / sum_t),
+            100 * (sum_alloc / sum_t),
+            shambase::readable_sizeof(sum_mem_total));
+
+        std::string print = "";
+
+        // clang-format off
+        if (shamcomm::world_rank() == 0) {
+            print = "processing rate infos : \n";
+            print += ("---------------------------------------------------------------------------------------\n");
+            print += ("| rank |  rate  (N.s^-1)  |     Nobj    | t compute (s) | interf | alloc |  mem (max) |\n");
+            if (shamcomm::world_size() > 1) {
+                print += ("------------------------------------- Per ranks ---------------------------------------");
+                print += (gathered) + "\n";
+              //print += ("| rank |  rate  (N.s^-1)  |     Nobj    | t compute (s) | interf | alloc | mem (max) |\n");
+                print += ("---------<sum N>/<max t> ----- <sum> ------- <max> ------ <avg> -- <avg> --- <sum> ----");
+                print += (log_all_rate) + "\n";
+            }else{
+                print += ("---------------------------------------------------------------------------------------");
+                print += (gathered) + "\n";
+            }
+            print += ("---------------------------------------------------------------------------------------");
+        }
+        // clang-format on
+
+        return print;
+    }
+
+} // namespace shammodels


### PR DESCRIPTION
# Memory usage tracking in models

This PR add measurment of the time spent in allocations as well as max memory usage in each schemes.
It also adds a new reporter for the timestep performance that is standardized for all schemes:
![Screenshot_20241215_213504](https://github.com/user-attachments/assets/b6c6cfe4-762e-45d7-9a02-21e15f668481)
