### PR TITLE
[Backends] detect physical memory size & correct it on acpp OpenMP backend

### DIFF
--- a/.github/workflows/shamrock-acpp-clang-asan.yml
+++ b/.github/workflows/shamrock-acpp-clang-asan.yml
@@ -91,19 +91,19 @@ jobs:
       - name: run Shamrock Unittests world_size = 1
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 ./shamrock_test --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 2
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 mpirun --bind-to socket:overload-allowed --oversubscribe --allow-run-as-root -n 2 ./shamrock_test --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 mpirun --bind-to socket:overload-allowed --oversubscribe --allow-run-as-root -n 2 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 3
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 mpirun --bind-to socket:overload-allowed --oversubscribe --allow-run-as-root -n 3 ./shamrock_test --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 mpirun --bind-to socket:overload-allowed --oversubscribe --allow-run-as-root -n 3 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 4
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 mpirun --bind-to socket:overload-allowed --oversubscribe --allow-run-as-root -n 4 ./shamrock_test --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp ASAN_OPTIONS=detect_leaks=0 mpirun --bind-to socket:overload-allowed --oversubscribe --allow-run-as-root -n 4 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi

--- a/.github/workflows/shamrock-acpp-clang-coverage.yml
+++ b/.github/workflows/shamrock-acpp-clang-coverage.yml
@@ -86,31 +86,31 @@ jobs:
       - name: run Shamrock Unittests world_size = 1
         run: |
           cd acpp_omp_debug
-          LLVM_PROFILE_FILE="utests_0_0.profraw" ./shamrock_test --sycl-ls-map --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+          LLVM_PROFILE_FILE="utests_0_0.profraw" ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 2
         run: |
           cd acpp_omp_debug
           mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe \
-            -n 1 -x LLVM_PROFILE_FILE=utests_2_0.profraw ./shamrock_test --sycl-ls-map --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
-            -n 1 -x LLVM_PROFILE_FILE=utests_2_1.profraw ./shamrock_test --sycl-ls-map --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+            -n 1 -x LLVM_PROFILE_FILE=utests_2_0.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
+            -n 1 -x LLVM_PROFILE_FILE=utests_2_1.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 3
         run: |
           cd acpp_omp_debug
           mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe \
-            -n 1 -x LLVM_PROFILE_FILE=utests_3_0.profraw ./shamrock_test --sycl-ls-map --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
-            -n 1 -x LLVM_PROFILE_FILE=utests_3_1.profraw ./shamrock_test --sycl-ls-map --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
-            -n 1 -x LLVM_PROFILE_FILE=utests_3_2.profraw ./shamrock_test --sycl-ls-map --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+            -n 1 -x LLVM_PROFILE_FILE=utests_3_0.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
+            -n 1 -x LLVM_PROFILE_FILE=utests_3_1.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
+            -n 1 -x LLVM_PROFILE_FILE=utests_3_2.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 4
         run: |
           cd acpp_omp_debug
           mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe \
-            -n 1 -x LLVM_PROFILE_FILE=utests_4_0.profraw ./shamrock_test --sycl-ls-map --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
-            -n 1 -x LLVM_PROFILE_FILE=utests_4_1.profraw ./shamrock_test --sycl-ls-map --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
-            -n 1 -x LLVM_PROFILE_FILE=utests_4_2.profraw ./shamrock_test --sycl-ls-map --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
-            -n 1 -x LLVM_PROFILE_FILE=utests_4_3.profraw ./shamrock_test --sycl-ls-map --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+            -n 1 -x LLVM_PROFILE_FILE=utests_4_0.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
+            -n 1 -x LLVM_PROFILE_FILE=utests_4_1.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
+            -n 1 -x LLVM_PROFILE_FILE=utests_4_2.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi : \
+            -n 1 -x LLVM_PROFILE_FILE=utests_4_3.profraw ./shamrock_test --smi-full --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
 
       - name: merge coverage reports
         run: |

--- a/.github/workflows/shamrock-acpp-clang-ubsan.yml
+++ b/.github/workflows/shamrock-acpp-clang-ubsan.yml
@@ -91,19 +91,19 @@ jobs:
       - name: run Shamrock Unittests world_size = 1
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" ./shamrock_test --sycl-ls-map  --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" ./shamrock_test --smi-full  --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 2
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 2 ./shamrock_test --sycl-ls-map  --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 2 ./shamrock_test --smi-full  --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 3
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 3 ./shamrock_test --sycl-ls-map  --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 3 ./shamrock_test --smi-full  --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 4
         run: |
           cd build
