### PR TITLE
[CmdOpt] add getenv func that also register the description

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,9 +71,6 @@ int main(int argc, char *argv[]) {
 
         shamcmdopt::register_opt("--feenableexcept", "", "Enable FPE exceptions");
 
-        shamcmdopt::register_env_var_doc(
-            "SHAMLOGFORMATTER", "Change the log formatter (values :0-3)");
-
         shamcmdopt::register_env_var_doc("SHAM_PROF_PREFIX", "Prefix of shamrock profile outputs");
         shamcmdopt::register_env_var_doc("SHAM_PROF_USE_NVTX", "Enable NVTX profiling");
         shamcmdopt::register_env_var_doc("SHAM_PROFILING", "Enable Shamrock profiling");
@@ -82,8 +79,6 @@ int main(int argc, char *argv[]) {
             "Use complete event instead of begin end for chrome tracing");
         shamcmdopt::register_env_var_doc(
             "SHAM_PROF_EVENT_RECORD_THRES", "Change the event recording threshold");
-        shamcmdopt::register_env_var_doc(
-            "SHAMLOG_ERR_ON_EXCEPT", "Enable logging of exceptions (default to 1)");
 
         opts::init(argc, argv);
 

--- a/src/main_test.cpp
+++ b/src/main_test.cpp
@@ -49,7 +49,6 @@ int main(int argc, char *argv[]) {
     shamcmdopt::register_opt("--feenableexcept", "", "Enable FPE exceptions");
 
     opts::register_env_var_doc("REF_FILES_PATH", "reference test files path");
-    shamcmdopt::register_env_var_doc("SHAMLOGFORMATTER", "Change the log formatter (values :0-3)");
 
     shamcmdopt::register_env_var_doc("SHAM_PROF_PREFIX", "Prefix of shamrock profile outputs");
     shamcmdopt::register_env_var_doc("SHAM_PROF_USE_NVTX", "Enable NVTX profiling");
@@ -59,8 +58,6 @@ int main(int argc, char *argv[]) {
         "Use complete event instead of begin end for chrome tracing");
     shamcmdopt::register_env_var_doc(
         "SHAM_PROF_EVENT_RECORD_THRES", "Change the event recording threshold");
-    shamcmdopt::register_env_var_doc(
-        "SHAMLOG_ERR_ON_EXCEPT", "Enable logging of exceptions (default to 1)");
 
     opts::init(argc, argv);
     if (opts::is_help_mode()) {

--- a/src/shambackends/src/DeviceQueue.cpp
+++ b/src/shambackends/src/DeviceQueue.cpp
@@ -18,6 +18,9 @@
 #include "shamcomm/logs.hpp"
 #include <utility>
 
+std::string SHAMROCK_WAIT_AFTER_SUBMIT = shamcmdopt::getenv_str_default_register(
+    "SHAMROCK_WAIT_AFTER_SUBMIT", "0", "Make queues wait after submit (default: 0)");
+
 namespace sham {
 
     auto build_queue = [](sycl::context &ctx, sycl::device &dev, bool in_order) -> sycl::queue {
@@ -29,18 +32,7 @@ namespace sham {
     };
 
     auto parse_wait_after_submit = []() -> bool {
-        shamcmdopt::register_env_var_doc(
-            "SHAMROCK_WAIT_AFTER_SUBMIT", "Make queues wait after submit");
-
-        std::optional<std::string> SHAMROCK_WAIT_AFTER_SUBMIT
-            = shamcmdopt::getenv_str("SHAMROCK_WAIT_AFTER_SUBMIT");
-
-        bool ret;
-        if (SHAMROCK_WAIT_AFTER_SUBMIT.has_value()) {
-            ret = *SHAMROCK_WAIT_AFTER_SUBMIT == "1";
-        } else {
-            ret = false;
-        }
+        bool ret = SHAMROCK_WAIT_AFTER_SUBMIT == "1";
 
         if (ret) {
             shamcomm::logs::warn_ln("Backends", "DeviceQueue :", "wait_after_submit is on !");

--- a/src/shamcmdopt/include/shamcmdopt/env.hpp
+++ b/src/shamcmdopt/include/shamcmdopt/env.hpp
@@ -48,10 +48,48 @@ namespace shamcmdopt {
      * This function is used to register the documentation of an environment variable.
      * The documentation will be printed in the help message.
      *
+     * @throw std::invalid_argument if the environment variable is already registered
+     *
      * @param env_var the name of the environment variable
      * @param desc the description of the environment variable
      */
     void register_env_var_doc(std::string env_var, std::string desc);
+
+    /**
+     * @brief Get the content of the environment variable if it exist and register it documentation
+     *
+     * This function is a shortcut for calling both getenv_str() and register_env_var_doc().
+     * It is used to register the documentation of the environment variable and return its value if
+     * it exist.
+     *
+     * @param env_var the name of the env variable
+     * @param desc the description of the environment variable
+     * @return std::optional<std::string> return the value of the env variable if it exist, none
+     * otherwise
+     */
+    inline std::optional<std::string> getenv_str_register(const char *env_var, std::string desc) {
+        register_env_var_doc(env_var, desc);
+        return getenv_str(env_var);
+    }
+
+    /**
+     * @brief Get the content of the environment variable if it exist and register it documentation,
+     * otherwise return the default value
+     *
+     * This function is a shortcut for calling both getenv_str_default() and register_env_var_doc().
+     * It is used to register the documentation of the environment variable and return its value if
+     * it exist, otherwise return the default value.
+     *
+     * @param env_var the name of the env variable
+     * @param default_val the default value to return if the env variable does not exist
+     * @param desc the description of the environment variable
+     * @return std::string the value of the env variable if it exist, the default value otherwise
+     */
+    inline std::string
+    getenv_str_default_register(const char *env_var, std::string default_val, std::string desc) {
+        register_env_var_doc(env_var, desc);
+        return getenv_str_default(env_var, default_val);
+    }
 
     /**
      * @brief Print the documentation of the environment variables registered with

--- a/src/shamcmdopt/src/env.cpp
+++ b/src/shamcmdopt/src/env.cpp
@@ -32,6 +32,14 @@ std::optional<std::string> shamcmdopt::getenv_str(const char *env_var) {
 std::vector<std::pair<std::string, std::string>> env_var_reg = {};
 
 void shamcmdopt::register_env_var_doc(std::string env_var, std::string desc) {
+
+    for (auto &[_env_var, _desc] : env_var_reg) {
+        if (_env_var == env_var) {
+            shambase::throw_with_loc<std::invalid_argument>(
+                shambase::format("The env var {} is already registered", env_var));
+        }
+    }
+
     env_var_reg.push_back({env_var, desc});
 }
 

--- a/src/shamsys/src/NodeInstance.cpp
+++ b/src/shamsys/src/NodeInstance.cpp
@@ -43,6 +43,12 @@
 #include <stdexcept>
 #include <string>
 
+std::string SHAMLOGFORMATTER = shamcmdopt::getenv_str_default_register(
+    "SHAMLOGFORMATTER", "3", "Change the log formatter (values :0-3) [default: 3]");
+
+std::string SHAMLOG_ERR_ON_EXCEPT = shamcmdopt::getenv_str_default_register(
+    "SHAMLOG_ERR_ON_EXCEPT", "1", "Enable logging of exceptions (default to 1)");
+
 /**
  * @brief Namespace for log formatters
  */
@@ -622,31 +628,26 @@ namespace shamsys::instance {
 
         logger::debug_ln("Sys", "changing formatter to MPI form");
 
-        if (shamcmdopt::getenv_str_default("SHAMLOG_ERR_ON_EXCEPT", "1") == "1") {
-            shambase::set_exception_gen_callback(&logformatter::exception_gen_callback);
-        }
-
-        auto env_formatter = shamcmdopt::getenv_str("SHAMLOGFORMATTER");
-        if (env_formatter) {
-            if (*env_formatter == "0") {
-                logger::change_formaters(
-                    logformatter::style0_formatter_full, logformatter::style0_formatter_simple);
-            } else if (*env_formatter == "1") {
-                logger::change_formaters(
-                    logformatter::style1_formatter_full, logformatter::style1_formatter_simple);
-            } else if (*env_formatter == "2") {
-                logger::change_formaters(
-                    logformatter::style2_formatter_full, logformatter::style2_formatter_simple);
-            } else if (*env_formatter == "3") {
-                logger::change_formaters(
-                    logformatter::style3_formatter_full, logformatter::style3_formatter_simple);
-            } else {
-                logger::err_ln("Log", "Unknown formatter");
-                throw ShamsysInstanceException("Unknown formatter");
-            }
-        } else {
+        if (SHAMLOGFORMATTER == "0") {
+            logger::change_formaters(
+                logformatter::style0_formatter_full, logformatter::style0_formatter_simple);
+        } else if (SHAMLOGFORMATTER == "1") {
+            logger::change_formaters(
+                logformatter::style1_formatter_full, logformatter::style1_formatter_simple);
+        } else if (SHAMLOGFORMATTER == "2") {
+            logger::change_formaters(
+                logformatter::style2_formatter_full, logformatter::style2_formatter_simple);
+        } else if (SHAMLOGFORMATTER == "3") {
             logger::change_formaters(
                 logformatter::style3_formatter_full, logformatter::style3_formatter_simple);
+        } else {
+            logger::err_ln("Log", "Unknown formatter");
+            throw ShamsysInstanceException("Unknown formatter");
+        }
+
+        if (SHAMLOG_ERR_ON_EXCEPT == "1") {
+            logger::debug_ln("Log", "Enabling exception handler callback");
+            shambase::set_exception_gen_callback(&logformatter::exception_gen_callback);
         }
 
 #ifdef MPI_LOGGER_ENABLED


### PR DESCRIPTION
This pr add two new functions that get environment variable as well as registering their description.

```c++
/**
 * @brief Get the content of the environment variable if it exist and register it documentation
 *...
 */
inline std::optional<std::string> getenv_str_register(const char *env_var, std::string desc);

/**
 * @brief Get the content of the environment variable if it exist and register it documentation,
 * otherwise return the default value
 *...
 */
inline std::string
getenv_str_default_register(const char *env_var, std::string default_val, std::string desc);
```

this pr also use those function to replace some usage of env variable to register it where it is used instead of beign registered in the main function.