### PR TITLE
[Tests] apply python sys.path mod in testing

### DIFF
--- a/src/shambindings/include/shambindings/start_python.hpp
+++ b/src/shambindings/include/shambindings/start_python.hpp
@@ -40,6 +40,9 @@ namespace shambindings {
      * @param file_path path to the runscript
      */
     void run_py_file(std::string file_path, bool do_print);
+
+    /// Modify Python sys.path to point to one detected during cmake invocation
+    void modify_py_sys_path();
 #endif
 
 } // namespace shambindings

--- a/src/shambindings/src/start_python.cpp
+++ b/src/shambindings/src/start_python.cpp
@@ -46,6 +46,8 @@ sys.path = paths
 
 namespace shambindings {
 
+    void modify_py_sys_path() { py::exec(modify_path); }
+
     void start_ipython(bool do_print) {
         py::scoped_interpreter guard{};
         py::exec(modify_path);

--- a/src/shamtest/shamtest.cpp
+++ b/src/shamtest/shamtest.cpp
@@ -19,6 +19,7 @@
 #include "shambase/string.hpp"
 #include "shambase/time.hpp"
 #include "shambindings/pybindaliases.hpp"
+#include "shambindings/start_python.hpp"
 #include "shamcmdopt/env.hpp"
 #include "shamcmdopt/term_colors.hpp"
 #include "shamsys/MpiWrapper.hpp"
@@ -547,6 +548,7 @@ namespace shamtest {
 
         logger::info_ln("Test", "start python interpreter");
         py::initialize_interpreter();
+        shambindings::modify_py_sys_path();
 
         std::filesystem::create_directories("tests/figures");
 


### PR DESCRIPTION
The `modify_path` was called in the main executable and not in tests, as a result the python venv was not accessible in tests... This PR fix that.