-          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 4 ./shamrock_test --sycl-ls-map  --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi
+          ACPP_VISIBILITY_MASK=omp UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 4 ./shamrock_test --smi-full  --sycl-cfg 0:0 --unittest --loglevel 0 --benchmark-mpi

--- a/.github/workflows/shamrock-acpp-clang.yml
+++ b/.github/workflows/shamrock-acpp-clang.yml
@@ -139,25 +139,25 @@ jobs:
         if: matrix.runtest
         run: |
           cd build
-          ./shamrock_test --color --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          ./shamrock_test --color --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 2
         if: matrix.runtest
         run: |
           cd build
-          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 2 ./shamrock_test --color --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 2 ./shamrock_test --color --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 3
         if: matrix.runtest
         run: |
           cd build
-          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 3 ./shamrock_test --color --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 3 ./shamrock_test --color --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 4
         if: matrix.runtest
         run: |
           cd build
-          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 4 ./shamrock_test --color --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 4 ./shamrock_test --color --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: Try starting Shamrock (installed version)
         shell: bash # In docker container github action default to sh

--- a/.github/workflows/shamrock-acpp-conda.yml
+++ b/.github/workflows/shamrock-acpp-conda.yml
@@ -108,28 +108,28 @@ jobs:
         run: |
           cd build
           source ./activate
-          ./shamrock_test --color --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          ./shamrock_test --color --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 2
         if: matrix.runtest
         run: |
           cd build
           source ./activate
-          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 2 ./shamrock_test --color --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 2 ./shamrock_test --color --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 3
         if: matrix.runtest
         run: |
           cd build
           source ./activate
-          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 3 ./shamrock_test --color --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 3 ./shamrock_test --color --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 4
         if: matrix.runtest
         run: |
           cd build
           source ./activate
-          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 4 ./shamrock_test --color --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 4 ./shamrock_test --color --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: Try starting Shamrock (installed version)
         if: matrix.runtest

--- a/.github/workflows/shamrock-acpp-macos.yml
+++ b/.github/workflows/shamrock-acpp-macos.yml
@@ -88,22 +88,22 @@ jobs:
       - name: run Shamrock Unittests world_size = 1
         run: |
           cd build
-          ./shamrock_test --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 2
         run: |
           cd build
-          mpirun --oversubscribe -n 2 ./shamrock_test --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          mpirun --oversubscribe -n 2 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 3
         run: |
           cd build
-          mpirun --oversubscribe -n 3 ./shamrock_test --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          mpirun --oversubscribe -n 3 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 4
         run: |
           cd build
-          mpirun --oversubscribe -n 4 ./shamrock_test --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          mpirun --oversubscribe -n 4 ./shamrock_test --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
 
       - name: Try starting Shamrock (installed version)

--- a/.github/workflows/shamrock-dpcpp.yml
+++ b/.github/workflows/shamrock-dpcpp.yml
@@ -106,25 +106,25 @@ jobs:
         if: matrix.runtest
         run: |
           cd build
-          ./shamrock_test --color --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          ./shamrock_test --color --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 2
         if: matrix.runtest
         run: |
           cd build
-          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 2 ./shamrock_test --color --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 2 ./shamrock_test --color --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 3
         if: matrix.runtest
         run: |
           cd build
-          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 3 ./shamrock_test --color --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 3 ./shamrock_test --color --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: run Shamrock Unittests world_size = 4
         if: matrix.runtest
         run: |
           cd build
-          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 4 ./shamrock_test --color --sycl-ls-map  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
+          mpirun --allow-run-as-root --bind-to socket:overload-allowed --oversubscribe -n 4 ./shamrock_test --color --smi-full  --sycl-cfg 0:0 --loglevel 0 --benchmark-mpi
 
       - name: Try starting Shamrock (installed version)
         shell: bash # In docker container github action default to sh

