### PR TITLE
[CMake] Allow disabling SYCL header inclusion in cmake

### DIFF
--- a/cmake/SYCLAdaptACppDirect.cmake
+++ b/cmake/SYCLAdaptACppDirect.cmake
@@ -19,24 +19,24 @@ check_cxx_source_compiles("
     SYCL_COMPILER_IS_ACPP)
 
 if(NOT SYCL_COMPILER_IS_ACPP)
-  message(FATAL_ERROR
-    "ACpp does not define any of the following Macro here "
-    "__ACPP__,__OPENSYCL__,__HIPSYCL__  "
-    "this doesn't seems like the acpp compiler "
-    "please select the acpp compiler using : "
-    "-DCMAKE_CXX_COMPILER=<path_to_compiler>")
+    message(FATAL_ERROR
+        "ACpp does not define any of the following Macro here "
+        "__ACPP__,__OPENSYCL__,__HIPSYCL__  "
+        "this doesn't seems like the acpp compiler "
+        "please select the acpp compiler using : "
+        "-DCMAKE_CXX_COMPILER=<path_to_compiler>")
 endif()
 
 variable_watch(__CMAKE_CXX_COMPILER_OUTPUT)
 
 if(NOT DEFINED HAS_SYCL2020_HEADER)
-  try_compile(
-      HAS_SYCL2020_HEADER ${CMAKE_BINARY_DIR}/compile_tests
-      ${CMAKE_SOURCE_DIR}/cmake/feature_test/sycl2020_sycl_header.cpp OUTPUT_VARIABLE TRY_COMPILE_OUTPUT)
+    try_compile(
+        HAS_SYCL2020_HEADER ${CMAKE_BINARY_DIR}/compile_tests
+        ${CMAKE_SOURCE_DIR}/cmake/feature_test/sycl2020_sycl_header.cpp OUTPUT_VARIABLE TRY_COMPILE_OUTPUT)
 endif()
 
 if(NOT HAS_SYCL2020_HEADER)
-  message(FATAL_ERROR "Acpp can not compile a simple exemple including <sycl/sycl.hpp> \n Logs: ${TRY_COMPILE_OUTPUT}" )
+    message(FATAL_ERROR "Acpp can not compile a simple exemple including <sycl/sycl.hpp> \n Logs: ${TRY_COMPILE_OUTPUT}")
 endif()
 
 
@@ -51,40 +51,40 @@ check_cxx_source_compiles(
 
 
 check_cxx_source_compiles(
-      "
-      #include <sycl/sycl.hpp>
-      int main(void){
+    "
+    #include <sycl/sycl.hpp>
+    int main(void){
         auto a = sycl::clz(std::uint64_t(10));
-      }
-      "
-      SYCL2020_FEATURE_CLZ)
+    }
+    "
+    SYCL2020_FEATURE_CLZ)
 
 if(NOT DEFINED SYCL2020_FEATURE_REDUCTION)
-  message(STATUS "Performing Test SYCL2020_FEATURE_REDUCTION")
-  try_compile(
-    SYCL_feature_reduc2020 ${CMAKE_BINARY_DIR}/compile_tests
-    ${CMAKE_SOURCE_DIR}/cmake/feature_test/sycl2020_reduc.cpp)
-  if(SYCL_feature_reduc2020)
-    set(SYCL2020_FEATURE_REDUCTION ON CACHE INTERNAL "" FORCE)
-    message(STATUS "Performing Test SYCL2020_FEATURE_REDUCTION - Success")
-  else()
-    set(SYCL2020_FEATURE_REDUCTION Off CACHE INTERNAL "" FORCE)
-    message(STATUS "Performing Test SYCL2020_FEATURE_REDUCTION - Failed")
-  endif()
+    message(STATUS "Performing Test SYCL2020_FEATURE_REDUCTION")
+    try_compile(
+        SYCL_feature_reduc2020 ${CMAKE_BINARY_DIR}/compile_tests
+        ${CMAKE_SOURCE_DIR}/cmake/feature_test/sycl2020_reduc.cpp)
+    if(SYCL_feature_reduc2020)
+        set(SYCL2020_FEATURE_REDUCTION ON CACHE INTERNAL "" FORCE)
+        message(STATUS "Performing Test SYCL2020_FEATURE_REDUCTION - Success")
+    else()
+        set(SYCL2020_FEATURE_REDUCTION Off CACHE INTERNAL "" FORCE)
+        message(STATUS "Performing Test SYCL2020_FEATURE_REDUCTION - Failed")
+    endif()
 endif()
 
 if(NOT DEFINED SYCL2020_FEATURE_GROUP_REDUCTION)
