### PR TITLE
[Env][Conda] pin acpp and clang versions

### DIFF
--- a/.github/workflows/shamrock-acpp-conda.yml
+++ b/.github/workflows/shamrock-acpp-conda.yml
@@ -59,6 +59,9 @@ jobs:
           cd build
           source ./activate
 
+      - name: Show current conda env
+        run: conda env export
+
       - name: Configure
         run: |
           cd build

--- a/.github/workflows/shamrock-acpp-conda.yml
+++ b/.github/workflows/shamrock-acpp-conda.yml
@@ -60,7 +60,10 @@ jobs:
           source ./activate
 
       - name: Show current conda env
-        run: conda env export
+        run: |
+          cd build
+          source ./activate
+          conda env export
 
       - name: Configure
         run: |

--- a/env/machine/conda/acpp/environment.yml
+++ b/env/machine/conda/acpp/environment.yml
@@ -2,15 +2,14 @@ name: shamrock_dev_environment
 channels:
   - conda-forge
 dependencies:
+  - adaptivecpp=24.10.0=cuda126_llvm19_hfec26a9_9
+  - clangxx=19.1.7=default_ha78316a_2
+  - boost=1.85.0=h9cebb41_4
   - python=3.12
   - cmake
   - ninja
-  - adaptivecpp
   - openmpi
-  - clang
-  - clangxx
   - fmt=11.0.2
-  - boost
   - numpy
   - matplotlib
   - psutil


### PR DESCRIPTION
I had to pin the version of acpp and clang because conda is so trash that requiring an env with acpp and clangxx create something that has to following error because of mismatched llvm versions

```
error: unable to load plugin '/opt/conda/envs/shamrock_dev_environment/bin/../lib/libacpp-clang.so': '/opt/conda/envs/shamrock_dev_environment/bin/../lib/libacpp-clang.so: undefined symbol: _ZN4llvm9DIBuilder23insertDbgValueIntrinsicEPNS_5ValueEPNS_15DILocalVariableEPNS_12DIExpressionEPKNS_10DILocationEPNS_11InstructionE'
```