--- a/doc/mkdocs/docs/devdoc/profiling.md
+++ b/doc/mkdocs/docs/devdoc/profiling.md
@@ -79,7 +79,7 @@ nsys profile -t cuda,nvtx,mpi --cuda-memory-usage=true --mpi-impl=openmpi /usr/b
 
 Current command on the GDX :
 ```
-nsys profile -t cuda,nvtx,mpi --gpu-metrics-device=1,2,3,4 --cuda-memory-usage=true --mpi-impl=openmpi  mpirun -n 4 ./shamrock --sycl-cfg auto:CUDA --sycl-ls-map --loglevel 1 --rscript ../exemples/spherical_wave.py
+nsys profile -t cuda,nvtx,mpi --gpu-metrics-device=1,2,3,4 --cuda-memory-usage=true --mpi-impl=openmpi  mpirun -n 4 ./shamrock --sycl-cfg auto:CUDA --smi-full --loglevel 1 --rscript ../exemples/spherical_wave.py
 ```
 
 ### NCU

--- a/doc/mkdocs/docs/usermanual/cluster.md
+++ b/doc/mkdocs/docs/usermanual/cluster.md
@@ -83,14 +83,14 @@ Runing the code on 8 gpu per nodes
 ```bash
 module load hip
 module load openmpi
-$(which mpirun) -machinefile $OAR_NODEFILE -npernode 8 -x PATH=~/dpcpp_compiler/bin:$PATH -x LD_LIBRARY_PATH=~/dpcpp_compiler/lib:$LD_LIBRARY_PATH ./shamrock --sycl-cfg auto:HIP --loglevel 1 --sycl-ls-map  --benchmark-mpi --rscript ../exemples/spherical_wave.py
+$(which mpirun) -machinefile $OAR_NODEFILE -npernode 8 -x PATH=~/dpcpp_compiler/bin:$PATH -x LD_LIBRARY_PATH=~/dpcpp_compiler/lib:$LD_LIBRARY_PATH ./shamrock --sycl-cfg auto:HIP --loglevel 1 --smi  --benchmark-mpi --rscript ../exemples/spherical_wave.py
 ```
 
 
 ```bash
 module load hip
 module load openmpi
-$(which mpirun) -machinefile $OAR_NODEFILE -npernode 8 --mca pml ucx -x UCX_TLS=self,sm,rocm -x PATH=~/dpcpp_compiler/bin:$PATH -x LD_LIBRARY_PATH=~/dpcpp_compiler/lib:$LD_LIBRARY_PATH ./shamrock --sycl-cfg auto:HIP --loglevel 1 --sycl-ls-map  --benchmark-mpi --rscript ../exemples/spherical_wave.py
+$(which mpirun) -machinefile $OAR_NODEFILE -npernode 8 --mca pml ucx -x UCX_TLS=self,sm,rocm -x PATH=~/dpcpp_compiler/bin:$PATH -x LD_LIBRARY_PATH=~/dpcpp_compiler/lib:$LD_LIBRARY_PATH ./shamrock --sycl-cfg auto:HIP --loglevel 1 --smi  --benchmark-mpi --rscript ../exemples/spherical_wave.py
 ```
 
 

--- a/doc/mkdocs/docs/usermanual/clusters/adastra.md
+++ b/doc/mkdocs/docs/usermanual/clusters/adastra.md
@@ -271,7 +271,7 @@ export MPICH_GPU_SUPPORT_ENABLED=1
 export ACPP_DEBUG_LEVEL=2
 
 srun --ntasks-per-node=8 --cpus-per-task=8 --threads-per-core=1 --gpu-bind=closest -- \
-    ./shamrock --sycl-cfg 0:0 --loglevel 125 --sycl-ls-map \
+    ./shamrock --sycl-cfg 0:0 --loglevel 125 --smi \
     --rscript sedov_scale_test_updated.py
 ```
 
@@ -316,7 +316,7 @@ export LD_LIBRARY_PATH=$LLVM_HOME/lib:$LD_LIBRARY_PATH
 ldd ./shamrock
 
 srun --ntasks-per-node=8 --cpus-per-task=8 --threads-per-core=1 --gpu-bind=closest -- \
-    ./shamrock --sycl-cfg auto:HIP --loglevel 125 --sycl-ls-map \
+    ./shamrock --sycl-cfg auto:HIP --loglevel 125 --smi-full \
     --rscript sedov_scale_test_updated.py
 ```
 

--- a/doc/mkdocs/docs/usermanual/clusters/psmn.md
+++ b/doc/mkdocs/docs/usermanual/clusters/psmn.md
@@ -194,7 +194,7 @@ mpirun --bind-to socket -npernode 2 \
     -x LD_LIBRARY_PATH=$HOME/llvm-17.x-local/lib:$LD_LIBRARY_PATH \
     -x OMP_NUM_THREADS=96 \
     -x ACPP_DEBUG_LEVEL=0 \
