### PR TITLE
[Backends] use const ref to device scheduler instead of simple ref

### DIFF
--- a/src/shamalgs/include/shamalgs/details/algorithm/algorithm.hpp
+++ b/src/shamalgs/include/shamalgs/details/algorithm/algorithm.hpp
@@ -45,7 +45,7 @@ namespace shamalgs::algorithm {
 
     template<class Tkey, class Tval>
     void sort_by_key(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<Tkey> &buf_key,
         sham::DeviceBuffer<Tval> &buf_values,
         u32 len);
@@ -117,7 +117,7 @@ namespace shamalgs::algorithm {
 
     template<class T>
     void index_remap(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<T> &source,
         sham::DeviceBuffer<T> &dest,
         sham::DeviceBuffer<u32> &index_map,
@@ -125,7 +125,7 @@ namespace shamalgs::algorithm {
 
     template<class T>
     void index_remap_nvar(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<T> &source,
         sham::DeviceBuffer<T> &dest,
         sham::DeviceBuffer<u32> &index_map,
@@ -134,7 +134,7 @@ namespace shamalgs::algorithm {
 
     template<class T>
     sham::DeviceBuffer<T> index_remap(
-        sham::DeviceScheduler_ptr &sched_ptr,
+        const sham::DeviceScheduler_ptr &sched_ptr,
         sham::DeviceBuffer<T> &source,
         sham::DeviceBuffer<u32> &index_map,
         u32 len) {
@@ -146,7 +146,7 @@ namespace shamalgs::algorithm {
 
     template<class T>
     sham::DeviceBuffer<T> index_remap_nvar(
-        sham::DeviceScheduler_ptr &sched_ptr,
+        const sham::DeviceScheduler_ptr &sched_ptr,
         sham::DeviceBuffer<T> &source,
         sham::DeviceBuffer<u32> &index_map,
         u32 len,

--- a/src/shamalgs/include/shamalgs/details/algorithm/bitonicSort_updated_usm.hpp
+++ b/src/shamalgs/include/shamalgs/details/algorithm/bitonicSort_updated_usm.hpp
@@ -29,7 +29,7 @@ namespace shamalgs::algorithm::details {
 
     template<class Tkey, class Tval, u32 MaxStencilSize>
     void sort_by_key_bitonic_updated_usm(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<Tkey> &buf_key,
         sham::DeviceBuffer<Tval> &buf_values,
         u32 len);

--- a/src/shamalgs/include/shamalgs/details/numeric/numericFallback.hpp
+++ b/src/shamalgs/include/shamalgs/details/numeric/numericFallback.hpp
@@ -27,7 +27,7 @@ namespace shamalgs::numeric::details {
 
     template<class T>
     sham::DeviceBuffer<T> exclusive_sum_fallback_usm(
-        sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 len);
+        const sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 len);
 
     template<class T>
     sycl::buffer<T> inclusive_sum_fallback(sycl::queue &q, sycl::buffer<T> &buf1, u32 len);

--- a/src/shamalgs/include/shamalgs/details/random/random.hpp
+++ b/src/shamalgs/include/shamalgs/details/random/random.hpp
@@ -55,8 +55,8 @@ namespace shamalgs::random {
     sycl::buffer<T> mock_buffer(u64 seed, u32 len, T min_bound, T max_bound);
 
     template<class T>
-    sham::DeviceBuffer<T>
-    mock_buffer_usm(sham::DeviceScheduler_ptr &sched, u64 seed, u32 len, T min_bound, T max_bound);
+    sham::DeviceBuffer<T> mock_buffer_usm(
+        const sham::DeviceScheduler_ptr &sched, u64 seed, u32 len, T min_bound, T max_bound);
 
     template<class T>
     inline std::vector<T> mock_vector(u64 seed, u32 len) {

--- a/src/shamalgs/include/shamalgs/details/reduction/fallbackReduction_usm.hpp
+++ b/src/shamalgs/include/shamalgs/details/reduction/fallbackReduction_usm.hpp
@@ -27,14 +27,23 @@ namespace shamalgs::reduction::details {
 
     template<class T>
     T sum_usm_fallback(
-        sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 start_id, u32 end_id);
+        const sham::DeviceScheduler_ptr &sched,
+        sham::DeviceBuffer<T> &buf1,
+        u32 start_id,
+        u32 end_id);
 
     template<class T>
     T min_usm_fallback(
-        sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 start_id, u32 end_id);
+        const sham::DeviceScheduler_ptr &sched,
+        sham::DeviceBuffer<T> &buf1,
+        u32 start_id,
+        u32 end_id);
 
     template<class T>
     T max_usm_fallback(
-        sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 start_id, u32 end_id);
+        const sham::DeviceScheduler_ptr &sched,
+        sham::DeviceBuffer<T> &buf1,
+        u32 start_id,
+        u32 end_id);
 
 } // namespace shamalgs::reduction::details

--- a/src/shamalgs/include/shamalgs/details/reduction/groupReduction_usm.hpp
+++ b/src/shamalgs/include/shamalgs/details/reduction/groupReduction_usm.hpp
@@ -36,21 +36,21 @@ namespace shamalgs::reduction::details {
 
     template<class T>
     T sum_usm_group(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<T> &buf1,
         u32 start_id,
         u32 end_id,
         u32 work_group_size);
     template<class T>
     T min_usm_group(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<T> &buf1,
         u32 start_id,
         u32 end_id,
         u32 work_group_size);
     template<class T>
     T max_usm_group(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<T> &buf1,
         u32 start_id,
         u32 end_id,

--- a/src/shamalgs/include/shamalgs/details/reduction/groupReduction_usm_impl.hpp
+++ b/src/shamalgs/include/shamalgs/details/reduction/groupReduction_usm_impl.hpp
@@ -72,7 +72,7 @@ namespace shamalgs::reduction::details {
 
     template<class T, class GroupCombiner, class BinaryOp, class IdentityGetter>
     inline T reduc_internal(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<T> &buf1,
         u32 start_id,
         u32 end_id,

--- a/src/shamalgs/include/shamalgs/details/reduction/reduction.hpp
+++ b/src/shamalgs/include/shamalgs/details/reduction/reduction.hpp
@@ -27,13 +27,25 @@
 namespace shamalgs::reduction {
 
     template<class T>
-    T sum(sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 start_id, u32 end_id);
+    T sum(
+        const sham::DeviceScheduler_ptr &sched,
+        sham::DeviceBuffer<T> &buf1,
+        u32 start_id,
+        u32 end_id);
 
     template<class T>
-    T min(sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 start_id, u32 end_id);
+    T min(
+        const sham::DeviceScheduler_ptr &sched,
+        sham::DeviceBuffer<T> &buf1,
+        u32 start_id,
+        u32 end_id);
 
     template<class T>
-    T max(sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 start_id, u32 end_id);
+    T max(
+        const sham::DeviceScheduler_ptr &sched,
+        sham::DeviceBuffer<T> &buf1,
+        u32 start_id,
+        u32 end_id);
 
     template<class T>
     T sum(sycl::queue &q, sycl::buffer<T> &buf1, u32 start_id, u32 end_id);
@@ -78,7 +90,7 @@ namespace shamalgs::reduction {
 
     template<class T>
     inline bool equals(
-        sham::DeviceScheduler_ptr &q,
+        const sham::DeviceScheduler_ptr &q,
         sham::DeviceBuffer<T> &buf1,
         sham::DeviceBuffer<T> &buf2,
         u32 cnt) {

--- a/src/shamalgs/src/details/algorithm/algorithm.cpp
+++ b/src/shamalgs/src/details/algorithm/algorithm.cpp
@@ -37,7 +37,7 @@ namespace shamalgs::algorithm {
 
     template<class Tkey, class Tval>
     void sort_by_key(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<Tkey> &buf_key,
         sham::DeviceBuffer<Tval> &buf_values,
         u32 len) {
@@ -51,13 +51,13 @@ namespace shamalgs::algorithm {
     sort_by_key(sycl::queue &q, sycl::buffer<u64> &buf_key, sycl::buffer<u32> &buf_values, u32 len);
 
     template void sort_by_key(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<u32> &buf_key,
         sham::DeviceBuffer<u32> &buf_values,
         u32 len);
 
     template void sort_by_key(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<u64> &buf_key,
         sham::DeviceBuffer<u32> &buf_values,
         u32 len);
@@ -126,7 +126,7 @@ namespace shamalgs::algorithm {
 
     template<class T>
     void index_remap(
-        sham::DeviceScheduler_ptr &sched_ptr,
+        const sham::DeviceScheduler_ptr &sched_ptr,
         sham::DeviceBuffer<T> &source,
         sham::DeviceBuffer<T> &dest,
         sham::DeviceBuffer<u32> &index_map,
@@ -153,7 +153,7 @@ namespace shamalgs::algorithm {
 
     template<class T>
     void index_remap_nvar(
-        sham::DeviceScheduler_ptr &sched_ptr,
+        const sham::DeviceScheduler_ptr &sched_ptr,
         sham::DeviceBuffer<T> &source,
         sham::DeviceBuffer<T> &dest,
         sham::DeviceBuffer<u32> &index_map,
@@ -217,14 +217,14 @@ namespace shamalgs::algorithm {
         u32 nvar);                                                                                 \
                                                                                                    \
     template void index_remap(                                                                     \
-        sham::DeviceScheduler_ptr &sched,                                                          \
+        const sham::DeviceScheduler_ptr &sched,                                                    \
         sham::DeviceBuffer<_arg_> &source,                                                         \
         sham::DeviceBuffer<_arg_> &dest,                                                           \
         sham::DeviceBuffer<u32> &index_map,                                                        \
         u32 len);                                                                                  \
                                                                                                    \
     template void index_remap_nvar(                                                                \
-        sham::DeviceScheduler_ptr &sched,                                                          \
+        const sham::DeviceScheduler_ptr &sched,                                                    \
         sham::DeviceBuffer<_arg_> &source,                                                         \
         sham::DeviceBuffer<_arg_> &dest,                                                           \
         sham::DeviceBuffer<u32> &index_map,                                                        \

--- a/src/shamalgs/src/details/algorithm/bitonicSort_updated_usm.cpp
+++ b/src/shamalgs/src/details/algorithm/bitonicSort_updated_usm.cpp
@@ -283,7 +283,7 @@ namespace shamalgs::algorithm::details {
 
     template<class Tkey, class Tval, u32 MaxStencilSize>
     void sort_by_key_bitonic_updated_usm(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<Tkey> &buf_key,
         sham::DeviceBuffer<Tval> &buf_values,
         u32 len) {
@@ -398,37 +398,37 @@ namespace shamalgs::algorithm::details {
     }
 
     template void sort_by_key_bitonic_updated_usm<u32, u32, 16>(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<u32> &buf_key,
         sham::DeviceBuffer<u32> &buf_values,
         u32 len);
 
     template void sort_by_key_bitonic_updated_usm<u64, u32, 16>(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<u64> &buf_key,
         sham::DeviceBuffer<u32> &buf_values,
         u32 len);
 
     template void sort_by_key_bitonic_updated_usm<u32, u32, 8>(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<u32> &buf_key,
         sham::DeviceBuffer<u32> &buf_values,
         u32 len);
 
     template void sort_by_key_bitonic_updated_usm<u64, u32, 8>(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<u64> &buf_key,
         sham::DeviceBuffer<u32> &buf_values,
         u32 len);
 
     template void sort_by_key_bitonic_updated_usm<u32, u32, 32>(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<u32> &buf_key,
         sham::DeviceBuffer<u32> &buf_values,
         u32 len);
 
     template void sort_by_key_bitonic_updated_usm<u64, u32, 32>(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<u64> &buf_key,
         sham::DeviceBuffer<u32> &buf_values,
         u32 len);

--- a/src/shamalgs/src/details/numeric/numericFallback.cpp
+++ b/src/shamalgs/src/details/numeric/numericFallback.cpp
@@ -42,7 +42,7 @@ namespace shamalgs::numeric::details {
 
     template<class T>
     sham::DeviceBuffer<T> exclusive_sum_fallback_usm(
-        sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 len) {
+        const sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 len) {
 
         sham::DeviceBuffer<T> ret_buf(len, sched);
 
@@ -115,7 +115,7 @@ namespace shamalgs::numeric::details {
     inclusive_sum_fallback(sycl::queue &q, sycl::buffer<u32> &buf1, u32 len);
 
     template sham::DeviceBuffer<u32> exclusive_sum_fallback_usm(
-        sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<u32> &buf1, u32 len);
+        const sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<u32> &buf1, u32 len);
 
     template sycl::buffer<u32>
     exclusive_sum_fallback(sycl::queue &q, sycl::buffer<u32> &buf1, u32 len);

--- a/src/shamalgs/src/details/random/random.cpp
+++ b/src/shamalgs/src/details/random/random.cpp
@@ -182,8 +182,8 @@ namespace shamalgs::random {
     }
 
     template<class T>
-    sham::DeviceBuffer<T>
-    mock_buffer_usm(sham::DeviceScheduler_ptr &sched, u64 seed, u32 len, T min_bound, T max_bound) {
+    sham::DeviceBuffer<T> mock_buffer_usm(
+        const sham::DeviceScheduler_ptr &sched, u64 seed, u32 len, T min_bound, T max_bound) {
         auto vec = mock_vector(seed, len, min_bound, max_bound);
         sham::DeviceBuffer<T> ret(len, sched);
         ret.copy_from_stdvec(vec);
@@ -197,7 +197,7 @@ namespace shamalgs::random {
         template std::vector<_arg_> mock_vector(                                                   \
             u64 seed, u32 len, _arg_ min_bound, _arg_ max_bound);                                  \
         template sham::DeviceBuffer<_arg_> mock_buffer_usm(                                        \
-            sham::DeviceScheduler_ptr &sched,                                                      \
+            const sham::DeviceScheduler_ptr &sched,                                                \
             u64 seed,                                                                              \
             u32 len,                                                                               \
             _arg_ min_bound,                                                                       \

--- a/src/shamalgs/src/details/reduction/fallbackReduction_usm.cpp
+++ b/src/shamalgs/src/details/reduction/fallbackReduction_usm.cpp
@@ -24,7 +24,7 @@ namespace shamalgs::reduction::details {
 
     template<class T, class BinaryOp>
     T reduc_internal(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<T> &buf1,
         u32 start_id,
         u32 end_id,
@@ -44,7 +44,10 @@ namespace shamalgs::reduction::details {
 
     template<class T>
     T sum_usm_fallback(
-        sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 start_id, u32 end_id) {
+        const sham::DeviceScheduler_ptr &sched,
+        sham::DeviceBuffer<T> &buf1,
+        u32 start_id,
+        u32 end_id) {
 
         return reduc_internal<T>(sched, buf1, start_id, end_id, [](T lhs, T rhs) {
             return lhs + rhs;
@@ -53,7 +56,10 @@ namespace shamalgs::reduction::details {
 
     template<class T>
     T max_usm_fallback(
-        sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 start_id, u32 end_id) {
+        const sham::DeviceScheduler_ptr &sched,
+        sham::DeviceBuffer<T> &buf1,
+        u32 start_id,
+        u32 end_id) {
 
         return reduc_internal<T>(sched, buf1, start_id, end_id, [](T lhs, T rhs) {
             return sham::max(lhs, rhs);
@@ -62,7 +68,10 @@ namespace shamalgs::reduction::details {
 
     template<class T>
     T min_usm_fallback(
-        sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 start_id, u32 end_id) {
+        const sham::DeviceScheduler_ptr &sched,
+        sham::DeviceBuffer<T> &buf1,
+        u32 start_id,
+        u32 end_id) {
 
         return reduc_internal<T>(sched, buf1, start_id, end_id, [](T lhs, T rhs) {
             return sham::min(lhs, rhs);
@@ -96,18 +105,18 @@ namespace shamalgs::reduction::details {
 
     #define X(_arg_)                                                                               \
         template _arg_ shamalgs::reduction::details::sum_usm_fallback<_arg_>(                      \
-            sham::DeviceScheduler_ptr & sched,                                                     \
-            sham::DeviceBuffer<_arg_> & buf1,                                                      \
+            const sham::DeviceScheduler_ptr &sched,                                                \
+            sham::DeviceBuffer<_arg_> &buf1,                                                       \
             u32 start_id,                                                                          \
             u32 end_id);                                                                           \
         template _arg_ shamalgs::reduction::details::max_usm_fallback<_arg_>(                      \
-            sham::DeviceScheduler_ptr & sched,                                                     \
-            sham::DeviceBuffer<_arg_> & buf1,                                                      \
+            const sham::DeviceScheduler_ptr &sched,                                                \
+            sham::DeviceBuffer<_arg_> &buf1,                                                       \
             u32 start_id,                                                                          \
             u32 end_id);                                                                           \
         template _arg_ shamalgs::reduction::details::min_usm_fallback<_arg_>(                      \
-            sham::DeviceScheduler_ptr & sched,                                                     \
-            sham::DeviceBuffer<_arg_> & buf1,                                                      \
+            const sham::DeviceScheduler_ptr &sched,                                                \
+            sham::DeviceBuffer<_arg_> &buf1,                                                       \
             u32 start_id,                                                                          \
             u32 end_id);
 

--- a/src/shamalgs/src/details/reduction/groupReduction_usm.cpp
+++ b/src/shamalgs/src/details/reduction/groupReduction_usm.cpp
@@ -38,7 +38,7 @@ namespace shamalgs::reduction::details {
      */
     template<class T>
     T sum_usm_group(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<T> &buf1,
         u32 start_id,
         u32 end_id,
@@ -74,7 +74,7 @@ namespace shamalgs::reduction::details {
      */
     template<class T>
     T max_usm_group(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<T> &buf1,
         u32 start_id,
         u32 end_id,
@@ -110,7 +110,7 @@ namespace shamalgs::reduction::details {
      */
     template<class T>
     T min_usm_group(
-        sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<T> &buf1,
         u32 start_id,
         u32 end_id,
@@ -163,20 +163,20 @@ namespace shamalgs::reduction::details {
 
         #define X(_arg_)                                                                           \
             template _arg_ shamalgs::reduction::details::sum_usm_group<_arg_>(                     \
-                sham::DeviceScheduler_ptr & sched,                                                 \
-                sham::DeviceBuffer<_arg_> & buf1,                                                  \
+                const sham::DeviceScheduler_ptr &sched,                                            \
+                sham::DeviceBuffer<_arg_> &buf1,                                                   \
                 u32 start_id,                                                                      \
                 u32 end_id,                                                                        \
                 u32 work_group_size);                                                              \
             template _arg_ shamalgs::reduction::details::max_usm_group<_arg_>(                     \
-                sham::DeviceScheduler_ptr & sched,                                                 \
-                sham::DeviceBuffer<_arg_> & buf1,                                                  \
+                const sham::DeviceScheduler_ptr &sched,                                            \
+                sham::DeviceBuffer<_arg_> &buf1,                                                   \
                 u32 start_id,                                                                      \
                 u32 end_id,                                                                        \
                 u32 work_group_size);                                                              \
             template _arg_ shamalgs::reduction::details::min_usm_group<_arg_>(                     \
-                sham::DeviceScheduler_ptr & sched,                                                 \
-                sham::DeviceBuffer<_arg_> & buf1,                                                  \
+                const sham::DeviceScheduler_ptr &sched,                                            \
+                sham::DeviceBuffer<_arg_> &buf1,                                                   \
                 u32 start_id,                                                                      \
                 u32 end_id,                                                                        \
                 u32 work_group_size);

--- a/src/shamalgs/src/details/reduction/reduction.cpp
+++ b/src/shamalgs/src/details/reduction/reduction.cpp
@@ -28,7 +28,11 @@
 namespace shamalgs::reduction {
 
     template<class T>
-    T sum(sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 start_id, u32 end_id) {
+    T sum(
+        const sham::DeviceScheduler_ptr &sched,
+        sham::DeviceBuffer<T> &buf1,
+        u32 start_id,
+        u32 end_id) {
 #ifdef SHAMALGS_GROUP_REDUCTION_SUPPORT
         return details::sum_usm_group(sched, buf1, start_id, end_id, 128);
 #else
@@ -37,7 +41,11 @@ namespace shamalgs::reduction {
     }
 
     template<class T>
-    T min(sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 start_id, u32 end_id) {
+    T min(
+        const sham::DeviceScheduler_ptr &sched,
+        sham::DeviceBuffer<T> &buf1,
+        u32 start_id,
+        u32 end_id) {
 #ifdef SHAMALGS_GROUP_REDUCTION_SUPPORT
         return details::min_usm_group(sched, buf1, start_id, end_id, 128);
 #else
@@ -46,7 +54,11 @@ namespace shamalgs::reduction {
     }
 
     template<class T>
-    T max(sham::DeviceScheduler_ptr &sched, sham::DeviceBuffer<T> &buf1, u32 start_id, u32 end_id) {
+    T max(
+        const sham::DeviceScheduler_ptr &sched,
+        sham::DeviceBuffer<T> &buf1,
+        u32 start_id,
+        u32 end_id) {
 #ifdef SHAMALGS_GROUP_REDUCTION_SUPPORT
         return details::max_usm_group(sched, buf1, start_id, end_id, 128);
 #else
@@ -203,18 +215,18 @@ namespace shamalgs::reduction {
 
     #define X(_arg_)                                                                               \
         template _arg_ sum<_arg_>(                                                                 \
-            sham::DeviceScheduler_ptr & sched,                                                     \
-            sham::DeviceBuffer<_arg_> & buf1,                                                      \
+            const sham::DeviceScheduler_ptr &sched,                                                \
+            sham::DeviceBuffer<_arg_> &buf1,                                                       \
             u32 start_id,                                                                          \
             u32 end_id);                                                                           \
         template _arg_ min<_arg_>(                                                                 \
-            sham::DeviceScheduler_ptr & sched,                                                     \
-            sham::DeviceBuffer<_arg_> & buf1,                                                      \
+            const sham::DeviceScheduler_ptr &sched,                                                \
+            sham::DeviceBuffer<_arg_> &buf1,                                                       \
             u32 start_id,                                                                          \
             u32 end_id);                                                                           \
         template _arg_ max<_arg_>(                                                                 \
-            sham::DeviceScheduler_ptr & sched,                                                     \
-            sham::DeviceBuffer<_arg_> & buf1,                                                      \
+            const sham::DeviceScheduler_ptr &sched,                                                \
+            sham::DeviceBuffer<_arg_> &buf1,                                                       \
             u32 start_id,                                                                          \
             u32 end_id);                                                                           \
         template _arg_ sum(sycl::queue &q, sycl::buffer<_arg_> &buf1, u32 start_id, u32 end_id);   \

--- a/src/tests/shamalgs/algorithm/sortTests.hpp
+++ b/src/tests/shamalgs/algorithm/sortTests.hpp
@@ -122,7 +122,10 @@ template<class Tkey, class Tval>
 struct TestSortByKeyUSM {
 
     using vFunctionCall = void (*)(
-        sham::DeviceScheduler_ptr &, sham::DeviceBuffer<Tkey> &, sham::DeviceBuffer<Tval> &, u32);
+        const sham::DeviceScheduler_ptr &,
+        sham::DeviceBuffer<Tkey> &,
+        sham::DeviceBuffer<Tval> &,
+        u32);
 
     vFunctionCall fct;
 
@@ -237,7 +240,7 @@ struct TestIndexRemap {
 template<class T>
 struct TestIndexRemapUSM {
     using vFunctionCall = void (*)(
-        sham::DeviceScheduler_ptr &,
+        const sham::DeviceScheduler_ptr &,
         sham::DeviceBuffer<T> &,
         sham::DeviceBuffer<T> &,
         sham::DeviceBuffer<u32> &,

--- a/src/tests/shamalgs/reduction/reductionTests.cpp
+++ b/src/tests/shamalgs/reduction/reductionTests.cpp
@@ -287,7 +287,7 @@ void unit_test_reduc_sum_usm_group_impl() {
 
     unit_test_reduc_sum_usm<f64>(
         "reduction : main (f64)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64> &buf1,
            u32 start_id,
            u32 end_id) -> f64 {
@@ -296,7 +296,7 @@ void unit_test_reduc_sum_usm_group_impl() {
 
     unit_test_reduc_sum_usm<f32>(
         "reduction : main (f32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f32> &buf1,
            u32 start_id,
            u32 end_id) -> f32 {
@@ -305,7 +305,7 @@ void unit_test_reduc_sum_usm_group_impl() {
 
     unit_test_reduc_sum_usm<u32>(
         "reduction : main (u32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<u32> &buf1,
            u32 start_id,
            u32 end_id) -> u32 {
@@ -314,7 +314,7 @@ void unit_test_reduc_sum_usm_group_impl() {
 
     unit_test_reduc_sum_usm<f64_3>(
         "reduction : main (f64_3)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64_3> &buf1,
            u32 start_id,
            u32 end_id) -> f64_3 {
@@ -325,7 +325,7 @@ void unit_test_reduc_min_usm_group_impl() {
 
     unit_test_reduc_min_usm<f64>(
         "reduction : main (f64)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64> &buf1,
            u32 start_id,
            u32 end_id) -> f64 {
@@ -334,7 +334,7 @@ void unit_test_reduc_min_usm_group_impl() {
 
     unit_test_reduc_min_usm<f32>(
         "reduction : main (f32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f32> &buf1,
            u32 start_id,
            u32 end_id) -> f32 {
@@ -343,7 +343,7 @@ void unit_test_reduc_min_usm_group_impl() {
 
     unit_test_reduc_min_usm<u32>(
         "reduction : main (u32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<u32> &buf1,
            u32 start_id,
            u32 end_id) -> u32 {
@@ -352,7 +352,7 @@ void unit_test_reduc_min_usm_group_impl() {
 
     unit_test_reduc_min_usm<f64_3>(
         "reduction : main (f64_3)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64_3> &buf1,
            u32 start_id,
            u32 end_id) -> f64_3 {
@@ -363,7 +363,7 @@ void unit_test_reduc_max_usm_group_impl() {
 
     unit_test_reduc_max_usm<f64>(
         "reduction : main (f64)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64> &buf1,
            u32 start_id,
            u32 end_id) -> f64 {
@@ -372,7 +372,7 @@ void unit_test_reduc_max_usm_group_impl() {
 
     unit_test_reduc_max_usm<f32>(
         "reduction : main (f32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f32> &buf1,
            u32 start_id,
            u32 end_id) -> f32 {
@@ -381,7 +381,7 @@ void unit_test_reduc_max_usm_group_impl() {
 
     unit_test_reduc_max_usm<u32>(
         "reduction : main (u32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<u32> &buf1,
            u32 start_id,
            u32 end_id) -> u32 {
@@ -390,7 +390,7 @@ void unit_test_reduc_max_usm_group_impl() {
 
     unit_test_reduc_max_usm<f64_3>(
         "reduction : main (f64_3)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64_3> &buf1,
            u32 start_id,
            u32 end_id) -> f64_3 {
@@ -403,7 +403,7 @@ void unit_test_reduc_sum_usm_fallback_impl() {
 
     unit_test_reduc_sum_usm<f64>(
         "reduction : main (f64)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64> &buf1,
            u32 start_id,
            u32 end_id) -> f64 {
@@ -412,7 +412,7 @@ void unit_test_reduc_sum_usm_fallback_impl() {
 
     unit_test_reduc_sum_usm<f32>(
         "reduction : main (f32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f32> &buf1,
            u32 start_id,
            u32 end_id) -> f32 {
@@ -421,7 +421,7 @@ void unit_test_reduc_sum_usm_fallback_impl() {
 
     unit_test_reduc_sum_usm<u32>(
         "reduction : main (u32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<u32> &buf1,
            u32 start_id,
            u32 end_id) -> u32 {
@@ -430,7 +430,7 @@ void unit_test_reduc_sum_usm_fallback_impl() {
 
     unit_test_reduc_sum_usm<f64_3>(
         "reduction : main (f64_3)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64_3> &buf1,
            u32 start_id,
            u32 end_id) -> f64_3 {
@@ -441,7 +441,7 @@ void unit_test_reduc_min_usm_fallback_impl() {
 
     unit_test_reduc_min_usm<f64>(
         "reduction : main (f64)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64> &buf1,
            u32 start_id,
            u32 end_id) -> f64 {
@@ -450,7 +450,7 @@ void unit_test_reduc_min_usm_fallback_impl() {
 
     unit_test_reduc_min_usm<f32>(
         "reduction : main (f32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f32> &buf1,
            u32 start_id,
            u32 end_id) -> f32 {
@@ -459,7 +459,7 @@ void unit_test_reduc_min_usm_fallback_impl() {
 
     unit_test_reduc_min_usm<u32>(
         "reduction : main (u32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<u32> &buf1,
            u32 start_id,
            u32 end_id) -> u32 {
@@ -468,7 +468,7 @@ void unit_test_reduc_min_usm_fallback_impl() {
 
     unit_test_reduc_min_usm<f64_3>(
         "reduction : main (f64_3)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64_3> &buf1,
            u32 start_id,
            u32 end_id) -> f64_3 {
@@ -479,7 +479,7 @@ void unit_test_reduc_max_usm_fallback_impl() {
 
     unit_test_reduc_max_usm<f64>(
         "reduction : main (f64)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64> &buf1,
            u32 start_id,
            u32 end_id) -> f64 {
@@ -488,7 +488,7 @@ void unit_test_reduc_max_usm_fallback_impl() {
 
     unit_test_reduc_max_usm<f32>(
         "reduction : main (f32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f32> &buf1,
            u32 start_id,
            u32 end_id) -> f32 {
@@ -497,7 +497,7 @@ void unit_test_reduc_max_usm_fallback_impl() {
 
     unit_test_reduc_max_usm<u32>(
         "reduction : main (u32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<u32> &buf1,
            u32 start_id,
            u32 end_id) -> u32 {
@@ -506,7 +506,7 @@ void unit_test_reduc_max_usm_fallback_impl() {
 
     unit_test_reduc_max_usm<f64_3>(
         "reduction : main (f64_3)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64_3> &buf1,
            u32 start_id,
            u32 end_id) -> f64_3 {
@@ -517,7 +517,7 @@ void unit_test_reduc_sum_usm() {
 
     unit_test_reduc_sum_usm<f64>(
         "reduction : main (f64)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64> &buf1,
            u32 start_id,
            u32 end_id) -> f64 {
@@ -526,7 +526,7 @@ void unit_test_reduc_sum_usm() {
 
     unit_test_reduc_sum_usm<f32>(
         "reduction : main (f32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f32> &buf1,
            u32 start_id,
            u32 end_id) -> f32 {
@@ -535,7 +535,7 @@ void unit_test_reduc_sum_usm() {
 
     unit_test_reduc_sum_usm<u32>(
         "reduction : main (u32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<u32> &buf1,
            u32 start_id,
            u32 end_id) -> u32 {
@@ -544,7 +544,7 @@ void unit_test_reduc_sum_usm() {
 
     unit_test_reduc_sum_usm<f64_3>(
         "reduction : main (f64_3)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64_3> &buf1,
            u32 start_id,
            u32 end_id) -> f64_3 {
@@ -555,7 +555,7 @@ void unit_test_reduc_min_usm() {
 
     unit_test_reduc_min_usm<f64>(
         "reduction : main (f64)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64> &buf1,
            u32 start_id,
            u32 end_id) -> f64 {
@@ -564,7 +564,7 @@ void unit_test_reduc_min_usm() {
 
     unit_test_reduc_min_usm<f32>(
         "reduction : main (f32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f32> &buf1,
            u32 start_id,
            u32 end_id) -> f32 {
@@ -573,7 +573,7 @@ void unit_test_reduc_min_usm() {
 
     unit_test_reduc_min_usm<u32>(
         "reduction : main (u32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<u32> &buf1,
            u32 start_id,
            u32 end_id) -> u32 {
@@ -582,7 +582,7 @@ void unit_test_reduc_min_usm() {
 
     unit_test_reduc_min_usm<f64_3>(
         "reduction : main (f64_3)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64_3> &buf1,
            u32 start_id,
            u32 end_id) -> f64_3 {
@@ -593,7 +593,7 @@ void unit_test_reduc_max_usm() {
 
     unit_test_reduc_max_usm<f64>(
         "reduction : main (f64)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64> &buf1,
            u32 start_id,
            u32 end_id) -> f64 {
@@ -602,7 +602,7 @@ void unit_test_reduc_max_usm() {
 
     unit_test_reduc_max_usm<f32>(
         "reduction : main (f32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f32> &buf1,
            u32 start_id,
            u32 end_id) -> f32 {
@@ -611,7 +611,7 @@ void unit_test_reduc_max_usm() {
 
     unit_test_reduc_max_usm<u32>(
         "reduction : main (u32)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<u32> &buf1,
            u32 start_id,
            u32 end_id) -> u32 {
@@ -620,7 +620,7 @@ void unit_test_reduc_max_usm() {
 
     unit_test_reduc_max_usm<f64_3>(
         "reduction : main (f64_3)",
-        [](sham::DeviceScheduler_ptr &sched,
+        [](const sham::DeviceScheduler_ptr &sched,
            sham::DeviceBuffer<f64_3> &buf1,
            u32 start_id,
            u32 end_id) -> f64_3 {


### PR DESCRIPTION
This should avoid the need to duplicate the device scheduler pointer, thus eliminating some atomic adds in the shared ptr refcount.