### PR TITLE
[CMake] add check on git submodule commit hash

### DIFF
--- a/cmake/AreSubmoduleClones.cmake
+++ b/cmake/AreSubmoduleClones.cmake
@@ -11,7 +11,9 @@
 ### test git submodules
 ###############################################################################
 
-function(_git_submod_is_empty directory)
+option(SHAMROCK_CHECK_SUBMODULES_COMMIT_HASH "Check the commit hash of the git submodules" On)
+
+function(_check_git_submodule_cloned directory expect_hash)
     file(GLOB files RELATIVE "${directory}" "${directory}/*")
     if(NOT files)
 
@@ -21,7 +23,26 @@ function(_git_submod_is_empty directory)
         )
 
     endif()
+
+    if(SHAMROCK_FOLDER_IS_GIT AND SHAMROCK_CHECK_SUBMODULES_COMMIT_HASH)
+        execute_process(
+            COMMAND git log -1 --format=%h
+            WORKING_DIRECTORY "${directory}"
+            OUTPUT_VARIABLE submodule_commit_hash
+            RESULT_VARIABLE GIT_HASH_RETURN_CODE
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+        #message(STATUS "Submodule '${directory}' commit hash: ${submodule_commit_hash}")
+
+        if(NOT "${submodule_commit_hash}" STREQUAL "${expect_hash}")
+            message(FATAL_ERROR
+                "The git submodule '${directory}' is not in sync\n"
+                "current commit hash '${submodule_commit_hash}' is not equal to expected '${expect_hash}'\n"
+                "please do : git pull --recurse-submodules\n"
+            )
+        endif()
+    endif()
+
     #message(STATUS "The subdirectory '${directory}' contains ${files}")
 endfunction()
-
-_git_submod_is_empty(${CMAKE_CURRENT_SOURCE_DIR}/external/pybind11)

--- a/cmake/ShamConfigureFmtlib.cmake
+++ b/cmake/ShamConfigureFmtlib.cmake
@@ -25,6 +25,8 @@ message(STATUS "SHAMROCK_EXTERNAL_FMTLIB : ${SHAMROCK_EXTERNAL_FMTLIB}")
 if(NOT SHAMROCK_EXTERNAL_FMTLIB)
     message(STATUS "Using git submodule fmtlib")
 
+    _check_git_submodule_cloned(${CMAKE_CURRENT_SOURCE_DIR}/external/fmt 8303d140)
+
     option(USE_MANUAL_FMTLIB "Bypass fmt cmake integration" Off)
 
     if(USE_MANUAL_FMTLIB)

--- a/cmake/ShamConfigureMDSpan.cmake
+++ b/cmake/ShamConfigureMDSpan.cmake
@@ -13,4 +13,6 @@ message("   ---- MDSPAN section ----")
 ### MDSPAN
 ###############################################################################
 
+_check_git_submodule_cloned(${CMAKE_CURRENT_SOURCE_DIR}/external/mdspan 414a5dc)
+
 include_directories(external/mdspan/include)

--- a/cmake/ShamConfigureNVTX.cmake
+++ b/cmake/ShamConfigureNVTX.cmake
@@ -17,6 +17,9 @@ option(SHAMROCK_USE_NVTX "use nvtx tooling" On)
 
 if(SHAMROCK_USE_NVTX)
     #include(NVTX/c/nvtxImportedTargets.cmake)
+
+    _check_git_submodule_cloned(${CMAKE_CURRENT_SOURCE_DIR}/external/NVTX b44f81c)
+
     add_subdirectory(external/NVTX/c)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSHAMROCK_USE_NVTX")
 endif()

--- a/cmake/ShamConfigureNlohmannJson.cmake
+++ b/cmake/ShamConfigureNlohmannJson.cmake
@@ -21,5 +21,8 @@ if(SHAMROCK_EXTERNAL_JSON)
     find_package(nlohmann_json 3.11.3 REQUIRED)
 else()
     set(JSON_BuildTests OFF CACHE INTERNAL "")
+
+    _check_git_submodule_cloned(${CMAKE_CURRENT_SOURCE_DIR}/external/nlohmann_json 9cca280a)
+
     add_subdirectory(external/nlohmann_json)
 endif()

--- a/cmake/ShamConfigurePlfNanotimer.cmake
+++ b/cmake/ShamConfigurePlfNanotimer.cmake
@@ -13,4 +13,6 @@ message("   ---- plf_nanotimer section ----")
 ### plf_nanotimer
 ###############################################################################
 
+_check_git_submodule_cloned(${CMAKE_CURRENT_SOURCE_DIR}/external/plf_nanotimer 55e0fcb)
+
 include_directories(external/plf_nanotimer)

--- a/cmake/ShamConfigurePybind11.cmake
+++ b/cmake/ShamConfigurePybind11.cmake
@@ -65,5 +65,8 @@ if(SHAMROCK_EXTERNAL_PYBIND11)
     find_package(pybind11 REQUIRED)
 else()
     message(STATUS "Using git submodule pybind11")
+
+    _check_git_submodule_cloned(${CMAKE_CURRENT_SOURCE_DIR}/external/pybind11 a2e59f0e)
+
     add_subdirectory(external/pybind11)
 endif()

--- a/cmake/ShamVersioning.cmake
+++ b/cmake/ShamVersioning.cmake
@@ -24,7 +24,9 @@ execute_process(
 # With a release tarball, "git status" will fail (return non zero)
 if(GIT_STATUS)
     set(SHAMROCK_VERSION_SUFFIX "")
+    set(SHAMROCK_FOLDER_IS_GIT 0)
 else()
+    set(SHAMROCK_FOLDER_IS_GIT 1)
     # Get the latest abbreviated commit hash of the working branch
     execute_process(
         COMMAND git log -1 --format=%h


### PR DESCRIPTION
# Checking that git submodule are on cloned & on correct commit

Most peoples use `git pull` or `git checkout` to update their local repo. However, this does not update/clone submodules. As a result every time I update a submodule this results in breakage on local repos because everyone forget about this.

So this PR add a check to verify that each submodule is cloned and at the correct commit and prompt the correct command to fix it if not.