### PR TITLE
[Sys] add micro GPU benchmark to post startup benchmarks

### DIFF
--- a/.github/workflows/shamrock-acpp-clang-asan.yml
+++ b/.github/workflows/shamrock-acpp-clang-asan.yml
@@ -27,7 +27,7 @@ jobs:
 
     #if: false
 
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       #### Checkout part ####
       # Checkout merge commit if PR otherwise default

--- a/.github/workflows/shamrock-acpp-clang-asan.yml
+++ b/.github/workflows/shamrock-acpp-clang-asan.yml
@@ -91,19 +91,19 @@ jobs:
       - name: run Shamrock Unittests world_size = 1
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0
 
       - name: run Shamrock Unittests world_size = 2
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 mpirun --bind-to socket:overload-allowed --oversubscribe --allow-run-as-root -n 2 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 mpirun --bind-to socket:overload-allowed --oversubscribe --allow-run-as-root -n 2 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0
 
       - name: run Shamrock Unittests world_size = 3
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 mpirun --bind-to socket:overload-allowed --oversubscribe --allow-run-as-root -n 3 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 mpirun --bind-to socket:overload-allowed --oversubscribe --allow-run-as-root -n 3 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0
 
       - name: run Shamrock Unittests world_size = 4
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 mpirun --bind-to socket:overload-allowed --oversubscribe --allow-run-as-root -n 4 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 mpirun --bind-to socket:overload-allowed --oversubscribe --allow-run-as-root -n 4 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0

--- a/.github/workflows/shamrock-acpp-clang-coverage.yml
+++ b/.github/workflows/shamrock-acpp-clang-coverage.yml
@@ -86,31 +86,31 @@ jobs:
       - name: run Shamrock Unittests world_size = 1
         run: |
           cd acpp_omp_debug
-          LLVM_PROFILE_FILE="utests_0_0.profraw" ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+          LLVM_PROFILE_FILE="utests_0_0.profraw" ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0
 
       - name: run Shamrock Unittests world_size = 2
         run: |
           cd acpp_omp_debug
           mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe \
-            -n 1 -x LLVM_PROFILE_FILE=utests_2_0.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
-            -n 1 -x LLVM_PROFILE_FILE=utests_2_1.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+            -n 1 -x LLVM_PROFILE_FILE=utests_2_0.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 : \
+            -n 1 -x LLVM_PROFILE_FILE=utests_2_1.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0
 
       - name: run Shamrock Unittests world_size = 3
         run: |
           cd acpp_omp_debug
           mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe \
-            -n 1 -x LLVM_PROFILE_FILE=utests_3_0.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
-            -n 1 -x LLVM_PROFILE_FILE=utests_3_1.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
-            -n 1 -x LLVM_PROFILE_FILE=utests_3_2.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+            -n 1 -x LLVM_PROFILE_FILE=utests_3_0.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 : \
+            -n 1 -x LLVM_PROFILE_FILE=utests_3_1.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 : \
+            -n 1 -x LLVM_PROFILE_FILE=utests_3_2.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0
 
       - name: run Shamrock Unittests world_size = 4
         run: |
           cd acpp_omp_debug
           mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe \
-            -n 1 -x LLVM_PROFILE_FILE=utests_4_0.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
-            -n 1 -x LLVM_PROFILE_FILE=utests_4_1.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
-            -n 1 -x LLVM_PROFILE_FILE=utests_4_2.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
-            -n 1 -x LLVM_PROFILE_FILE=utests_4_3.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+            -n 1 -x LLVM_PROFILE_FILE=utests_4_0.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 : \
+            -n 1 -x LLVM_PROFILE_FILE=utests_4_1.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 : \
+            -n 1 -x LLVM_PROFILE_FILE=utests_4_2.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 : \
+            -n 1 -x LLVM_PROFILE_FILE=utests_4_3.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0
 
       - name: merge coverage reports
         run: |

--- a/.github/workflows/shamrock-acpp-clang-ubsan.yml
+++ b/.github/workflows/shamrock-acpp-clang-ubsan.yml
@@ -26,7 +26,7 @@ jobs:
             container: ghcr.io/shamrock-code/shamrock-ci:ubuntu20
     #if: false
 
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       #### Checkout part ####
       # Checkout merge commit if PR otherwise default

