### PR TITLE
[Cmake] add warning if submodule were not checked out

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,3 +1,18 @@
+function(_git_submod_is_empty directory)
+    file(GLOB files RELATIVE "${directory}" "${directory}/*")
+    if(NOT files)
+
+        message(FATAL_ERROR
+            "The git submodule '${directory}' is empty\n"
+            "please do : git submodule update --init --recursive\n"
+        )
+
+    endif()
+    message(STATUS "The subdirectory '${directory}' contains ${files}")
+endfunction()
+
+_git_submod_is_empty(${CMAKE_CURRENT_SOURCE_DIR}/pybind11)
+
 add_subdirectory(pybind11)
 
 option(USE_SYSTEM_FMTLIB "use fmt lib from the host system" Off)


### PR DESCRIPTION
Now if you have not checked out submodules you get
```
❯ shamconfigure
-- Shamrock version : 2024.10.0+git.6c7105b1.feat/cmake-warn-no-submod.dirty
 ---- Shamrock C++ config ---- 
  CMAKE_CXX_FLAGS :  --acpp-targets='generic' -pedantic-errors -fcolor-diagnostics -Werror=return-type
  CMAKE_CXX_FLAGS_DEBUG : -g
  CMAKE_CXX_FLAGS_RELEASE : -O3 -DNDEBUG -march=native
 ----------------------------- 
-- current build type : CMAKE_BUILD_TYPE=Release
-- Shamrock configure SYCL backend
-- Chosen SYCL implementation : ACPPDirect
 ---- Acpp compiler direct config ---- 
  ACPP_PATH : /home/tdavidcl/Documents/shamrock-dev/Shamrock/build/.env/acpp-installdir
  HAS_ACPP_HEADER_FOLDER : 1
  HAS_OpenSYCL_HEADER_FOLDER : 
  HAS_hipSYCL_HEADER_FOLDER : 
  ACPP_FAST_MATH : OFF
 ------------------------------------- 
 ---- Shamrock SYCL backend config ---- 
  SYCL_COMPILER : ACPP
  sycl 2020 reduction : 
  sycl 2020 isinf : 1
  sycl 2020 clz : 1
  SHAMROCK_LOOP_DEFAULT : PARRALEL_FOR_ROUND
  SHAMROCK_LOOP_GSIZE : 256
 -------------------------------------- 
-- Shamrock configure SYCL backend - done
-- Shamrock configure MPI
-- MPI include dir : /nix/store/vk0ix84y43ndknzyaf55qgkmdm4sbcgc-openmpi-5.0.6-dev/include
-- Shamrock configure MPI - done
CMake Error at external/CMakeLists.txt:5 (message):
  The git submodule
  '<obfuscated path>/Shamrock/external/pybind11' is empty

  please do : git submodule update --init --recursive

Call Stack (most recent call first):
  external/CMakeLists.txt:14 (_git_submod_is_empty)
```