-    ./shamrock --sycl-cfg 0:0 --loglevel 1 --sycl-ls-map \
+    ./shamrock --sycl-cfg 0:0 --loglevel 1 --smi \
     --rscript ../../exemples/sedov_scale_test.py
 ```
 

--- a/doc/mkdocs/docs/usermanual/firstcalculation.md
+++ b/doc/mkdocs/docs/usermanual/firstcalculation.md
@@ -2,8 +2,8 @@
 First you need to set up a SYCL configuration:
 
 ```bash
-./shamrock --sycl-cfg 0:0 --sycl-ls-map
-mpirun -n 4 ./shamrock --sycl-cfg 0:0 --sycl-ls-map
+./shamrock --sycl-cfg 0:0 --smi
+mpirun -n 4 ./shamrock --sycl-cfg 0:0 --smi
 ```
 ## Using an ipython console within the terminal
 
@@ -14,7 +14,7 @@ sudo apt install python3-ipython
 Then open the console
 
 ```bash
-./shamrock --sycl-cfg 0:0 --sycl-ls-map --ipython
+./shamrock --sycl-cfg 0:0 --smi --ipython
 ```
 ## run a pre-written script
 Setting and running a simulation can all be done through a python script. You don't need to go through the arcanes of SHAMROCK! First, activate the Shamrock virtual environment:
@@ -27,7 +27,7 @@ SHAMROCK provides an array of pre-cooked scripts you can run as is. When running
 For the sake of clarity, let's take the example of the spherical_wave.py script. To run it, type this in your terminal:
 
 ```bash
-./shamrock --sycl-cfg 0:0 --sycl-ls-map --loglevel 10 --rscript ../exemples/spherical_wave.py
+./shamrock --sycl-cfg 0:0 --smi --loglevel 10 --rscript ../exemples/spherical_wave.py
 ```
 the --loglevel argument specifies the degree of verbosity of SHAMROCK.
 - 0 silent

--- a/doc/mkdocs/docs/usermanual/usage.md
+++ b/doc/mkdocs/docs/usermanual/usage.md
@@ -11,23 +11,30 @@ executable : ./shamrock
 Usage :
 --benchmark-mpi                 : micro benchmark for MPI
 --color                         : force colored ouput
+--feenableexcept                 : Enable FPE exceptions
 --force-dgpu-off                 : for direct mpi comm off
 --force-dgpu-on                 : for direct mpi comm on
 --help                          : show this message
 --ipython                       : run shamrock in Ipython mode
 --loglevel      (logvalue)      : specify a log level
 --nocolor                       : disable colored ouput
+--pypath        (sys.path)      : python sys.path to set
+--pypath-from-bin (python binary) : set sys.path from python binary
 --rscript       (filepath)      : run shamrock with python runscirpt
+--smi                           : print information about available SYCL devices in the cluster
+--smi-full                      : print information about EVERY available SYCL devices in the cluster
 --sycl-cfg      (idcomp:idalt)  : specify the compute & alt queue index
---sycl-ls                       : list available devices
---sycl-ls-map                   : list available devices & list of queue bindings
 
 Env variables :
-  SHAMLOGFORMATTER              : Change the log formatter (values :0-3)
+  SHAM_PROF_PREFIX              : Prefix of shamrock profile outputs
+  SHAM_PROF_USE_NVTX            : Enable NVTX profiling
+  SHAM_PROFILING                : Enable Shamrock profiling
+  SHAM_PROF_USE_COMPLETE_EVENT  : Use complete event instead of begin end for chrome tracing
+  SHAM_PROF_EVENT_RECORD_THRES  : Change the event recording threshold
   NO_COLOR                      : Disable colors (if no color cli args are passed)
   CLICOLOR_FORCE                : Enable colors (if no color cli args are passed)
   TERM                          : Terminal emulator identifier
-    = xterm-kitty
+    = xterm-256color
   COLORTERM                     : Terminal color support identifier
     = truecolor
   SHAMTTYCOL                    : Set tty assumed column count
@@ -35,7 +42,7 @@ Env variables :
 Env deduced vars :
   isatty = Yes
   color = enabled
-  tty size = 45x133
+  tty size = 36x106
 ```
 
 Most of those options are just changing the configuration of the code at runtime and will be explained later.

--- a/env/machine/adastra/mi250/exemple_batch.sh
+++ b/env/machine/adastra/mi250/exemple_batch.sh
@@ -25,5 +25,5 @@ ldd ./shamrock
 #
 chmod +x ./binding_script.sh
 srun --ntasks-per-node=8 --cpus-per-task=8 --threads-per-core=1 --gpu-bind=closest -- \
