### PR TITLE
finite volume solver refactorize

### DIFF
--- a/src/shammodels/ramses/CMakeLists.txt
+++ b/src/shammodels/ramses/CMakeLists.txt
@@ -33,6 +33,7 @@ set(Sources
     src/modules/ComputeCFL.cpp
     src/modules/ConsToPrim.cpp
     src/modules/StencilGenerator.cpp
+    src/modules/FluxDivergence.cpp
 )
 
 if(SHAMROCK_USE_SHARED_LIB)

--- a/src/shammodels/ramses/include/shammodels/ramses/Solver.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/Solver.hpp
@@ -34,6 +34,8 @@ namespace shammodels::basegodunov {
         Minmod      = 4,
     };
 
+    enum TimeIntegratorMode { MUSCL = 0, RK1 = 1, RK2 = 2, RK3 = 3, VL2 = 4 };
+
     enum DustRiemannSolverMode {
         NoDust = 0,
         DHLL   = 1, // Dust HLL . This is merely the HLL solver for dust. It's then a Rusanov like
@@ -45,6 +47,17 @@ namespace shammodels::basegodunov {
         IRK1   = 1, // Implicit RK1
         IRK2   = 2, // Implicit RK2
         EXPO   = 3  // Matrix exponential
+    };
+
+    struct TimeIntegratorConfig {
+        TimeIntegratorMode time_integrator = MUSCL;
+
+        inline bool is_muscl_scheme() {
+            if (time_integrator == MUSCL) {
+                return true;
+            }
+            return false;
+        }
     };
 
     /**
@@ -121,6 +134,8 @@ namespace shammodels::basegodunov {
         bool face_half_time_interpolation = true;
         DustConfig dust_config{};
         DragConfig drag_config{};
+        TimeIntegratorConfig time_integrator_config{};
+        inline bool is_muscl_scheme() { return time_integrator_config.is_muscl_scheme(); }
 
         inline bool is_dust_on() { return dust_config.is_dust_on(); }
         // get alpha values from user
@@ -195,6 +210,11 @@ namespace shammodels::basegodunov {
                     "Godunov", "time since start :", shambase::details::get_wtime(), "(s)");
             }
         }
+
+        void get_old_fields();
+        void set_old_fields();
+
+        void reset_old_fields();
 
         void evolve_once();
 

--- a/src/shammodels/ramses/include/shammodels/ramses/modules/ComputeGradient.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/modules/ComputeGradient.hpp
@@ -12,6 +12,7 @@
 /**
  * @file ComputeGradient.hpp
  * @author Timothée David--Cléris (timothee.david--cleris@ens-lyon.fr)
+ * @author Leodasce Sewanou (leodasce.sewanou@ens-lyon.fr)
  * @brief
  *
  */
@@ -25,7 +26,7 @@
 namespace shammodels::basegodunov::modules {
 
     template<class Tvec, class TgridVec>
-    class ComputeGradient {
+    class Slopes {
 
         public:
         using Tscal                      = shambase::VecComponent<Tvec>;
@@ -43,26 +44,26 @@ namespace shammodels::basegodunov::modules {
         Config &solver_config;
         Storage &storage;
 
-        ComputeGradient(ShamrockCtx &context, Config &solver_config, Storage &storage)
+        Slopes(ShamrockCtx &context, Config &solver_config, Storage &storage)
             : context(context), solver_config(solver_config), storage(storage) {}
 
-        void compute_grad_rho_van_leer();
-        void compute_grad_v_van_leer();
-        void compute_grad_P_van_leer();
-        void compute_grad_rho_dust_van_leer();
-        void compute_grad_v_dust_van_leer();
+        void slope_rho();
+        void slope_v();
+        void slope_P();
+        void slope_rho_dust();
+        void slope_v_dust();
 
         private:
         template<SlopeMode mode>
-        void _compute_grad_rho_van_leer();
+        void _slope_rho();
         template<SlopeMode mode>
-        void _compute_grad_v_van_leer();
+        void _slope_v();
         template<SlopeMode mode>
-        void _compute_grad_P_van_leer();
+        void _slope_P();
         template<SlopeMode mode>
-        void _compute_grad_rho_dust_van_leer();
+        void _slope_rho_dust();
         template<SlopeMode mode>
-        void _compute_grad_v_dust_van_leer();
+        void _slope_v_dust();
 
         inline PatchScheduler &scheduler() { return shambase::get_check_ref(context.sched); }
     };

--- a/src/shammodels/ramses/include/shammodels/ramses/modules/ConsToPrim.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/modules/ConsToPrim.hpp
@@ -47,6 +47,7 @@ namespace shammodels::basegodunov::modules {
             : context(context), solver_config(solver_config), storage(storage) {}
 
         void cons_to_prim();
+        void cons_to_prim_dust();
 
         private:
         inline PatchScheduler &scheduler() { return shambase::get_check_ref(context.sched); }

--- a/src/shammodels/ramses/include/shammodels/ramses/modules/FluxDivergence.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/modules/FluxDivergence.hpp
@@ -10,8 +10,9 @@
 #pragma once
 
 /**
- * @file FaceInterpolate.hpp
+ * @file FluxDivergence.hpp
  * @author Timothée David--Cléris (timothee.david--cleris@ens-lyon.fr)
+ * @author Leodasce Sewanou (leodasce.sewanou@ens-lyon.fr)
  * @brief
  *
  */
@@ -21,11 +22,16 @@
 #include "shammodels/ramses/Solver.hpp"
 #include "shammodels/ramses/modules/SolverStorage.hpp"
 #include "shamrock/scheduler/ComputeField.hpp"
+#include "shamrock/scheduler/ComputeFlux.hpp"
+#include "shamrock/scheduler/ComputeGradient.hpp"
+#include "shamrock/scheduler/ComputeTimeDerivative.hpp"
+#include "shamrock/scheduler/ConsToPrim.hpp"
+#include "shamrock/scheduler/FaceInterpolate.hpp"
 
 namespace shammodels::basegodunov::modules {
 
     template<class Tvec, class TgridVec>
-    class FaceInterpolate {
+    class FluxDivergence {
 
         public:
         using Tscal                      = shambase::VecComponent<Tvec>;
@@ -43,17 +49,17 @@ namespace shammodels::basegodunov::modules {
         Config &solver_config;
         Storage &storage;
 
-        FaceInterpolate(ShamrockCtx &context, Config &solver_config, Storage &storage)
+        FluxDivergence(ShamrockCtx &context, Config &solver_config, Storage &storage)
             : context(context), solver_config(solver_config), storage(storage) {}
 
-        /** When is_muscl = 0 then no prediction step (i.e no muscl scheme) so we only need the
-         * reconstruction at cells interfaces.*/
-        void interpolate_rho_to_face(Tscal dt, bool is_muscl = 0);
-        void interpolate_v_to_face(Tscal dt, bool is_muscl = 0);
-        void interpolate_P_to_face(Tscal dt, bool is_muscl = 0);
+        /** compute the Flux at cell interfaces by solving Riemann problems*/
+        // modules::ComputeFlux flux_compute(context, solver_config, storage);
 
-        void interpolate_rho_dust_to_face(Tscal dt, bool is_muscl = 0);
-        void interpolate_v_dust_to_face(Tscal dt, bool is_muscl = 0);
+        void eval_flux_divergence_hydro_fields();
+        void eval_flux_divergence_dust_fields();
+
+        void reset_storage_buffers_hydro();
+        void reset_storage_buffers_dust();
 
         private:
         inline PatchScheduler &scheduler() { return shambase::get_check_ref(context.sched); }

--- a/src/shammodels/ramses/include/shammodels/ramses/modules/SolverStorage.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/modules/SolverStorage.hpp
@@ -62,6 +62,12 @@ namespace shammodels::basegodunov {
             shammodels::basegodunov::modules::OrientedAMRGraph<Tvec, TgridVec>>>
             cell_link_graph;
 
+        Component<shamrock::ComputeField<Tscal>> rho_old;
+        Component<shamrock::ComputeField<Tvec>> rhovel_old;
+        Component<shamrock::ComputeField<Tscal>> rhoetot_old;
+        Component<shamrock::ComputeField<Tscal>> rho_dust_old;
+        Component<shamrock::ComputeField<Tvec>> rhovel_dust_old;
+
         Component<shamrock::ComputeField<Tvec>> vel;
         Component<shamrock::ComputeField<Tscal>> press;
 
@@ -90,6 +96,28 @@ namespace shammodels::basegodunov {
             shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
             rho_face_zm;
 
+        /**/
+
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            rho_tilde_xp;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            rho_tilde_xm;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            rho_tilde_yp;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            rho_tilde_ym;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            rho_tilde_zp;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            rho_tilde_zm;
+        /**/
+
         Component<shambase::DistributedData<
             shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
             vel_face_xp;
@@ -109,6 +137,27 @@ namespace shammodels::basegodunov {
             shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
             vel_face_zm;
 
+        /**/
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
+            vel_tilde_xp;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
+            vel_tilde_xm;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
+            vel_tilde_yp;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
+            vel_tilde_ym;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
+            vel_tilde_zp;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
+            vel_tilde_zm;
+        /**/
+
         Component<shambase::DistributedData<
             shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
             press_face_xp;
@@ -127,6 +176,27 @@ namespace shammodels::basegodunov {
         Component<shambase::DistributedData<
             shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
             press_face_zm;
+
+        /**/
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            press_tilde_xp;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            press_tilde_xm;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            press_tilde_yp;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            press_tilde_ym;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            press_tilde_zp;
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            press_tilde_zm;
+        /**/
 
         Component<
             shambase::DistributedData<shammodels::basegodunov::modules::NeighGraphLinkField<Tscal>>>
@@ -210,41 +280,79 @@ namespace shammodels::basegodunov {
         // next time step dust momentum before drag
         Component<shamrock::ComputeField<Tvec>> rhov_d_next_no_drag;
         /**
-         * @brief dust densities in +x direction stored at the cells faces
+         * @brief dust densities +x direction stored at the cells faces
          */
         Component<shambase::DistributedData<
             shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
             rho_dust_face_xp;
         /**
-         * @brief dust densities in -x direction stored at the cells faces
+         * @brief dust densities -x direction stored at the cells faces
          */
         Component<shambase::DistributedData<
             shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
             rho_dust_face_xm;
         /**
-         * @brief dust densities in +y direction stored at the cells faces
+         * @brief dust densities +y direction stored at the cells faces
          */
         Component<shambase::DistributedData<
             shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
             rho_dust_face_yp;
         /**
-         * @brief dust densities in -y direction stored at the cells faces
+         * @brief dust densities -y direction stored at the cells faces
          */
         Component<shambase::DistributedData<
             shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
             rho_dust_face_ym;
         /**
-         * @brief dust densities in +z direction stored at the cells faces
+         * @brief dust densities +z direction stored at the cells faces
          */
         Component<shambase::DistributedData<
             shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
             rho_dust_face_zp;
         /**
-         * @brief dust densities in -z direction stored at the cells faces
+         * @brief dust densities -z direction stored at the cells faces
          */
         Component<shambase::DistributedData<
             shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
             rho_dust_face_zm;
+
+        /**
+         * @brief dust densities reconstruct in +x direction stored at the cells faces
+         */
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            rho_dust_tilde_xp;
+        /**
+         * @brief dust densities reconstruct in -x direction stored at the cells faces
+         */
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            rho_dust_tilde_xm;
+        /**
+         * @brief dust densities reconstruct in +y direction stored at the cells faces
+         */
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            rho_dust_tilde_yp;
+        /**
+         * @brief dust densities reconstruct in -y direction stored at the cells faces
+         */
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            rho_dust_tilde_ym;
+        /**
+         * @brief dust densities reconstruct in +z direction stored at the cells faces
+         */
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            rho_dust_tilde_zp;
+        /**
+         * @brief dust densities reconstruct in -z direction stored at the cells faces
+         */
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tscal, 2>>>>
+            rho_dust_tilde_zm;
+
         /**
          * @brief dust velocities in +x direction stored at the cells faces
          */
@@ -281,6 +389,44 @@ namespace shammodels::basegodunov {
         Component<shambase::DistributedData<
             shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
             vel_dust_face_zm;
+
+        /**
+         * @brief dust velocities reconstruct in +x direction stored at the cells faces
+         */
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
+            vel_dust_tilde_xp;
+        /**
+         * @brief dust velocities reconstruct in -x direction stored at the cells faces
+         */
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
+            vel_dust_tilde_xm;
+        /**
+         * @brief dust velocities reconstruct in +y direction stored at the cells faces
+         */
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
+            vel_dust_tilde_yp;
+        /**
+         * @brief dust velocities reconstruct in -y direction stored at the cells faces
+         */
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
+            vel_dust_tilde_ym;
+        /**
+         * @brief dust velocities reconstruct in +z direction stored at the cells faces
+         */
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
+            vel_dust_tilde_zp;
+        /**
+         * @brief dust velocities reconstruct in -z direction stored at the cells faces
+         */
+        Component<shambase::DistributedData<
+            shammodels::basegodunov::modules::NeighGraphLinkField<std::array<Tvec, 2>>>>
+            vel_dust_tilde_zm;
+
         /**
          * @brief dust density flux at cells interfaces in +x direction
          */

--- a/src/shammodels/ramses/include/shammodels/ramses/modules/TimeIntegrator.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/modules/TimeIntegrator.hpp
@@ -46,7 +46,9 @@ namespace shammodels::basegodunov::modules {
         TimeIntegrator(ShamrockCtx &context, Config &solver_config, Storage &storage)
             : context(context), solver_config(solver_config), storage(storage) {}
 
-        void forward_euler(Tscal dt);
+        // void forward_euler(Tscal dt);
+        void evolve_old_fields(Tscal dt, Tscal coef);
+        void evolve_intermediate(Tscal dt, Tscal coef1, Tscal coef2);
 
         private:
         inline PatchScheduler &scheduler() { return shambase::get_check_ref(context.sched); }

--- a/src/shammodels/ramses/src/modules/ConsToPrim.cpp
+++ b/src/shammodels/ramses/src/modules/ConsToPrim.cpp
@@ -39,6 +39,122 @@ void shammodels::basegodunov::modules::ConsToPrim<Tvec, TgridVec>::cons_to_prim(
               return storage.merged_patchdata_ghost.get().get(id).total_elements;
           });
 
+    storage.merged_patchdata_ghost.get().for_each([&](u64 id, MergedPDat &mpdat) {
+        sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+
+        sham::DeviceBuffer<Tscal> &buf_rho  = storage.rho_old.get().get_buf(id);
+        sham::DeviceBuffer<Tvec> &buf_rhov  = storage.rhovel_old.get().get_buf(id);
+        sham::DeviceBuffer<Tscal> &buf_rhoe = storage.rhoetot_old.get().get_buf(id);
+
+        sham::DeviceBuffer<Tvec> &buf_vel = v_ghost.get_buf(id);
+        sham::DeviceBuffer<Tscal> &buf_P  = P_ghost.get_buf(id);
+
+        sham::EventList depends_list;
+
+        auto rho    = buf_rho.get_read_access(depends_list);
+        auto rhovel = buf_rhov.get_read_access(depends_list);
+        auto rhoe   = buf_rhoe.get_read_access(depends_list);
+
+        auto vel = buf_vel.get_write_access(depends_list);
+        auto P   = buf_P.get_write_access(depends_list);
+
+        auto e = q.submit(depends_list, [&](sycl::handler &cgh) {
+            Tscal gamma = solver_config.eos_gamma;
+
+            u32 cell_count = (mpdat.total_elements) * AMRBlock::block_size;
+
+            shambase::parralel_for(cgh, cell_count, "cons_to_prim", [=](u64 gid) {
+                auto conststate = shammath::ConsState<Tvec>{rho[gid], rhoe[gid], rhovel[gid]};
+
+                auto prim_state = shammath::cons_to_prim(conststate, gamma);
+
+                vel[gid] = prim_state.vel;
+                P[gid]   = prim_state.press;
+            });
+        });
+
+        buf_rho.complete_event_state(e);
+        buf_rhov.complete_event_state(e);
+        buf_rhoe.complete_event_state(e);
+        buf_vel.complete_event_state(e);
+        buf_P.complete_event_state(e);
+    });
+
+    storage.vel.set(std::move(v_ghost));
+    storage.press.set(std::move(P_ghost));
+}
+
+template<class Tvec, class TgridVec>
+void shammodels::basegodunov::modules::ConsToPrim<Tvec, TgridVec>::cons_to_prim_dust() {
+
+    StackEntry stack_loc{};
+
+    using MergedPDat = shamrock::MergedPatchData;
+
+    shamrock::SchedulerUtility utility(scheduler());
+
+    u32 ndust                                      = solver_config.dust_config.ndust;
+    shamrock::patch::PatchDataLayout &ghost_layout = storage.ghost_layout.get();
+
+    shamrock::ComputeField<Tvec> v_dust_ghost
+        = utility.make_compute_field<Tvec>("vel_dust", ndust * AMRBlock::block_size, [&](u64 id) {
+              return storage.merged_patchdata_ghost.get().get(id).total_elements;
+          });
+
+    storage.merged_patchdata_ghost.get().for_each([&](u64 id, MergedPDat &mpdat) {
+        sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+
+        sham::DeviceBuffer<Tscal> &buf_rho_dust = storage.rho_dust_old.get().get_buf(id);
+        sham::DeviceBuffer<Tvec> &buf_rhov_dust = storage.rhovel_dust_old.get().get_buf(id);
+        sham::DeviceBuffer<Tvec> &buf_vel_dust  = v_dust_ghost.get_buf(id);
+
+        sham::EventList depends_list;
+
+        auto rho_dust    = buf_rho_dust.get_read_access(depends_list);
+        auto rhovel_dust = buf_rhov_dust.get_read_access(depends_list);
+
+        auto vel_dust = buf_vel_dust.get_write_access(depends_list);
+
+        auto e = q.submit(depends_list, [&](sycl::handler &cgh) {
+            u32 cell_count = (mpdat.total_elements) * AMRBlock::block_size;
+
+            u32 nvar_dust = ndust;
+            shambase::parralel_for(cgh, nvar_dust * cell_count, "cons_to_prim_dust", [=](u64 gid) {
+                auto d_conststate = shammath::DustConsState<Tvec>{rho_dust[gid], rhovel_dust[gid]};
+
+                auto d_prim_state = shammath::d_cons_to_prim(d_conststate);
+
+                vel_dust[gid] = d_prim_state.vel;
+            });
+        });
+
+        buf_rho_dust.complete_event_state(e);
+        buf_rhov_dust.complete_event_state(e);
+        buf_vel_dust.complete_event_state(e);
+    });
+    storage.vel_dust.set(std::move(v_dust_ghost));
+}
+
+/*
+template<class Tvec, class TgridVec>
+void shammodels::basegodunov::modules::ConsToPrim<Tvec, TgridVec>::cons_to_prim() {
+
+    StackEntry stack_loc{};
+
+    using MergedPDat = shamrock::MergedPatchData;
+
+    shamrock::SchedulerUtility utility(scheduler());
+
+    shamrock::ComputeField<Tvec> v_ghost
+        = utility.make_compute_field<Tvec>("vel", AMRBlock::block_size, [&](u64 id) {
+              return storage.merged_patchdata_ghost.get().get(id).total_elements;
+          });
+
+    shamrock::ComputeField<Tscal> P_ghost
+        = utility.make_compute_field<Tscal>("P", AMRBlock::block_size, [&](u64 id) {
+              return storage.merged_patchdata_ghost.get().get(id).total_elements;
+          });
+
     shamrock::patch::PatchDataLayout &ghost_layout = storage.ghost_layout.get();
     u32 irho_ghost                                 = ghost_layout.get_field_idx<Tscal>("rho");
     u32 irhov_ghost                                = ghost_layout.get_field_idx<Tvec>("rhovel");
@@ -90,9 +206,21 @@ void shammodels::basegodunov::modules::ConsToPrim<Tvec, TgridVec>::cons_to_prim(
 
     storage.vel.set(std::move(v_ghost));
     storage.press.set(std::move(P_ghost));
+}
 
-    if (solver_config.is_dust_on()) {
-        u32 ndust                                      = solver_config.dust_config.ndust;
+*/
+
+/*
+template<class Tvec, class TgridVec>
+void shammodels::basegodunov::modules::ConsToPrim<Tvec, TgridVec>::cons_to_prim_dust() {
+
+    StackEntry stack_loc{};
+
+    using MergedPDat = shamrock::MergedPatchData;
+
+    shamrock::SchedulerUtility utility(scheduler());
+
+     u32 ndust                                      = solver_config.dust_config.ndust;
         shamrock::patch::PatchDataLayout &ghost_layout = storage.ghost_layout.get();
 
         shamrock::ComputeField<Tvec> v_dust_ghost = utility.make_compute_field<Tvec>(
@@ -142,7 +270,8 @@ void shammodels::basegodunov::modules::ConsToPrim<Tvec, TgridVec>::cons_to_prim(
             buf_vel_dust.complete_event_state(e);
         });
         storage.vel_dust.set(std::move(v_dust_ghost));
-    }
+
 }
+*/
 
 template class shammodels::basegodunov::modules::ConsToPrim<f64_3, i64_3>;

--- a/src/shammodels/ramses/src/modules/FluxDivergence.cpp
+++ b/src/shammodels/ramses/src/modules/FluxDivergence.cpp
@@ -1,0 +1,211 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2024 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+/**
+ * @file FluxDivergence.cpp
+ * @author Timothée David--Cléris (timothee.david--cleris@ens-lyon.fr)
+ * @brief
+ *
+ */
+
+#include "shambase/stacktrace.hpp"
+#include "shambackends/sycl.hpp"
+#include "shammodels/ramses/modules/ComputeFlux.hpp"
+#include "shammodels/ramses/modules/ComputeFluxUtilities.hpp"
+#include "shammodels/ramses/modules/FluxDivergence.hpp"
+#include "shamrock/scheduler/SchedulerUtility.hpp"
+
+template<class T>
+using NGLink = shammodels::basegodunov::modules::NeighGraphLinkField<T>;
+
+template<class Tvec, class TgridVec>
+void shammodels::basegodunov::modules::FluxDivergence<Tvec, TgridVec>::
+    eval_flux_divergence_hydro_fields() {
+
+    StackEntry stack_loc{};
+
+    // const to prim
+    modules::ConsToPrim ctop(context, solver_config, storage);
+    ctop.cons_to_prim();
+    if (solver_config.is_dust_on())
+        ctop.cons_to_prim_dust();
+
+    // compute & limit gradients /* maybe compute fields slopes is a better name ?*/
+    modules::Slopes slopes(context, solver_config, storage);
+    slopes.slope_rho();
+    slopes.slope_v();
+    slopes.slope_P();
+    if (solver_config.is_dust_on()) {
+        slopes.slope_rho_dust();
+        slopes.slope_v_dust();
+    }
+
+    // shift values /* Field reconstruction (and interpolation for muscl-hancock ) ?*/
+    modules::FaceInterpolate face_interpolator(
+        context, solver_config, storage); /** change the class name to reconstruction is more
+                                             general than interpolation ?*/
+    bool is_muscl = solver_config.is_muscl_scheme();
+    face_interpolator.interpolate_rho_to_face(dt_input, is_muscl);
+    face_interpolator.interpolate_v_to_face(dt_input, is_muscl);
+    face_interpolator.interpolate_P_to_face(dt_input, is_muscl);
+
+    if (solver_config.is_dust_on()) {
+        face_interpolator.interpolate_rho_dust_to_face(dt_input, is_muscl);
+        face_interpolator.interpolate_v_dust_to_face(dt_input, is_muscl);
+    }
+
+    // flux at cell faces
+    modules::ComputeFlux flux_compute(context, solver_config, storage);
+    flux_compute.compute_flux();
+    if (solver_config.is_dust_on()) {
+        flux_compute.compute_flux_dust();
+    }
+    // compute dt fields or  flux divergence operator evaluation
+    modules::ComputeTimeDerivative dt_compute(context, solver_config, storage);
+    dt_compute.compute_dt_fields();
+    if (solver_config.is_dust_on()) {
+        dt_compute.compute_dt_dust_fields();
+    }
+}
+
+template<class Tvec, class TgridVec>
+void shammodels::basegodunov::modules::FluxDivergence<Tvec, TgridVec>::
+    eval_flux_divergence_dust_fields() {
+
+    StackEntry stack_loc{};
+
+    // const to prim
+    modules::ConsToPrim ctop(context, solver_config, storage);
+    ctop.cons_to_prim_dust();
+
+    // compute & limit gradients /* maybe compute fields slopes is a better name ?*/
+    modules::Slopes slopes(context, solver_config, storage);
+    slopes.slope_rho_dust();
+    slopes.slope_v_dust();
+
+    // shift values /* Field reconstruction (and interpolation for muscl-hancock ) ?*/
+    modules::FaceInterpolate face_interpolator(
+        context, solver_config, storage); /** change the class name to reconstruction is more
+                                             general than interpolation ?*/
+    bool is_muscl = solver_config.is_muscl_scheme();
+    face_interpolator.interpolate_rho_dust_to_face(dt_input, is_muscl);
+    face_interpolator.interpolate_v_dust_to_face(dt_input, is_muscl);
+
+    // flux at cell faces
+    modules::ComputeFlux flux_compute(context, solver_config, storage);
+    flux_compute.compute_flux_dust();
+
+    // compute dt fields or  flux divergence operator evaluation
+    modules::ComputeTimeDerivative dt_compute(context, solver_config, storage);
+    dt_compute.compute_dt_dust_fields();
+}
+
+template<class Tvec, class TgridVec>
+void shammodels::basegodunov::modules::FluxDivergence<Tvec, TgridVec>::
+    reset_storage_buffers_hydro() {
+    StackEntry stack_loc{};
+
+    storage.vel.reset();
+    storage.press.reset();
+
+    storage.grad_rho.reset();
+    storage.dx_v.reset();
+    storage.dy_v.reset();
+    storage.dz_v.reset();
+    storage.grad_P.reset();
+
+    storage.rho_face_xp.reset();
+    storage.rho_face_xm.reset();
+    storage.rho_face_yp.reset();
+    storage.rho_face_ym.reset();
+    storage.rho_face_zp.reset();
+    storage.rho_face_zm.reset();
+
+    storage.vel_face_xp.reset();
+    storage.vel_face_xm.reset();
+    storage.vel_face_yp.reset();
+    storage.vel_face_ym.reset();
+    storage.vel_face_zp.reset();
+    storage.vel_face_zm.reset();
+
+    storage.press_face_xp.reset();
+    storage.press_face_xm.reset();
+    storage.press_face_yp.reset();
+    storage.press_face_ym.reset();
+    storage.press_face_zp.reset();
+    storage.press_face_zm.reset();
+
+    storage.flux_rho_face_xp.reset();
+    storage.flux_rho_face_xm.reset();
+    storage.flux_rho_face_yp.reset();
+    storage.flux_rho_face_ym.reset();
+    storage.flux_rho_face_zp.reset();
+    storage.flux_rho_face_zm.reset();
+    storage.flux_rhov_face_xp.reset();
+    storage.flux_rhov_face_xm.reset();
+    storage.flux_rhov_face_yp.reset();
+    storage.flux_rhov_face_ym.reset();
+    storage.flux_rhov_face_zp.reset();
+    storage.flux_rhov_face_zm.reset();
+    storage.flux_rhoe_face_xp.reset();
+    storage.flux_rhoe_face_xm.reset();
+    storage.flux_rhoe_face_yp.reset();
+    storage.flux_rhoe_face_ym.reset();
+    storage.flux_rhoe_face_zp.reset();
+    storage.flux_rhoe_face_zm.reset();
+
+    storage.dtrho.reset();
+    storage.dtrhov.reset();
+    storage.dtrhoe.reset();
+}
+
+template<class Tvec, class TgridVec>
+void shammodels::basegodunov::modules::FluxDivergence<Tvec, TgridVec>::
+    reset_storage_buffers_dust() {
+    StackEntry stack_loc{};
+
+    storage.vel_dust.reset();
+
+    storage.grad_rho_dust.reset();
+    storage.dx_v_dust.reset();
+    storage.dy_v_dust.reset();
+    storage.dz_v_dust.reset();
+
+    storage.rho_dust_face_xm.reset();
+    storage.rho_dust_face_yp.reset();
+    storage.rho_dust_face_ym.reset();
+    storage.rho_dust_face_xp.reset();
+    storage.rho_dust_face_zp.reset();
+    storage.rho_dust_face_zm.reset();
+
+    storage.vel_dust_face_xp.reset();
+    storage.vel_dust_face_xm.reset();
+    storage.vel_dust_face_yp.reset();
+    storage.vel_dust_face_ym.reset();
+    storage.vel_dust_face_zp.reset();
+    storage.vel_dust_face_zm.reset();
+
+    storage.flux_rho_dust_face_xp.reset();
+    storage.flux_rho_dust_face_xm.reset();
+    storage.flux_rho_dust_face_yp.reset();
+    storage.flux_rho_dust_face_ym.reset();
+    storage.flux_rho_dust_face_zp.reset();
+    storage.flux_rho_dust_face_zm.reset();
+    storage.flux_rhov_dust_face_xp.reset();
+    storage.flux_rhov_dust_face_xm.reset();
+    storage.flux_rhov_dust_face_yp.reset();
+    storage.flux_rhov_dust_face_ym.reset();
+    storage.flux_rhov_dust_face_zp.reset();
+    storage.flux_rhov_dust_face_zm.reset();
+
+    storage.dtrho_dust.reset();
+    storage.dtrhov_dust.reset();
+}
+
+template class shammodels::basegodunov::modules::FluxDivergence<f64_3, i64_3>;

--- a/src/shammodels/ramses/src/modules/TimeIntegrator.cpp
+++ b/src/shammodels/ramses/src/modules/TimeIntegrator.cpp
@@ -16,6 +16,241 @@
 #include "shammodels/ramses/modules/TimeIntegrator.hpp"
 
 template<class Tvec, class TgridVec>
+void shammodels::basegodunov::modules::TimeIntegrator<Tvec, TgridVec>::evolve_old_fields(
+    Tscal dt, Tscal coef) {
+
+    StackEntry stack_loc{};
+
+    using MergedPDat = shamrock::MergedPatchData;
+
+    shamrock::SchedulerUtility utility(scheduler());
+
+    storage.merged_patchdata_ghost.get().for_each([&](u64 id, MergedPDat &mpdat) {
+        sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+
+        sham::DeviceBuffer<Tscal> &buf_rho  = storage.rho_old.get().get_buf(id);
+        sham::DeviceBuffer<Tvec> &buf_rhov  = storage.rhovel_old.get().get_buf(id);
+        sham::DeviceBuffer<Tscal> &buf_rhoe = storage.rhoetot_old.get().get_buf(id);
+
+        shamrock::DeviceBuffer<Tscal> &dtrho  = storage.dtrho.get().get_buf(id);
+        shamrock::DeviceBuffer<Tvec> &dtrhov  = storage.dtrhov.get().get_buf(id);
+        shamrock::DeviceBuffer<Tscal> &dtrhoe = storage.dtrhoe.get().get_buf(id);
+
+        u32 cell_count = (mpdat.total_elements) * AMRBlock::block_size;
+
+        sham::EventList depends_list;
+        auto acc_dt_rho  = dt_rho.get_read_access(depends_list);
+        auto acc_dt_rhov = dt_rhov.get_read_access(depends_list);
+        auto acc_dt_rhoe = dt_rhoe.get_read_access(depends_list);
+
+        auto rho  = buf_rho.get_write_access(depends_list);
+        auto rhov = buf_rhov.get_write_access(depends_list);
+        auto rhoe = buf_rhoe.get_write_access(depends_list);
+
+        auto e = q.submit(depends_list, [&, dt](sycl::handler &cgh) {
+            shambase::parralel_for(cgh, cell_count, "update old fields", [=](u32 id_a) {
+                const u32 cell_global_id = (u32) id_a;
+
+                rho[id_a] += coef * dt * acc_dt_rho[id_a];
+                rhov[id_a] += coef * dt * acc_dt_rhov[id_a];
+                rhoe[id_a] += coef * dt * acc_dt_rhoe[id_a];
+            });
+        });
+
+        dt_rho.complete_event_state(e);
+        dt_rhov.complete_event_state(e);
+        dt_rhoe.complete_event_state(e);
+
+        buf_rho.complete_event_state(e);
+        buf_rhov.complete_event_state(e);
+        buf_rhoe.complete_event_state(e);
+    });
+
+    if (solver_config.is_dust_on()) {
+
+        storage.merged_patchdata_ghost.get().for_each([&](u64 id, MergedPDat &mpdat) {
+            sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+
+            sham::DeviceBuffer<Tscal> &buf_rho_dust = storage.rho_dust_old.get().get_buf(id);
+            sham::DeviceBuffer<Tvec> &buf_rhov_dust = storage.rhovel_dust_old.get().get_buf(id);
+
+            shamrock::DeviceBuffer<Tscal> &dt_rho_dust = storage.dtrho_dust.get().get_buf(id);
+            shamrock::DeviceBuffer<Tvec> &dt_rhov_dust = storage.dtrhov_dust.get().get_buf(id);
+
+            cell_count = (mpdat.total_elements) * AMRBlock::block_size;
+            u32 ndust  = solver_config.dust_config.ndust;
+
+            sham::EventList depends_list;
+            auto dt_rho_dust  = dt_rho_dust.get_read_access(depends_list);
+            auto dt_rhov_dust = dt_rhov_dust.get_read_access(depends_list);
+
+            auto rho_dust  = buf_rho_dust.get_write_access(depends_list);
+            auto rhov_dust = buf_rhov_dust.get_write_access(depends_list);
+
+            auto e = q.submit(depends_list, [&, dt](sycl::handler &cgh) {
+                shambase::parralel_for(
+                    cgh, ndust * cell_count, "update old fields [dust]", [=](u32 id_a) {
+                        rho_dust[id_a] += coef * dt * dt_rho_dust[id_a];
+                        rhov_dust[id_a] += coef * dt * dt_rhov_dust[id_a];
+                    });
+            });
+
+            dt_rho_dust.complete_event_state(e);
+            dt_rhov_dust.complete_event_state(e);
+            buf_rho_dust.complete_event_state(e);
+            buf_rhov_dust.complete_event_state(e);
+        });
+    }
+}
+
+template<class Tvec, class TgridVec>
+void shammodels::basegodunov::modules::TimeIntegrator<Tvec, TgridVec>::evolve_intermediate(
+    Tscal dt, Tscal coef1, Tscal coef2) {
+
+    StackEntry stack_loc{};
+
+    using namespace shamrock::patch;
+    using namespace shamrock;
+    using namespace shammath;
+
+    shamrock::ComputeField<Tscal> &cfiled_rho_old  = storage.rho_old.get();
+    shamrock::ComputeField<Tvec> &cfield_rhov_old  = storage.rhovel_old.get();
+    shamrock::ComputeField<Tscal> &cfield_rhoe_old = storage.rhoetot_old.get();
+
+    shamrock::ComputeField<Tscal> &cfield_dtrho  = storage.dtrho.get();
+    shamrock::ComputeField<Tvec> &cfield_dtrhov  = storage.dtrhov.get();
+    shamrock::ComputeField<Tscal> &cfield_dtrhoe = storage.dtrhoe.get();
+
+    // load layout info
+    PatchDataLayout &pdl = scheduler().pdl;
+
+    const u32 icell_min = pdl.get_field_idx<TgridVec>("cell_min");
+    const u32 icell_max = pdl.get_field_idx<TgridVec>("cell_max");
+    const u32 irho      = pdl.get_field_idx<Tscal>("rho");
+    const u32 irhoetot  = pdl.get_field_idx<Tscal>("rhoetot");
+    const u32 irhovel   = pdl.get_field_idx<Tvec>("rhovel");
+
+    scheduler().for_each_patchdata_nonempty(
+        [&, dt](const shamrock::patch::Patch p, shamrock::patch::PatchData &pdat) {
+            logger::debug_ln("[AMR Flux]", "intermediate time stage patch", p.id_patch);
+
+            sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+            u32 id               = p.id_patch;
+
+            sham::DeviceBuffer<Tscal> &dt_rho_patch  = cfield_dtrho.get_buf_check(id);
+            sham::DeviceBuffer<Tvec> &dt_rhov_patch  = cfield_dtrhov.get_buf_check(id);
+            sham::DeviceBuffer<Tscal> &dt_rhoe_patch = cfield_dtrhoe.get_buf_check(id);
+
+            sham::DeviceBuffer<Tscal> &rho_old_patch  = cfield_rho_old.get_buf_check(id);
+            sham::DeviceBuffer<Tvec> &rhov_old_patch  = cfield_rhov_old.get_buf_check(id);
+            sham::DeviceBuffer<Tscal> &rhoe_old_patch = cfield_rhoe_old.get_buf_check(id);
+
+            u32 cell_count                      = pdat.get_obj_cnt() * AMRBlock::block_size;
+            sham::DeviceBuffer<Tscal> &buf_rho  = pdat.get_field_buf_ref<Tscal>(irho);
+            sham::DeviceBuffer<Tvec> &buf_rhov  = pdat.get_field_buf_ref<Tvec>(irhovel);
+            sham::DeviceBuffer<Tscal> &buf_rhoe = pdat.get_field_buf_ref<Tscal>(irhoetot);
+
+            sham::EventList depends_list;
+            auto acc_dt_rho_patch  = dt_rho_patch.get_read_access(depends_list);
+            auto acc_dt_rhov_patch = dt_rhov_patch.get_read_access(depends_list);
+            auto acc_dt_rhoe_patch = dt_rhoe_patch.get_read_access(depends_list);
+
+            auto rho  = buf_rho.get_read_access(depends_list);
+            auto rhov = buf_rhov.get_read_access(depends_list);
+            auto rhoe = buf_rhoe.get_read_access(depends_list);
+
+            auto rho_old  = rho_old_patch.get_write_access(depends_list);
+            auto rhov_old = rhov_old_patch.get_write_access(depends_list);
+            auto rhoe_old = rhoe_old_patch.get_write_access(depends_list);
+
+            auto e = q.submit(depends_list, [&, dt](sycl::handler &cgh) {
+                shambase::parralel_for(cgh, cell_count, "accumulate fluxes", [=](u32 id_a) {
+                    const u32 cell_global_id = (u32) id_a;
+
+                    rho_old[id_a] = coef1 * rho[id_a] + coef2 * rho_old[id_a]
+                                    + coef2 * dt * acc_dt_rho_patch[id_a];
+                    rhov_old[id_a] = coef1 * rhov[id_a] + coef2 * rhov_old[id_a]
+                                     + coef2 * dt * acc_dt_rhov_patch[id_a];
+                    rhoe_old[id_a] = coef1 * rhoe[id_a] + coef2 * rhoe_old[id_a]
+                                     + coef2 * dt * acc_dt_rhoe_patch[id_a];
+                });
+            });
+
+            dt_rho_patch.complete_event_state(e);
+            dt_rhov_patch.complete_event_state(e);
+            dt_rhoe_patch.complete_event_state(e);
+
+            rho_old_patch.complete_event_state(e);
+            rhov_old_patch.complete_event_state(e);
+            rhoe_old_patch.complete_event_state(e);
+
+            buf_rho.complete_event_state(e);
+            buf_rhov.complete_event_state(e);
+            buf_rhoe.complete_event_state(e);
+        });
+
+    if (solver_config.is_dust_on()) {
+        shamrock::ComputeField<Tscal> &cfiled_rho_dust_old = storage.rho_dust_old.get();
+        shamrock::ComputeField<Tvec> &cfield_rhov_dust_old = storage.rhovel_dust_old.get();
+
+        shamrock::ComputeField<Tscal> &cfield_dtrho_dust = storage.dtrho_dust.get();
+        shamrock::ComputeField<Tvec> &cfield_dtrhov_dust = storage.dtrhov_dust.get();
+
+        const u32 irho_dust    = pdl.get_field_idx<Tscal>("rho_dust");
+        const u32 irhovel_dust = pdl.get_field_idx<Tvec>("rhovel_dust");
+
+        scheduler().for_each_patchdata_nonempty([&, dt](
+                                                    const shamrock::patch::Patch p,
+                                                    shamrock::patch::PatchData &pdat) {
+            logger::debug_ln("[AMR Flux]", "intermediate time stage patch [dust]", p.id_patch);
+
+            sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+            u32 id               = p.id_patch;
+
+            sham::DeviceBuffer<Tscal> &dt_rho_dust_patch = cfield_dtrho_dust.get_buf_check(id);
+            sham::DeviceBuffer<Tvec> &dt_rhov_dust_patch = cfield_dtrhov_dust.get_buf_check(id);
+
+            sham::DeviceBuffer<Tscal> &rho_dust_old_patch = cfield_rho_dust_old.get_buf_check(id);
+            sham::DeviceBuffer<Tvec> &rhov_dust_old_patch = cfield_rhov_dust_old.get_buf_check(id);
+
+            u32 cell_count                          = pdat.get_obj_cnt() * AMRBlock::block_size;
+            sham::DeviceBuffer<Tscal> &buf_rho_dust = pdat.get_field_buf_ref<Tscal>(irho_dust);
+            sham::DeviceBuffer<Tvec> &buf_rhov_dust = pdat.get_field_buf_ref<Tvec>(irhovel_dust);
+
+            sham::EventList depends_list;
+            auto acc_dt_rho_dust_patch  = dt_rho_dust_patch.get_read_access(depends_list);
+            auto acc_dt_rhov_dust_patch = dt_rhov_dust_patch.get_read_access(depends_list);
+
+            auto rho_dust  = buf_rho_dust.get_read_access(depends_list);
+            auto rhov_dust = buf_rhov_dust.get_read_access(depends_list);
+
+            auto rho_old_dust  = rho_dust_old_patch.get_write_access(depends_list);
+            auto rhov_old_dust = rhov_dust_old_patch.get_write_access(depends_list);
+
+            auto e = q.submit(depends_list, [&, dt](sycl::handler &cgh) {
+                shambase::parralel_for(cgh, ndust * cell_count, "accumulate fluxes", [=](u32 id_a) {
+                    rho_old_dust[id_a] = coef1 * rho_dust[id_a] + coef2 * rho_old_dust[id_a]
+                                         + coef2 * dt * acc_dt_rho_dust_patch[id_a];
+                    rhov_old_dust[id_a] = coef1 * rhov_dust[id_a] + coef2 * rhov_old_dust[id_a]
+                                          + coef2 * dt * acc_dt_rhov_dust_patch[id_a];
+                });
+            });
+
+            dt_rho_dust_patch.complete_event_state(e);
+            dt_rhov_dust_patch.complete_event_state(e);
+
+            rho_old_dust_patch.complete_event_state(e);
+            rhov_old_dust_patch.complete_event_state(e);
+
+            buf_rho_dust.complete_event_state(e);
+            buf_rhov_dust.complete_event_state(e);
+        });
+    }
+}
+
+/*
+
+template<class Tvec, class TgridVec>
 void shammodels::basegodunov::modules::TimeIntegrator<Tvec, TgridVec>::forward_euler(Tscal dt) {
 
     StackEntry stack_loc{};
@@ -130,4 +365,5 @@ void shammodels::basegodunov::modules::TimeIntegrator<Tvec, TgridVec>::forward_e
     }
 }
 
+*/
 template class shammodels::basegodunov::modules::TimeIntegrator<f64_3, i64_3>;

--- a/src/shammodels/ramses/src/pyRamsesModel.cpp
+++ b/src/shammodels/ramses/src/pyRamsesModel.cpp
@@ -153,7 +153,30 @@ namespace shammodels::basegodunov {
                     self.amr_mode.set_refine_density_based(crit_mass);
                 },
                 py::kw_only(),
-                py::arg("crit_mass"));
+                py::arg("crit_mass"))
+            .def(
+                "set_time_integrator_mode_muscl",
+                [](TConfig &self) {
+                    self.time_integrator_config.time_integrator = MUSCL;
+                })
+            .def(
+                "set_time_integrator_mode_rk1",
+                [](TConfig &self) {
+                    self.time_integrator_config.time_integrator = RK1;
+                })
+            .def(
+                "set_time_integrator_mode_rk2",
+                [](TConfig &self) {
+                    self.time_integrator_config.time_integrator = RK2;
+                })
+            .def(
+                "set_time_integrator_mode_rk3",
+                [](TConfig &self) {
+                    self.time_integrator_config.time_integrator = RK3;
+                })
+            .def("set_time_integrator_mode_vl2", [](TConfig &self) {
+                self.time_integrator_config.time_integrator = VL2;
+            });
 
         std::string sod_tube_analysis_name = name_model + "_AnalysisSodTube";
         py::class_<TAnalysisSodTube>(m, sod_tube_analysis_name.c_str())


### PR DESCRIPTION
In this commit we are trying to refactorize the finite volume solvers.
- We fix some typo that we hadn't see before in FaceInterpolate.cpp
- We add new times integrators (semi-discrete methods) and more ...

We rewrite the consToprim() function, but note that Timothée David--Cléris (timothee.david--cleris@ens-lyon.fr) has already propose new one that can be more better than the one in this commit.