### PR TITLE
[SPH][Setup] fix and add control over initial h factor for disc setup

### DIFF
--- a/src/shammodels/sph/include/shammodels/sph/modules/SPHSetup.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/SPHSetup.hpp
@@ -59,7 +59,8 @@ namespace shammodels::sph::modules {
             std::function<Tscal(Tscal)> H_profile,
             std::function<Tscal(Tscal)> rot_profile,
             std::function<Tscal(Tscal)> cs_profile,
-            std::mt19937 eng);
+            std::mt19937 eng,
+            Tscal init_h_factor);
 
         std::shared_ptr<ISPHSetupNode>
         make_combiner_add(SetupNodePtr parent1, SetupNodePtr parent2);

--- a/src/shammodels/sph/include/shammodels/sph/modules/setup/GeneratorMCDisc.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/setup/GeneratorMCDisc.hpp
@@ -45,6 +45,7 @@ namespace shammodels::sph::modules {
 
         class DiscIterator;
         DiscIterator generator;
+        Tscal init_h_factor;
 
         static DiscIterator make_generator(
             Tscal part_mass,
@@ -80,7 +81,8 @@ namespace shammodels::sph::modules {
             std::function<Tscal(Tscal)> H_profile,
             std::function<Tscal(Tscal)> rot_profile,
             std::function<Tscal(Tscal)> cs_profile,
-            std::mt19937 eng)
+            std::mt19937 eng,
+            Tscal init_h_factor)
             : context(context), solver_config(solver_config), generator(make_generator(
                                                                   part_mass,
                                                                   disc_mass,
@@ -91,7 +93,7 @@ namespace shammodels::sph::modules {
                                                                   rot_profile,
                                                                   cs_profile,
                                                                   eng)),
-              pmass(part_mass) {}
+              init_h_factor(init_h_factor), pmass(part_mass) {}
 
         bool is_done();
 

--- a/src/shammodels/sph/src/modules/SPHSetup.cpp
+++ b/src/shammodels/sph/src/modules/SPHSetup.cpp
@@ -41,7 +41,8 @@ shammodels::sph::modules::SPHSetup<Tvec, SPHKernel>::make_generator_disc_mc(
     std::function<Tscal(Tscal)> H_profile,
     std::function<Tscal(Tscal)> rot_profile,
     std::function<Tscal(Tscal)> cs_profile,
-    std::mt19937 eng) {
+    std::mt19937 eng,
+    Tscal init_h_factor) {
     return std::shared_ptr<ISPHSetupNode>(new GeneratorMCDisc<Tvec, SPHKernel>(
         context,
         solver_config,
@@ -53,7 +54,8 @@ shammodels::sph::modules::SPHSetup<Tvec, SPHKernel>::make_generator_disc_mc(
         H_profile,
         rot_profile,
         cs_profile,
-        eng));
+        eng,
+        init_h_factor));
 }
 
 template<class Tvec, template<class> class SPHKernel>

--- a/src/shammodels/sph/src/modules/setup/GeneratorMCDisc.cpp
+++ b/src/shammodels/sph/src/modules/setup/GeneratorMCDisc.cpp
@@ -127,7 +127,7 @@ shammodels::sph::modules::GeneratorMCDisc<Tvec, SPHKernel>::next_n(u32 nmax) {
         vec_pos.push_back(o.pos);
         vec_vel.push_back(o.velocity);
         // vec_u.push_back(o.cs * o.cs / (/*solver.eos_gamma * */ (eos_gamma - 1)));
-        Tscal h = shamrock::sph::h_rho(pmass, o.rho * 0.1, Kernel::hfactd);
+        Tscal h = shamrock::sph::h_rho(pmass, o.rho, Kernel::hfactd) * init_h_factor;
         vec_h.push_back(h);
         vec_cs.push_back(o.cs);
     }

--- a/src/shammodels/sph/src/pySPHModel.cpp
+++ b/src/shammodels/sph/src/pySPHModel.cpp
@@ -214,7 +214,8 @@ void add_instance(py::module &m, std::string name_config, std::string name_model
                std::function<Tscal(Tscal)> H_profile,
                std::function<Tscal(Tscal)> rot_profile,
                std::function<Tscal(Tscal)> cs_profile,
-               u64 random_seed) {
+               u64 random_seed,
+               Tscal init_h_factor) {
                 return self.make_generator_disc_mc(
                     part_mass,
                     disc_mass,
@@ -224,7 +225,8 @@ void add_instance(py::module &m, std::string name_config, std::string name_model
                     H_profile,
                     rot_profile,
                     cs_profile,
-                    std::mt19937(random_seed));
+                    std::mt19937(random_seed),
+                    init_h_factor);
             },
             py::kw_only(),
             py::arg("part_mass"),
@@ -235,7 +237,8 @@ void add_instance(py::module &m, std::string name_config, std::string name_model
             py::arg("H_profile"),
             py::arg("rot_profile"),
             py::arg("cs_profile"),
-            py::arg("random_seed"))
+            py::arg("random_seed"),
+            py::arg("init_h_factor") = 0.8)
         .def(
             "make_combiner_add",
             [](TSPHSetup &self,


### PR DESCRIPTION
@y-lapeyre, This should fix the issue. I moved the factor to a global factor on h for clarity and added a new parameter h_init_factor (default = 0.8) which would be the factor applied to the smoothing lenght deduced from the density generated by the disc setup.

This should not require any change as it has a default value but will add the possibility to control it if needed.