### PR TITLE
[Base] disable print in benchmark_pow_len

### DIFF
--- a/src/shambase/include/shambase/time.hpp
+++ b/src/shambase/include/shambase/time.hpp
@@ -255,7 +255,6 @@ namespace shambase {
     benchmark_pow_len(std::function<f64(u32)> func, u32 start, u32 end, f64 pow_exp) {
         BenchmarkResult res;
         for (f64 i = start; i < end; i *= pow_exp) {
-            std::cout << "benchmark_pow_len N =" << i;
             res.counts.push_back(i);
             res.times.push_back(func(u32(i)));
         }


### PR DESCRIPTION
Remove an unnecessary print in `benchmark_pow_len`.