### PR TITLE
[SPH] move qa_ab qb_ab out of add_to_derivs

### DIFF
--- a/src/shammodels/sph/include/shammodels/sph/math/forces.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/math/forces.hpp
@@ -112,14 +112,8 @@ namespace shamrock::sph {
      * @return Tscal
      */
     template<class Tscal>
-    inline Tscal q_av(
-        const Tscal &rho,
-        const Tscal &h,
-        const Tscal &rab,
-        const Tscal &alpha_av,
-        const Tscal &cs,
-        const Tscal &vsig,
-        const Tscal &v_scal_rhat) {
+    inline Tscal q_av(const Tscal &rho, const Tscal &vsig, const Tscal &v_scal_rhat) {
+
         return sham::max(-Tscal(0.5) * rho * vsig * v_scal_rhat, Tscal(0));
     }
 

--- a/src/shammodels/sph/src/modules/UpdateDerivs.cpp
+++ b/src/shammodels/sph/src/modules/UpdateDerivs.cpp
@@ -213,8 +213,8 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_cons
                     Tscal abs_dp  = sham::abs(P_a - P_b);
                     Tscal vsig_u  = sycl::sqrt(abs_dp / rho_avg);
 
-                    Tscal qa_ab = q_av(rho_a, h_a, rab, alpha_a, cs_a, vsig_a, v_ab_r_ab);
-                    Tscal qb_ab = q_av(rho_b, h_b, rab, alpha_b, cs_b, vsig_b, v_ab_r_ab);
+                    Tscal qa_ab = q_av(rho_a, vsig_a, v_ab_r_ab);
+                    Tscal qb_ab = q_av(rho_b, vsig_b, v_ab_r_ab);
 
                     add_to_derivs_sph_artif_visco_cond(
                         pmass,
@@ -423,8 +423,8 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_mm97
                     Tscal abs_dp  = sham::abs(P_a - P_b);
                     Tscal vsig_u  = sycl::sqrt(abs_dp / rho_avg);
 
-                    Tscal qa_ab = q_av(rho_a, h_a, rab, alpha_a, cs_a, vsig_a, v_ab_r_ab);
-                    Tscal qb_ab = q_av(rho_b, h_b, rab, alpha_b, cs_b, vsig_b, v_ab_r_ab);
+                    Tscal qa_ab = q_av(rho_a, vsig_a, v_ab_r_ab);
+                    Tscal qb_ab = q_av(rho_b, vsig_b, v_ab_r_ab);
 
                     add_to_derivs_sph_artif_visco_cond(
                         pmass,
@@ -633,8 +633,8 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_cd10
                     Tscal abs_dp  = sham::abs(P_a - P_b);
                     Tscal vsig_u  = sycl::sqrt(abs_dp / rho_avg);
 
-                    Tscal qa_ab = q_av(rho_a, h_a, rab, alpha_a, cs_a, vsig_a, v_ab_r_ab);
-                    Tscal qb_ab = q_av(rho_b, h_b, rab, alpha_b, cs_b, vsig_b, v_ab_r_ab);
+                    Tscal qa_ab = q_av(rho_a, vsig_a, v_ab_r_ab);
+                    Tscal qb_ab = q_av(rho_b, vsig_b, v_ab_r_ab);
 
                     add_to_derivs_sph_artif_visco_cond(
                         pmass,


### PR DESCRIPTION
This pr the computation of qa_ab and qb_ab out of the derivative update function in forces.hpp