-    ./binding_script.sh ./shamrock --sycl-cfg auto:HIP --loglevel 1 --sycl-ls-map \
+    ./binding_script.sh ./shamrock --sycl-cfg auto:HIP --loglevel 1 --smi \
     --rscript $RSCRIPT

--- a/env/machine/lumi/g/acpp-custom-llvm/exemple_batch.sh
+++ b/env/machine/lumi/g/acpp-custom-llvm/exemple_batch.sh
@@ -37,5 +37,5 @@ export ACPP_DEBUG_LEVEL=0
 
 #
 srun --cpu-bind=${CPU_BIND} -- \
-    ./select_gpu $SHAMROCK_BIN_PATH/shamrock --force-dgpu-on --sycl-cfg auto:HIP --loglevel 1 --sycl-ls-map \
+    ./select_gpu $SHAMROCK_BIN_PATH/shamrock --force-dgpu-on --sycl-cfg auto:HIP --loglevel 1 --smi \
     --rscript $RSCRIPT

--- a/env/machine/lumi/g/acpp-rocm-llvm/exemple_batch.sh
+++ b/env/machine/lumi/g/acpp-rocm-llvm/exemple_batch.sh
@@ -37,5 +37,5 @@ export ACPP_DEBUG_LEVEL=0
 
 #
 srun --cpu-bind=${CPU_BIND} -- \
-    ./select_gpu $SHAMROCK_BIN_PATH/shamrock --force-dgpu-on --sycl-cfg auto:HIP --loglevel 1 --sycl-ls-map \
+    ./select_gpu $SHAMROCK_BIN_PATH/shamrock --force-dgpu-on --sycl-cfg auto:HIP --loglevel 1 --smi \
     --rscript $RSCRIPT

--- a/env/machine/lumi/g/intel-llvm/exemple_batch.sh
+++ b/env/machine/lumi/g/intel-llvm/exemple_batch.sh
@@ -37,5 +37,5 @@ export ACPP_DEBUG_LEVEL=0
 
 #
 srun --cpu-bind=${CPU_BIND} -- \