-message(STATUS "Performing Test SYCL2020_FEATURE_GROUP_REDUCTION")
-  try_compile(
-    SYCL_feature_group_reduc2020 ${CMAKE_BINARY_DIR}/compile_tests
-    ${CMAKE_SOURCE_DIR}/cmake/feature_test/sycl2020_group_reduc.cpp)
-  if(SYCL_feature_group_reduc2020)
-    set(SYCL2020_FEATURE_GROUP_REDUCTION ON CACHE INTERNAL "" FORCE)
-    message(STATUS "Performing Test SYCL2020_FEATURE_GROUP_REDUCTION - Success")
-  else()
-    set(SYCL2020_FEATURE_GROUP_REDUCTION Off CACHE INTERNAL "" FORCE)
-    message(STATUS "Performing Test SYCL2020_FEATURE_GROUP_REDUCTION - Failed")
-  endif()
+    message(STATUS "Performing Test SYCL2020_FEATURE_GROUP_REDUCTION")
+    try_compile(
+        SYCL_feature_group_reduc2020 ${CMAKE_BINARY_DIR}/compile_tests
+        ${CMAKE_SOURCE_DIR}/cmake/feature_test/sycl2020_group_reduc.cpp)
+    if(SYCL_feature_group_reduc2020)
+        set(SYCL2020_FEATURE_GROUP_REDUCTION ON CACHE INTERNAL "" FORCE)
+        message(STATUS "Performing Test SYCL2020_FEATURE_GROUP_REDUCTION - Success")
+    else()
+        set(SYCL2020_FEATURE_GROUP_REDUCTION Off CACHE INTERNAL "" FORCE)
+        message(STATUS "Performing Test SYCL2020_FEATURE_GROUP_REDUCTION - Failed")
+    endif()
 endif()
 
 
@@ -92,48 +92,52 @@ set(SYCL_COMPILER "ACPP")
 
 if(DEFINED ACPP_PATH)
 
-  check_cxx_source_compiles(
-  "
-  #include <${ACPP_PATH}/include/AdaptiveCpp/sycl/sycl.hpp>
-  int main(void){}
-  "
-  HAS_ACPP_HEADER_FOLDER)
+    check_cxx_source_compiles(
+        "
+        #include <${ACPP_PATH}/include/AdaptiveCpp/sycl/sycl.hpp>
+        int main(void){}
+        "
+        HAS_ACPP_HEADER_FOLDER)
 
 
-  check_cxx_source_compiles(
-  "
-  #include <${ACPP_PATH}/include/OpenSYCL/sycl/sycl.hpp>
-  int main(void){}
-  "
-  HAS_OpenSYCL_HEADER_FOLDER)
+    check_cxx_source_compiles(
+        "
+        #include <${ACPP_PATH}/include/OpenSYCL/sycl/sycl.hpp>
+        int main(void){}
+        "
+        HAS_OpenSYCL_HEADER_FOLDER)
 
 
-  check_cxx_source_compiles(
-  "
-  #include <${ACPP_PATH}/include/hipSYCL/sycl/sycl.hpp>
-  int main(void){}
-  "
-  HAS_hipSYCL_HEADER_FOLDER)
+    check_cxx_source_compiles(
+        "
+        #include <${ACPP_PATH}/include/hipSYCL/sycl/sycl.hpp>
+        int main(void){}
+        "
+        HAS_hipSYCL_HEADER_FOLDER)
 
 
 
 
-  set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -DSYCL_COMP_ACPP")
-  if(HAS_ACPP_HEADER_FOLDER)
-    set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -isystem ${ACPP_PATH}/include/AdaptiveCpp")
-  endif()
-  if(HAS_OpenSYCL_HEADER_FOLDER)
-    set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -isystem ${ACPP_PATH}/include/OpenSYCL")
-  endif()
-  if(HAS_hipSYCL_HEADER_FOLDER)
-    set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -isystem ${ACPP_PATH}/include/hipSYCL")
-  endif()
-  list(APPEND CMAKE_SYSTEM_PROGRAM_PATH "${ACPP_PATH}/bin")
-  list(APPEND CMAKE_SYSTEM_LIBRARY_PATH "${ACPP_PATH}/lib")
+    set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -DSYCL_COMP_ACPP")
+
+    if(SHAMROCK_ADD_SYCL_INCLUDES)
+        if(HAS_ACPP_HEADER_FOLDER)
+            set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -isystem ${ACPP_PATH}/include/AdaptiveCpp")
+        endif()
+        if(HAS_OpenSYCL_HEADER_FOLDER)
+            set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -isystem ${ACPP_PATH}/include/OpenSYCL")
+        endif()
+        if(HAS_hipSYCL_HEADER_FOLDER)
+            set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -isystem ${ACPP_PATH}/include/hipSYCL")
+        endif()
+    endif()
+
+    list(APPEND CMAKE_SYSTEM_PROGRAM_PATH "${ACPP_PATH}/bin")
+    list(APPEND CMAKE_SYSTEM_LIBRARY_PATH "${ACPP_PATH}/lib")
 else()