--- a/.github/workflows/shamrock-acpp-clang-ubsan.yml
+++ b/.github/workflows/shamrock-acpp-clang-ubsan.yml
@@ -91,19 +91,19 @@ jobs:
       - name: run Shamrock Unittests world_size = 1
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" ./shamrock_test --smi-full  --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" ./shamrock_test --smi-full  --sycl-cfg 0:0 --unittest --loglevel 0
 
       - name: run Shamrock Unittests world_size = 2
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 2 ./shamrock_test --smi-full  --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 2 ./shamrock_test --smi-full  --sycl-cfg 0:0 --unittest --loglevel 0
 
       - name: run Shamrock Unittests world_size = 3
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 3 ./shamrock_test --smi-full  --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 3 ./shamrock_test --smi-full  --sycl-cfg 0:0 --unittest --loglevel 0
 
       - name: run Shamrock Unittests world_size = 4
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 4 ./shamrock_test --smi-full  --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 4 ./shamrock_test --smi-full  --sycl-cfg 0:0 --unittest --loglevel 0

--- a/env/machine/docker/intel_oneapi/env_built_intel-llvm.sh
+++ b/env/machine/docker/intel_oneapi/env_built_intel-llvm.sh
@@ -19,6 +19,7 @@ function shamconfigure {
         -DCMAKE_CXX_COMPILER=$(which icpx) \
         -DCMAKE_CXX_FLAGS="-fsycl -fp-model=precise" \
         -DCMAKE_BUILD_TYPE="${SHAMROCK_BUILD_TYPE}" \
+        -DCXX_FLAG_ARCH_NATIVE=off \
         -DBUILD_TEST=Yes \
         "${CMAKE_OPT[@]}"
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -142,16 +142,6 @@ int main(int argc, char *argv[]) {
         shamcomm::validate_comm(sptr);
     }
 
-    if (opts::has_option("--benchmark-mpi")) {
-        if (shamsys::instance::is_initialized()) {
-            shamsys::run_micro_benchmark();
-        } else {
-            logger::warn_ln(
-                "Init",
-                "--benchmark-mpi can't be run without a sycl configuration (--sycl-cfg x:x)");
-        }
-    }
-
     if (shamcomm::world_rank() == 0) {
         logger::print_faint_row();
         logger::raw_ln("log status : ");
@@ -171,6 +161,16 @@ int main(int argc, char *argv[]) {
         shamsys::shamrock_smi();
         if (shamsys::instance::is_initialized()) {
             shamsys::instance::print_queue_map();
+        }
+    }
+
+    if (opts::has_option("--benchmark-mpi")) {
+        if (shamsys::instance::is_initialized()) {
+            shamsys::run_micro_benchmark();
+        } else {
+            logger::warn_ln(
+                "Init",
+                "--benchmark-mpi can't be run without a sycl configuration (--sycl-cfg x:x)");
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,12 +167,12 @@ int main(int argc, char *argv[]) {
             logger::print_faint_row();
         }
         shamsys::shamrock_smi(is_smi_full);
-        if (shamcomm::world_rank() == 0) {
-            logger::print_faint_row();
-        }
     }
 
     if (opts::has_option("--benchmark-mpi")) {
+        if (shamcomm::world_rank() == 0) {
+            logger::print_faint_row();
+        }
         if (shamsys::instance::is_initialized()) {
             shamsys::run_micro_benchmark();
         } else {

--- a/src/main_test.cpp
+++ b/src/main_test.cpp
@@ -129,16 +129,6 @@ int main(int argc, char *argv[]) {
         shamcomm::validate_comm(sptr);
     }
 
-    if (opts::has_option("--benchmark-mpi")) {
-        if (shamsys::instance::is_initialized()) {
-            shamsys::run_micro_benchmark();
-        } else {
-            logger::warn_ln(
-                "Init",
-                "--benchmark-mpi can't be run without a sycl configuration (--sycl-cfg x:x)");
-        }
-    }
-
     if (shamcomm::world_rank() == 0) {
         logger::print_faint_row();
         logger::raw_ln("log status : ");
@@ -150,32 +140,24 @@ int main(int argc, char *argv[]) {
         logger::print_active_level();
     }
 
-    if (opts::has_option("--sycl-ls")) {
-
-        if (shamcomm::world_rank() == 0) {
-            logger::print_faint_row();
-        }
-        shamsys::instance::print_device_list();
-    }
-
-    if (opts::has_option("--sycl-ls-map")) {
-
-        if (shamcomm::world_rank() == 0) {
-            logger::print_faint_row();
-        }
-        shamsys::instance::print_device_list();
-        if (shamsys::instance::is_initialized()) {
-            shamsys::instance::print_queue_map();
-        }
-    }
-
-    if (opts::has_option("--smi")) {
+    if (opts::has_option("--sycl-ls") || opts::has_option("--sycl-ls-map")
+        || opts::has_option("--smi")) {
         if (shamcomm::world_rank() == 0) {
             logger::print_faint_row();
         }
         shamsys::shamrock_smi();
         if (shamsys::instance::is_initialized()) {
             shamsys::instance::print_queue_map();
+        }
+    }
+
+    if (opts::has_option("--benchmark-mpi")) {
+        if (shamsys::instance::is_initialized()) {
+            shamsys::run_micro_benchmark();
+        } else {
+            logger::warn_ln(
+                "Init",
+                "--benchmark-mpi can't be run without a sycl configuration (--sycl-cfg x:x)");
         }
     }
 

--- a/src/main_test.cpp
+++ b/src/main_test.cpp
@@ -155,13 +155,12 @@ int main(int argc, char *argv[]) {
             logger::print_faint_row();
         }
         shamsys::shamrock_smi(is_smi_full);
-        if (shamcomm::world_rank() == 0) {
-            logger::print_faint_row();
-
-        }
     }
 
     if (opts::has_option("--benchmark-mpi")) {
+        if (shamcomm::world_rank() == 0) {
+            logger::print_faint_row();
+        }
         if (shamsys::instance::is_initialized()) {
             shamsys::run_micro_benchmark();
         } else {
@@ -170,7 +169,7 @@ int main(int argc, char *argv[]) {
                 "--benchmark-mpi can't be run without a sycl configuration (--sycl-cfg x:x)");
         }
     }
-  
+
     if (shamsys::instance::is_initialized()) {
         if (shamcomm::world_rank() == 0) {
             logger::print_faint_row();

--- a/src/shambackends/include/shambackends/benchmarks/add_mul.hpp
+++ b/src/shambackends/include/shambackends/benchmarks/add_mul.hpp
@@ -1,0 +1,101 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2024 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file add_mul.hpp
+ * @author Timothée David--Cléris (timothee.david--cleris@ens-lyon.fr)
+ * @brief
+ */
+
+#include "shambase/assert.hpp"
+#include "shambase/time.hpp"
+#include "shambackends/DeviceBuffer.hpp"
+#include "shambackends/DeviceScheduler.hpp"
+#include "shambackends/math.hpp"
+
+namespace sham::benchmarks {
+
+    template<class T>
+    inline void add_mul(
+        u32 i, int nrotation, T cs, T sn, T *__restrict in1, T *__restrict in2, T *__restrict out) {
+
+        T x = in1[i];
+        T y = in2[i];
+        for (int i = 0; i < nrotation; i++) {
+            T xx = cs * x - sn * y;
+            T yy = cs * y + sn * x;
+            x    = xx;
+            y    = yy;
+        }
+        out[i] = dot(x, y);
+    }
+
+    struct add_mul_result {
+        std::string func_name;
+        f64 milliseconds;
+        f64 flops;
+    };
+
+    // From https://www.bealto.com/gpu-benchmarks_flops.html
+    template<class T>
+    inline add_mul_result add_mul_bench(
+        DeviceScheduler_ptr sched,
+        int N,
+        T init_x,
+        T init_y,
+        T cs,
+        T sn,
+        int nrotation,
+        int float_count) {
+
+        sham::DeviceQueue &q = sched->get_queue();
+
+        sham::DeviceBuffer<T> x   = {size_t(N), sched};
+        sham::DeviceBuffer<T> y   = {size_t(N), sched};
+        sham::DeviceBuffer<T> out = {size_t(N), sched};
+
+        x.fill(init_x);
+        y.fill(init_y);
+
+        sham::EventList depends_list;
+
+        auto x_ptr   = x.get_write_access(depends_list);
+        auto y_ptr   = y.get_write_access(depends_list);
+        auto out_ptr = out.get_write_access(depends_list);
+
+        depends_list.wait();
+
+        sham::EventList empty_list{};
+
+        shambase::Timer t;
+        t.start();
+        auto e = q.submit(empty_list, [&](sycl::handler &cgh) {
+            cgh.parallel_for(sycl::range<1>{size_t(N)}, [=](sycl::item<1> item) {
+                add_mul(item.get_linear_id(), nrotation, cs, sn, x_ptr, y_ptr, out_ptr);
+            });
+        });
+        e.wait();
+        t.end();
+
+        x.complete_event_state(sycl::event{});
+        y.complete_event_state(sycl::event{});
+        out.complete_event_state(sycl::event{});
+
+        double milliseconds = t.elasped_sec() * 1e3;
+
+        int flop_per_thread = nrotation * 6;
+        double flop_count   = double(N) * flop_per_thread;
+        double flops        = flop_count / (milliseconds / 1e3);
+
+        return {SourceLocation{}.loc.function_name(), milliseconds, flops};
+    }
+
+} // namespace sham::benchmarks

--- a/src/shambackends/include/shambackends/benchmarks/add_mul.hpp
+++ b/src/shambackends/include/shambackends/benchmarks/add_mul.hpp
@@ -91,7 +91,7 @@ namespace sham::benchmarks {
 
         double milliseconds = t.elasped_sec() * 1e3;
 
-        int flop_per_thread = nrotation * 6;
+        int flop_per_thread = nrotation * 6 * float_count;
         double flop_count   = double(N) * flop_per_thread;
         double flops        = flop_count / (milliseconds / 1e3);
 

--- a/src/shambackends/include/shambackends/benchmarks/add_mul.hpp
+++ b/src/shambackends/include/shambackends/benchmarks/add_mul.hpp
@@ -35,7 +35,7 @@ namespace sham::benchmarks {
             x    = xx;
             y    = yy;
         }
-        out[i] = dot(x, y);
+        out[i] = sham::dot(x, y);
     }
 
     struct add_mul_result {

--- a/src/shambackends/include/shambackends/benchmarks/add_mul.hpp
+++ b/src/shambackends/include/shambackends/benchmarks/add_mul.hpp
@@ -23,6 +23,21 @@
 
 namespace sham::benchmarks {
 
+    /**
+     * @brief kernel for the add_mul benchmark
+     *
+     * Saturate the fpu to hide away memory latency
+     * Since we now that there are 6 flops per iteration
+     * this kernel can be used to compute the flops
+     *
+     * @param i the index of the element to rotate
+     * @param nrotation the number of rotations to apply
+     * @param cs the cosine of the angle of rotation
+     * @param sn the sine of the angle of rotation
+     * @param in1 the first input vector
+     * @param in2 the second input vector
+     * @param out the output vector
+     */
     template<class T>
     inline void add_mul(
         u32 i, int nrotation, T cs, T sn, T *__restrict in1, T *__restrict in2, T *__restrict out) {
@@ -38,13 +53,28 @@ namespace sham::benchmarks {
         out[i] = sham::dot(x, y);
     }
 
+    /// Structure containing the results of an add_mul benchmark
     struct add_mul_result {
-        std::string func_name;
-        f64 milliseconds;
-        f64 flops;
+        std::string func_name; ///< Name of the function
+        f64 milliseconds;      ///< Computation time in milliseconds
+        f64 flops;             ///< Flops per second
     };
 
-    // From https://www.bealto.com/gpu-benchmarks_flops.html
+    /**
+     * @brief Run the add_mul benchmark
+     *
+     * From https://www.bealto.com/gpu-benchmarks_flops.html
+     *
+     * @param sched the scheduler for the device
+     * @param N the number of elements to process
+     * @param init_x the initial value of the first input vector
+     * @param init_y the initial value of the second input vector
+     * @param cs the cosine of the rotation angle
+     * @param sn the sine of the rotation angle
+     * @param nrotation the number of rotations to apply
+     * @param float_count the number of floats per element
+     * @return the result of the benchmark as an add_mul_result
+     */
     template<class T>
     inline add_mul_result add_mul_bench(
         DeviceScheduler_ptr sched,

--- a/src/shambackends/include/shambackends/benchmarks/saxpy.hpp
+++ b/src/shambackends/include/shambackends/benchmarks/saxpy.hpp
@@ -1,0 +1,106 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2024 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file saxpy.hpp
+ * @author Timothée David--Cléris (timothee.david--cleris@ens-lyon.fr)
+ * @brief
+ */
+
+#include "shambase/assert.hpp"
+#include "shambase/time.hpp"
+#include "shambackends/DeviceBuffer.hpp"
+#include "shambackends/DeviceScheduler.hpp"
+#include "shambackends/math.hpp"
+
+namespace sham::benchmarks {
+
+    template<class T>
+    inline void saxpy(u32 i, int n, T a, T *__restrict x, T *__restrict y) {
+        if (i < n)
+            y[i] = a * x[i] + y[i];
+    }
+
+    struct saxpy_result {
+        std::string func_name;
+        f64 milliseconds;
+        f64 bandwidth;
+    };
+
+    // From https://developer.nvidia.com/blog/how-implement-performance-metrics-cuda-cc/
+    template<class T>
+    inline saxpy_result
+    saxpy_bench(DeviceScheduler_ptr sched, int N, T init_x, T init_y, T a, int load_size) {
+
+        sham::DeviceQueue &q = sched->get_queue();
+
+        sham::DeviceBuffer<T> x = {size_t(N), sched};
+        sham::DeviceBuffer<T> y = {size_t(N), sched};
+
+        x.fill(init_x);
+        y.fill(init_y);
+
+        sham::EventList depends_list;
+
+        auto x_ptr = x.get_write_access(depends_list);
+        auto y_ptr = y.get_write_access(depends_list);
+
+        depends_list.wait();
+
+        sham::EventList empty_list{};
+
+        shambase::Timer t;
+        t.start();
+        auto e = q.submit(empty_list, [&](sycl::handler &cgh) {
+            cgh.parallel_for(sycl::range<1>{size_t(N)}, [=](sycl::item<1> item) {
+                // printf("%d\n", item.get_linear_id());
+                saxpy(item.get_linear_id(), N, a, x_ptr, y_ptr);
+            });
+        });
+        e.wait();
+        t.end();
+
+        x.complete_event_state(sycl::event{});
+        y.complete_event_state(sycl::event{});
+
+        double milliseconds = t.elasped_sec() * 1e3;
+
+        auto y_res = y.copy_to_stdvec();
+
+        T expected = a * init_x + init_y;
+
+        T maxError = {};
+        for (int i = 0; i < N; i++) {
+            T delt = y_res[i] - expected;
+
+            if constexpr (std::is_same_v<T, sycl::marray<float, 3>>) {
+                maxError[0] = sham::max(maxError[0], sham::abs(delt[0]));
+                maxError[1] = sham::max(maxError[1], sham::abs(delt[1]));
+                maxError[2] = sham::max(maxError[2], sham::abs(delt[2]));
+            } else if constexpr (std::is_same_v<T, sycl::marray<float, 4>>) {
+                maxError[0] = sham::max(maxError[0], sham::abs(delt[0]));
+                maxError[1] = sham::max(maxError[1], sham::abs(delt[1]));
+                maxError[2] = sham::max(maxError[2], sham::abs(delt[2]));
+                maxError[3] = sham::max(maxError[3], sham::abs(delt[3]));
+            } else {
+                maxError = sham::max(maxError, sham::abs(delt));
+            }
+        }
+
+        SHAM_ASSERT(sham::equals(maxError, T{}));
+
+        return {
+            SourceLocation{}.loc.function_name(),
+            milliseconds,
+            double(N) * load_size * 3 / milliseconds / 1e6};
+    }
+
+} // namespace sham::benchmarks

--- a/src/shambackends/include/shambackends/benchmarks/saxpy.hpp
+++ b/src/shambackends/include/shambackends/benchmarks/saxpy.hpp
@@ -23,19 +23,47 @@
 
 namespace sham::benchmarks {
 
+    /** @brief saxpy function for benchmarking.
+     *
+     * @param[in] i        Index to start the computation.
+     * @param[in] n        Number of elements to process.
+     * @param[in] a        Coefficient in the saxpy operation.
+     * @param[in] x        Input array.
+     * @param[inout] y     Output array.
+     */
     template<class T>
     inline void saxpy(u32 i, int n, T a, T *__restrict x, T *__restrict y) {
         if (i < n)
             y[i] = a * x[i] + y[i];
     }
 
+    /// Structure containing the results of a saxpy benchmark.
     struct saxpy_result {
+        /// Name of the function.
         std::string func_name;
+        /// Computation time in milliseconds.
         f64 milliseconds;
+        /// Bandwidth in gibibytes per second.
         f64 bandwidth;
     };
 
-    // From https://developer.nvidia.com/blog/how-implement-performance-metrics-cuda-cc/
+    /**
+     * @brief saxpy function for benchmarking.
+     *
+     * @param[in] sched         Device scheduler.
+     * @param[in] N             Number of elements to process.
+     * @param[in] init_x        Initial value for the input array.
+     * @param[in] init_y        Initial value for the output array.
+     * @param[in] a             Coefficient in the saxpy operation.
+     * @param[in] load_size     Number of bytes processed per element.
+     * @param[in] check_correctness Check if the result is correct.
+     *
+     *From https://developer.nvidia.com/blog/how-implement-performance-metrics-cuda-cc/
+     *
+     * @return saxpy_result containing the computation time in milliseconds,
+     *         the bandwidth in gibibytes per second, and the name of the
+     *         function.
+     */
     template<class T>
     inline saxpy_result saxpy_bench(
         DeviceScheduler_ptr sched,

--- a/src/shamsys/src/MicroBenchmark.cpp
+++ b/src/shamsys/src/MicroBenchmark.cpp
@@ -41,8 +41,6 @@ void shamsys::run_micro_benchmark() {
     StackEntry stack_loc{};
 
     if (shamcomm::world_rank() == 0) {
-        logger::raw_ln("");
-        logger::print_faint_row();
         logger::raw_ln("Running micro benchamrks :");
     }
 

--- a/src/shamsys/src/MicroBenchmark.cpp
+++ b/src/shamsys/src/MicroBenchmark.cpp
@@ -189,7 +189,7 @@ void shamsys::microbench::saxpy() {
 
         for (; N <= (1 << 30) && N <= max_size; N *= 2) {
             auto result = bench_step(N);
-            std::cout << N << " " << result.milliseconds << std::endl;
+            std::cout << N << " " << result.milliseconds << " " << result.bandwidth << std::endl;
             if (result.milliseconds > 5) {
                 return result;
             }

--- a/src/shamsys/src/MicroBenchmark.cpp
+++ b/src/shamsys/src/MicroBenchmark.cpp
@@ -42,6 +42,7 @@ void shamsys::run_micro_benchmark() {
 
     if (shamcomm::world_rank() == 0) {
         logger::raw_ln("");
+        logger::print_faint_row();
         logger::raw_ln("Running micro benchamrks :");
     }
 

--- a/src/shamsys/src/MicroBenchmark.cpp
+++ b/src/shamsys/src/MicroBenchmark.cpp
@@ -179,7 +179,8 @@ void shamsys::microbench::saxpy() {
             {1.0f, 1.0f, 1.0f, 1.0f},
             {2.0f, 2.0f, 2.0f, 2.0f},
             {2.0f, 2.0f, 2.0f, 2.0f},
-            vec4_size);
+            vec4_size,
+            N < (1 << 20));
     };
 
     auto benchmark = [&]() {
@@ -191,8 +192,9 @@ void shamsys::microbench::saxpy() {
 
         for (; N <= (1 << 30) && N <= max_size; N *= 2) {
             auto result_new = bench_step(N);
-            std::cout << N << " " << result_new.milliseconds << " " << result_new.bandwidth
-                      << std::endl;
+
+            // std::cout << N << " " << result_new.milliseconds << " " << result_new.bandwidth
+            //           << std::endl;
 
             // We are kinda forced to do that as on some machine the current condition will stop
             // basically on the worst performing case. Using instead the best one make the result

--- a/src/shamsys/src/MicroBenchmark.cpp
+++ b/src/shamsys/src/MicroBenchmark.cpp
@@ -30,10 +30,19 @@
 #include <stdexcept>
 
 namespace shamsys::microbench {
+    /// MPI point-to-point bandwidth benchmark
     void p2p_bandwith(u32 wr_sender, u32 wr_receiv);
+
+    /// MPI point-to-point latency benchmark
     void p2p_latency(u32 wr1, u32 wr2);
+
+    /// SAXPY benchmark, to get the maximum bandwidth
     void saxpy();
+
+    /// ADD_MUL benchmark to get the maximum floating point performance
     void add_mul_rotation_f32();
+
+    /// same as add_mul_rotation_f32 but for double
     void add_mul_rotation_f64();
 } // namespace shamsys::microbench
 

--- a/src/shamsys/src/MicroBenchmark.cpp
+++ b/src/shamsys/src/MicroBenchmark.cpp
@@ -41,6 +41,7 @@ void shamsys::run_micro_benchmark() {
     StackEntry stack_loc{};
 
     if (shamcomm::world_rank() == 0) {
+        logger::raw_ln("");
         logger::raw_ln("Running micro benchamrks :");
     }
 
@@ -104,8 +105,8 @@ void shamsys::microbench::p2p_bandwith(u32 wr_sender, u32 wr_receiv) {
 
     if (shamcomm::world_rank() == 0) {
         logger::raw_ln(shambase::format(
-            " - p2p bandwith : {:0.2f} GB.s^-1 (ranks : {} -> {}) (loops : {})",
-            (f64(length * loops) / t) * 1e-9,
+            " - p2p bandwith    : {:.4e} B.s^-1 (ranks : {} -> {}) (loops : {})",
+            (f64(length * loops) / t),
             wr_sender,
             wr_receiv,
             loops));
@@ -159,7 +160,7 @@ void shamsys::microbench::p2p_latency(u32 wr1, u32 wr2) {
 
     if (shamcomm::world_rank() == 0) {
         logger::raw_ln(shambase::format(
-            " - p2p latency  : {:.4e} s (ranks : {} <-> {}) (loops : {})",
+            " - p2p latency     : {:.4e} s (ranks : {} <-> {}) (loops : {})",
             t / f64(loops),
             wr1,
             wr2,
@@ -180,14 +181,16 @@ void shamsys::microbench::saxpy() {
         {2.0f, 2.0f, 2.0f, 2.0f},
         vec4_size);
 
-    f64 min_bw = shamalgs::collective::allreduce_min(result.bandwidth);
-    f64 max_bw = shamalgs::collective::allreduce_max(result.bandwidth);
-    f64 sum_bw = shamalgs::collective::allreduce_sum(result.bandwidth);
+    f64 bw = result.bandwidth * 1e9;
+
+    f64 min_bw = shamalgs::collective::allreduce_min(bw);
+    f64 max_bw = shamalgs::collective::allreduce_max(bw);
+    f64 sum_bw = shamalgs::collective::allreduce_sum(bw);
     f64 avg_bw = sum_bw / (f64) shamcomm::world_size();
 
     if (shamcomm::world_rank() == 0) {
         logger::raw_ln(shambase::format(
-            " - saxpy (f32_4) : {:.2f} GB.s^-1 (min = {:.2f}, max = {:.2f}, avg = {:.2f}) ({:.2f} "
+            " - saxpy (f32_4)   : {:.3e} B.s^-1 (min = {:.1e}, max = {:.1e}, avg = {:.1e}) ({:.1e} "
             "ms)",
             sum_bw,
             min_bw,
@@ -212,16 +215,14 @@ void shamsys::microbench::add_mul_rotation_f32() {
         10000,
         4);
 
-    f64 gflops = result.flops / 1e9;
-
-    f64 min_flop = shamalgs::collective::allreduce_min(gflops);
-    f64 max_flop = shamalgs::collective::allreduce_max(gflops);
-    f64 sum_flop = shamalgs::collective::allreduce_sum(gflops);
+    f64 min_flop = shamalgs::collective::allreduce_min(result.flops);
+    f64 max_flop = shamalgs::collective::allreduce_max(result.flops);
+    f64 sum_flop = shamalgs::collective::allreduce_sum(result.flops);
     f64 avg_flop = sum_flop / (f64) shamcomm::world_size();
 
     if (shamcomm::world_rank() == 0) {
         logger::raw_ln(shambase::format(
-            " - add_mul (f32_4) : {:.2f} Gflops (min = {:.2f}, max = {:.2f}, avg = {:.2f}) ({:.2f} "
+            " - add_mul (f32_4) : {:.3e} flops (min = {:.1e}, max = {:.1e}, avg = {:.1e}) ({:.1e} "
             "ms)",
             sum_flop,
             min_flop,
@@ -246,16 +247,14 @@ void shamsys::microbench::add_mul_rotation_f64() {
         10000,
         4);
 
-    f64 gflops = result.flops / 1e9;
-
-    f64 min_flop = shamalgs::collective::allreduce_min(gflops);
-    f64 max_flop = shamalgs::collective::allreduce_max(gflops);
-    f64 sum_flop = shamalgs::collective::allreduce_sum(gflops);
+    f64 min_flop = shamalgs::collective::allreduce_min(result.flops);
+    f64 max_flop = shamalgs::collective::allreduce_max(result.flops);
+    f64 sum_flop = shamalgs::collective::allreduce_sum(result.flops);
     f64 avg_flop = sum_flop / (f64) shamcomm::world_size();
 
     if (shamcomm::world_rank() == 0) {
         logger::raw_ln(shambase::format(
-            " - add_mul (f64_4) : {:.2f} Gflops (min = {:.2f}, max = {:.2f}, avg = {:.2f}) ({:.2f} "
+            " - add_mul (f64_4) : {:.3e} flops (min = {:.1e}, max = {:.1e}, avg = {:.1e}) ({:.1e} "
             "ms)",
             sum_flop,
             min_flop,


### PR DESCRIPTION
# Expand shamrock tiny benchmarks to GPU ones

When using `--benchmark-mpi` (yes it should be renamed), new GPU benchmarks were added. Namely, sappy (bandwidth) and multiply additions rotations to compute flops. 

On a RTXA5000 the benchmarks report:
```
Running micro benchamrks : 
 - p2p bandwith    : 9.1475e+08 B.s^-1 (ranks : 0 -> 0) (loops : 111) 
 - saxpy (f32_4)   : 7.108e+11 B.s^-1 (min = 7.1e+11, max = 7.1e+11, avg = 7.1e+11) (9.1e+00 ms) 
 - add_mul (f32_4) : 1.482e+13 flops (min = 1.5e+13, max = 1.5e+13, avg = 1.5e+13) (1.7e+01 ms) 
 - add_mul (f64_4) : 2.042e+11 flops (min = 2.0e+11, max = 2.0e+11, avg = 2.0e+11) (1.2e+03 ms) 
```

Where the capability of a RTXA5000 are:
```
 - saxpy (f32_4)   : 7.68e+11 B.s^-1
 - add_mul (f32_4) : 2.777e+13 flops
 - add_mul (f64_4) : 4.33e+11 flops
```
So bandwidth is close but flops are a factor 2 below (which is kind of expected as we don't use the other type of computing units, e.g. tensor, ray, texture, ...)