-    ./select_gpu $SHAMROCK_BIN_PATH/shamrock --force-dgpu-on --sycl-cfg auto:HIP --loglevel 1 --sycl-ls-map \
+    ./select_gpu $SHAMROCK_BIN_PATH/shamrock --force-dgpu-on --sycl-cfg auto:HIP --loglevel 1 --smi \
     --rscript $RSCRIPT

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,9 +60,6 @@ int main(int argc, char *argv[]) {
 
     StackEntry stack_loc{};
 
-    opts::register_opt("--sycl-ls", {}, "list available devices");
-    opts::register_opt("--sycl-ls-map", {}, "list available devices & list of queue bindings");
-
     opts::register_opt(
         "--smi", {}, "print information about available SYCL devices in the cluster");
     opts::register_opt(

--- a/src/main_test.cpp
+++ b/src/main_test.cpp
@@ -34,8 +34,6 @@ PYBIND11_EMBEDDED_MODULE(shamrock, m) { shambindings::init_embed(m); }
 int main(int argc, char *argv[]) {
 
     opts::register_opt("--sycl-cfg", "(idcomp:idalt) ", "specify the compute & alt queue index");
-    opts::register_opt("--sycl-ls", {}, "list available devices");
-    opts::register_opt("--sycl-ls-map", {}, "list available devices & list of queue bindings");
 
     opts::register_opt(
         "--smi", {}, "print information about all available SYCL devices in the cluster");

--- a/src/shambackends/CMakeLists.txt
+++ b/src/shambackends/CMakeLists.txt
@@ -25,6 +25,7 @@ set(Sources
         src/DeviceScheduler.cpp
         src/SyclMpiTypes.cpp
         src/EventList.cpp
+        src/sysinfo.cpp
     )
 
 if(SHAMROCK_USE_SHARED_LIB)

--- a/src/shambackends/include/shambackends/sysinfo.hpp
+++ b/src/shambackends/include/shambackends/sysinfo.hpp
@@ -1,0 +1,34 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2024 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file sysinfo.hpp
+ * @author Timothée David--Cléris (timothee.david--cleris@ens-lyon.fr)
+ * @brief
+ *
+ */
+
+#include <cstddef>
+#include <optional>
+
+namespace sham {
+
+    /**
+     * @brief Get the amount of physical memory (RAM) available on the system, in bytes.
+     *
+     * @return The amount of physical memory available, or std::nullopt if the information
+     *         cannot be retrieved.
+     *
+     * @details This function is implemented for Mac OS X and Linux. Other platforms will
+     *          return std::nullopt.
+     */
+    std::optional<std::size_t> getPhysicalMemory();
+} // namespace sham

--- a/src/shambackends/src/Device.cpp
+++ b/src/shambackends/src/Device.cpp
@@ -17,6 +17,7 @@
 #include "shambackends/Device.hpp"
 #include "shambase/memory.hpp"
 #include "shambase/string.hpp"
+#include "shambackends/sysinfo.hpp"
 #include "shamcomm/logs.hpp"
 #include "shamcomm/mpiInfo.hpp"
 
@@ -203,13 +204,17 @@ namespace sham {
         FETCH_PROP(partition_type_property, sycl::info::partition_property)
         FETCH_PROP(partition_type_affinity_domain, sycl::info::partition_affinity_domain)
 
-        /*
-        #ifdef SYCL_COMP_ACPP
-        if(get_device_backend(dev) == Backend::OPENMP) {
+// On acpp 2^64-1 is returned, so we need to correct it
+// see : https://github.com/AdaptiveCpp/AdaptiveCpp/issues/1573
+#ifdef SYCL_COMP_ACPP
+        if (get_device_backend(dev) == Backend::OPENMP) {
             // Correct memory size
+            auto physmem = sham::getPhysicalMemory();
+            if (physmem) {
+                global_mem_size = {*physmem};
+            }
         }
-        #endif
-        */
+#endif
 
         return {
             Vendor::UNKNOWN,         // We cannot determine the vendor

--- a/src/shambackends/src/sysinfo.cpp
+++ b/src/shambackends/src/sysinfo.cpp
@@ -1,0 +1,53 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2024 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+/**
+ * @file sysinfo.cpp
+ * @author Timothée David--Cléris (timothee.david--cleris@ens-lyon.fr)
+ * @brief
+ *
+ */
+
+#include "shambackends/sysinfo.hpp"
+
+// Mac OSX implementation:
+#if defined(__MACH__)
+    #include <sys/sysctl.h>
+    #include <sys/types.h>
+
+std::optional<std::size_t> sham::getPhysicalMemory() {
+
+    int mib[]     = {CTL_HW, HW_MEMSIZE};
+    int64_t value = 0;
+    size_t length = sizeof(value);
+
+    if (-1 == sysctl(mib, 2, &value, &length, NULL, 0)) {
+        return std::nullopt;
+    }
+    return value;
+}
+
+// Linux/BSD implementation:
+#elif (defined(linux) || defined(__linux__) || defined(__linux))                                   \
+    || (defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__)                      \
+        || defined(__OpenBSD__))
+
+    #include <sys/sysinfo.h>
+
+std::optional<std::size_t> sham::getPhysicalMemory() {
+    struct sysinfo info;
+    sysinfo(&info);
+    return info.totalram;
+}
+
+#else
+
+std::optional<std::size_t> sham::getPhysicalMemory() { return std::nullopt; }
+
+#endif

--- a/src/tests/shambackends/sysinfo.cpp
+++ b/src/tests/shambackends/sysinfo.cpp
@@ -1,0 +1,25 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2024 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#include "shambackends/sysinfo.hpp"
+#include "shambase/string.hpp"
+#include "fmt/std.h"
+#include "shamcomm/logs.hpp"
+#include "shamtest/shamtest.hpp"
+
+TestStart(Unittest, "shambackends/sysinfo:getPhysicalMemory", test_sysinfo_getPhysicalMemory, 1) {
+    auto phys_mem = sham::getPhysicalMemory();
+
+    logger::raw_ln("Physical memory: bool(result)", bool(phys_mem));
+    if (phys_mem) {
+        logger::raw_ln("Physical memory: size =", shambase::readable_sizeof(*phys_mem));
+    }
+
+    REQUIRE(bool(phys_mem));
+}


### PR DESCRIPTION
see : https://github.com/AdaptiveCpp/AdaptiveCpp/issues/1573

On acpp OpenMP backend the global memory size report something huge (2^64 -1) so we need to correct it if we want to use this value to test allocation size.

Also remove the use of `--sycl-ls` and `--sycl-ls-map`.