### PR TITLE
[Test] disable flaky test for UUID thread unsafe version

### DIFF
--- a/src/tests/shambase/WithUUID.cpp
+++ b/src/tests/shambase/WithUUID.cpp
@@ -41,7 +41,7 @@ void test() {
     }
 
     // multithreaded case
-    {
+    if constexpr (thread_safe) {
         class A3 : public shambase::WithUUID<A3, u32, thread_safe> {};
 
         // test that there is no duplicate when creating in parallel


### PR DESCRIPTION
My bad i forgot to disable the multithreaded test for the unsafe version of WithUUID in #708.
This pr fixes it.