-  message(FATAL_ERROR
-    "ACPP_PATH is not set, please set it to the root path of acpp (formely Hipsycl or Opensycl) sycl compiler please set "
-    "-DACPP_PATH=<path_to_compiler_root_dir>")
+    message(FATAL_ERROR
+        "ACPP_PATH is not set, please set it to the root path of acpp (formely Hipsycl or Opensycl) sycl compiler please set "
+        "-DACPP_PATH=<path_to_compiler_root_dir>")
 endif()
 
 
@@ -144,7 +148,7 @@ if(ACPP_HAS_FAST_MATH)
 endif()
 
 if(ACPP_FAST_MATH)
-  set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -ffast-math")
+    set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -ffast-math")
 endif()
 
 

--- a/cmake/SYCLAdaptIntelLLVM.cmake
+++ b/cmake/SYCLAdaptIntelLLVM.cmake
@@ -32,8 +32,12 @@ set(SYCL2020_FEATURE_GROUP_REDUCTION ON)
 
 if(DEFINED INTEL_LLVM_PATH)
     set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -DSYCL_COMP_INTEL_LLVM -Wno-unknown-cuda-version")
-    set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -isystem ${INTEL_LLVM_PATH}/include")
-    set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -isystem ${INTEL_LLVM_PATH}/include/sycl")
+
+    if(SHAMROCK_ADD_SYCL_INCLUDES)
+        set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -isystem ${INTEL_LLVM_PATH}/include")
+        set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -isystem ${INTEL_LLVM_PATH}/include/sycl")
+    endif()
+
     list(APPEND CMAKE_SYSTEM_PROGRAM_PATH "${INTEL_LLVM_PATH}/bin")
     list(APPEND CMAKE_SYSTEM_LIBRARY_PATH "${INTEL_LLVM_PATH}/lib")
 else()
@@ -58,15 +62,15 @@ if(INTEL_LLVM_HAS_FAST_MATH)
 endif()
 
 if(INTEL_LLVM_FAST_MATH)
-  set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -ffast-math")
+    set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -ffast-math")
 endif()
 
 if(INTEL_LLVM_SYCL_ID_INT32)
-  set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -fsycl-id-queries-fit-in-int")
+    set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -fsycl-id-queries-fit-in-int")
 endif()
 
 if(INTEL_LLVM_NO_RDC)
-  set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -fno-sycl-rdc")
+    set(SHAM_CXX_SYCL_FLAGS "${SHAM_CXX_SYCL_FLAGS} -fno-sycl-rdc")
 endif()
 
 

--- a/cmake/ShamConfigureSYCL.cmake
+++ b/cmake/ShamConfigureSYCL.cmake
@@ -12,20 +12,27 @@ message("   ---- SYCL config section ----")
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
 
+# The LSPs have no clue of what a SYCL header is,
+# but since it is standard C++ simply adding them to the path works.
+option(SHAMROCK_ADD_SYCL_INCLUDES "Add SYCL includes to CXX_FLAGS to make LSP happy" On)
+
 message(STATUS "Shamrock configure SYCL backend")
+###############################################################################
+### Implementation choice
+###############################################################################
 
 # check that the wanted sycl backend is in the list
-set(KNOWN_SYCL_IMPLEMENTATIONS "IntelLLVM;ACPPDirect;ACPPCmake")
+set(KNOWN_SYCL_IMPLEMENTATIONS "IntelLLVM" "ACPPDirect" "ACPPCmake")
 if((NOT ${SYCL_IMPLEMENTATION} IN_LIST KNOWN_SYCL_IMPLEMENTATIONS) OR (NOT (DEFINED SYCL_IMPLEMENTATION)))
   message(FATAL_ERROR
     "The Shamrock SYCL backend requires specifying a SYCL implementation with "
     "-DSYCL_IMPLEMENTATION=[IntelLLVM;ACPPDirect,ACPPCmake]")
 endif()
-
 set(SYCL_IMPLEMENTATION "${SYCL_IMPLEMENTATION}" CACHE STRING "Sycl implementation used")
-
+set_property(CACHE SYCL_IMPLEMENTATION PROPERTY STRINGS ${KNOWN_SYCL_IMPLEMENTATIONS})
 
 message(STATUS "Chosen SYCL implementation : ${SYCL_IMPLEMENTATION}")
+
 
 set(SHAM_CXX_SYCL_FLAGS "")
 


### PR DESCRIPTION
Adding SYCL headers as include flags is necessary only when using Shamrock in an IDE with LSP or clang-tidy for them to find SYCL headers. On a supercomputer or in a packaged version this is not required. 

This PR add the `SHAMROCK_ADD_SYCL_INCLUDES` cmake option to toggle them (on by default).