### PR TITLE
[Models] make set_solver_config consistent across models

### DIFF
--- a/exemples/ci_tests/sod_tube_godunov.py
+++ b/exemples/ci_tests/sod_tube_godunov.py
@@ -5,12 +5,8 @@ import numpy as np
 
 import shamrock
 
-ctx = shamrock.Context()
-ctx.pdata_layout_new()
-
-model = shamrock.get_Model_Ramses(context=ctx, vector_type="f64_3", grid_repr="i64_3")
-
-model.init_scheduler(int(1e7), 1)
+# %%
+# Setup params
 
 multx = 4
 multy = 1
@@ -18,13 +14,24 @@ multz = 1
 
 sz = 1 << 1
 base = 32
-model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
+gamma = 1.4
 
+
+# %%
+# Init model
+
+ctx = shamrock.Context()
+ctx.pdata_layout_new()
+
+model = shamrock.get_Model_Ramses(context=ctx, vector_type="f64_3", grid_repr="i64_3")
+
+
+# %%
+# Init config
 cfg = model.gen_default_config()
 scale_fact = 2 / (sz * base * multx)
 cfg.set_scale_factor(scale_fact)
 
-gamma = 1.4
 cfg.set_eos_gamma(gamma)
 # cfg.set_riemann_solver_rusanov()
 cfg.set_riemann_solver_hll()
@@ -35,7 +42,14 @@ cfg.set_riemann_solver_hll()
 # cfg.set_slope_lim_vanleer_sym()
 cfg.set_slope_lim_minmod()
 cfg.set_face_time_interpolation(True)
-model.set_config(cfg)
+model.set_solver_config(cfg)
+
+
+# %%
+# Init scheduler and grid
+
+model.init_scheduler(int(1e7), 1)
+model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
 
 # without face time interpolation

--- a/exemples/ci_tests/sod_tube_zeus.py
+++ b/exemples/ci_tests/sod_tube_zeus.py
@@ -28,7 +28,7 @@ gamma = 1.4
 cfg.set_eos_gamma(gamma)
 cfg.set_consistent_transport(True)
 cfg.set_van_leer(True)
-model.set_config(cfg)
+model.set_solver_config(cfg)
 
 
 def rho_map(rmin, rmax):

--- a/exemples/ci_tests/sod_tube_zeus.py
+++ b/exemples/ci_tests/sod_tube_zeus.py
@@ -5,30 +5,32 @@ import numpy as np
 
 import shamrock
 
-ctx = shamrock.Context()
-ctx.pdata_layout_new()
-
-model = shamrock.get_Model_Zeus(context=ctx, vector_type="f64_3", grid_repr="i64_3")
-
-model.init_scheduler(int(1e7), 1)
-
 multx = 4
 multy = 1
 multz = 1
 
 sz = 1 << 1
 base = 32
-model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
+gamma = 1.4
+
+
+ctx = shamrock.Context()
+ctx.pdata_layout_new()
+
+model = shamrock.get_Model_Zeus(context=ctx, vector_type="f64_3", grid_repr="i64_3")
+
 
 cfg = model.gen_default_config()
 scale_fact = 2 / (sz * base * multx)
 cfg.set_scale_factor(scale_fact)
 
-gamma = 1.4
 cfg.set_eos_gamma(gamma)
 cfg.set_consistent_transport(True)
 cfg.set_van_leer(True)
 model.set_solver_config(cfg)
+
+model.init_scheduler(int(1e7), 1)
+model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
 
 def rho_map(rmin, rmax):

--- a/exemples/godunov_advect.py
+++ b/exemples/godunov_advect.py
@@ -28,7 +28,7 @@ def run_sim(vanleer=True, label="none"):
     scale_fact = 1 / (sz * base * multx)
     cfg.set_scale_factor(scale_fact)
     cfg.set_eos_gamma(1.0)
-    model.set_config(cfg)
+    model.set_solver_config(cfg)
 
     kx, ky, kz = 2 * np.pi, 0, 0
     delta_rho = 0

--- a/exemples/godunov_advect.py
+++ b/exemples/godunov_advect.py
@@ -7,6 +7,13 @@ import shamrock
 
 tmax = 1.0
 
+multx = 1
+multy = 1
+multz = 1
+
+sz = 1 << 1
+base = 32
+
 
 def run_sim(vanleer=True, label="none"):
     ctx = shamrock.Context()
@@ -14,21 +21,14 @@ def run_sim(vanleer=True, label="none"):
 
     model = shamrock.get_Model_Ramses(context=ctx, vector_type="f64_3", grid_repr="i64_3")
 
-    model.init_scheduler(int(1e7), 1)
-
-    multx = 1
-    multy = 1
-    multz = 1
-
-    sz = 1 << 1
-    base = 32
-    model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
-
     cfg = model.gen_default_config()
     scale_fact = 1 / (sz * base * multx)
     cfg.set_scale_factor(scale_fact)
     cfg.set_eos_gamma(1.0)
     model.set_solver_config(cfg)
+
+    model.init_scheduler(int(1e7), 1)
+    model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
     kx, ky, kz = 2 * np.pi, 0, 0
     delta_rho = 0

--- a/exemples/godunov_dust_advect.py
+++ b/exemples/godunov_dust_advect.py
@@ -27,7 +27,7 @@ def run_sim(vanleer=True, label="none"):
     cfg.set_dust_mode_dhll(1)
     # cfg.set_drag_mode_no_drag()
 
-    model.set_config(cfg)
+    model.set_solver_config(cfg)
     model.init_scheduler(int(1e7), 1)
     model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 

--- a/exemples/godunov_dusty_collision_test.py
+++ b/exemples/godunov_dusty_collision_test.py
@@ -95,7 +95,7 @@ def run_sim(times, vg_num, vd1_num, vd2_num):
     cfg.set_alpha_values(1)            # ts  := 1
     """
 
-    model.set_config(cfg)
+    model.set_solver_config(cfg)
     model.init_scheduler(int(1e7), 1)
     model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 

--- a/exemples/godunov_dusty_wave_test.py
+++ b/exemples/godunov_dusty_wave_test.py
@@ -93,7 +93,7 @@ def run_sim(times, x0, normalized_rd_num, normalized_rg_num, normalized_vd_num, 
     cfg.set_alpha_values(float(1.0 / 0.464159))  # ts = 0.464159
     cfg.set_alpha_values(1.0)  # ts = 1.0
 
-    model.set_config(cfg)
+    model.set_solver_config(cfg)
     model.init_scheduler(int(1e7), 1)
     model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 

--- a/exemples/godunov_sedov.py
+++ b/exemples/godunov_sedov.py
@@ -105,7 +105,7 @@ else:
     cfg.set_slope_lim_vanleer_sym()
     cfg.set_face_time_interpolation(True)
     cfg.set_Csafe(C_cour)
-    model.set_config(cfg)
+    model.set_solver_config(cfg)
     model.set_field_value_lambda_f64("rho", rho_map)
     model.set_field_value_lambda_f64("rhoetot", rhoe_map)
     model.set_field_value_lambda_f64_3("rhovel", rhovel_map)

--- a/exemples/godunov_sedov.py
+++ b/exemples/godunov_sedov.py
@@ -96,8 +96,7 @@ if idump_last_dump is not None:
     idump = idump_last_dump + 1  # avoid overwriting your start dump !
 else:
     idump = 0
-    model.init_scheduler(int(1e7), 1)
-    model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
+
     cfg = model.gen_default_config()
     cfg.set_scale_factor(scale_fact)
     cfg.set_eos_gamma(gamma)
@@ -106,6 +105,10 @@ else:
     cfg.set_face_time_interpolation(True)
     cfg.set_Csafe(C_cour)
     model.set_solver_config(cfg)
+
+    model.init_scheduler(int(1e7), 1)
+    model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
+
     model.set_field_value_lambda_f64("rho", rho_map)
     model.set_field_value_lambda_f64("rhoetot", rhoe_map)
     model.set_field_value_lambda_f64_3("rhovel", rhovel_map)

--- a/exemples/godunov_sod.py
+++ b/exemples/godunov_sod.py
@@ -34,7 +34,7 @@ cfg.set_riemann_solver_hll()
 # cfg.set_slope_lim_vanleer_std()
 # cfg.set_slope_lim_vanleer_sym()
 cfg.set_slope_lim_minmod()
-model.set_config(cfg)
+model.set_solver_config(cfg)
 
 
 kx, ky, kz = 2 * np.pi, 0, 0
@@ -81,7 +81,7 @@ dt = 0.0000
 t = 0
 tend = 0.245
 
-for i in range(701):
+for i in range(1):
 
     if i % freq == 0:
         model.dump_vtk("test" + str(i // freq) + ".vtk")

--- a/exemples/godunov_sod.py
+++ b/exemples/godunov_sod.py
@@ -10,7 +10,6 @@ ctx.pdata_layout_new()
 
 model = shamrock.get_Model_Ramses(context=ctx, vector_type="f64_3", grid_repr="i64_3")
 
-model.init_scheduler(int(1e7), 1)
 
 multx = 4
 multy = 1
@@ -18,7 +17,6 @@ multz = 1
 
 sz = 1 << 1
 base = 32
-model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
 cfg = model.gen_default_config()
 scale_fact = 2 / (sz * base * multx)
@@ -36,6 +34,9 @@ cfg.set_riemann_solver_hll()
 cfg.set_slope_lim_minmod()
 model.set_solver_config(cfg)
 
+
+model.init_scheduler(int(1e7), 1)
+model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
 kx, ky, kz = 2 * np.pi, 0, 0
 delta_rho = 1e-2

--- a/exemples/godunov_soundwave.py
+++ b/exemples/godunov_soundwave.py
@@ -25,7 +25,7 @@ scale_fact = 1 / (sz * base * multx)
 cfg.set_scale_factor(scale_fact)
 
 cfg.set_eos_gamma(5.0 / 3.0)
-model.set_config(cfg)
+model.set_solver_config(cfg)
 
 
 gamma = 5.0 / 3.0

--- a/exemples/godunov_soundwave.py
+++ b/exemples/godunov_soundwave.py
@@ -10,7 +10,6 @@ ctx.pdata_layout_new()
 
 model = shamrock.get_Model_Ramses(context=ctx, vector_type="f64_3", grid_repr="i64_3")
 
-model.init_scheduler(int(1e7), 1)
 
 multx = 1
 multy = 1
@@ -18,7 +17,6 @@ multz = 1
 
 sz = 1 << 1
 base = 32
-model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
 cfg = model.gen_default_config()
 scale_fact = 1 / (sz * base * multx)
@@ -27,6 +25,9 @@ cfg.set_scale_factor(scale_fact)
 cfg.set_eos_gamma(5.0 / 3.0)
 model.set_solver_config(cfg)
 
+
+model.init_scheduler(int(1e7), 1)
+model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
 gamma = 5.0 / 3.0
 

--- a/exemples/sod_tube_godunov_amr.py
+++ b/exemples/sod_tube_godunov_amr.py
@@ -39,7 +39,7 @@ cfg.set_slope_lim_minmod()
 cfg.set_face_time_interpolation(True)
 mass_crit = 0.0000001 * 5 * 2 * 2
 cfg.set_amr_mode_density_based(crit_mass=mass_crit)
-model.set_config(cfg)
+model.set_solver_config(cfg)
 
 
 # without face time interpolation

--- a/exemples/sod_tube_godunov_amr.py
+++ b/exemples/sod_tube_godunov_amr.py
@@ -10,7 +10,6 @@ ctx.pdata_layout_new()
 
 model = shamrock.get_Model_Ramses(context=ctx, vector_type="f64_3", grid_repr="i64_3")
 
-model.init_scheduler(int(1e7), 1)
 
 multx = 4
 multy = 1
@@ -18,9 +17,6 @@ multz = 1
 
 cell_size = 1 << 2  # refinement is limited to cell_size = 2
 base = 16
-model.make_base_grid(
-    (0, 0, 0), (cell_size, cell_size, cell_size), (base * multx, base * multy, base * multz)
-)
 
 cfg = model.gen_default_config()
 scale_fact = 2 / (cell_size * base * multx)
@@ -41,6 +37,11 @@ mass_crit = 0.0000001 * 5 * 2 * 2
 cfg.set_amr_mode_density_based(crit_mass=mass_crit)
 model.set_solver_config(cfg)
 
+
+model.init_scheduler(int(1e7), 1)
+model.make_base_grid(
+    (0, 0, 0), (cell_size, cell_size, cell_size), (base * multx, base * multy, base * multz)
+)
 
 # without face time interpolation
 # 0.07979993131348424 (0.17970690984930585, 0.0, 0.0) 0.12628776652228088

--- a/exemples/zeus_advect.py
+++ b/exemples/zeus_advect.py
@@ -30,7 +30,7 @@ def run_sim(ctp=False, vanleer=False, label="none"):
     cfg.set_eos_gamma(1.0)
     cfg.set_consistent_transport(ctp)
     cfg.set_van_leer(vanleer)
-    model.set_config(cfg)
+    model.set_solver_config(cfg)
 
     kx, ky, kz = 2 * np.pi, 0, 0
     delta_rho = 0

--- a/exemples/zeus_advect.py
+++ b/exemples/zeus_advect.py
@@ -14,15 +14,12 @@ def run_sim(ctp=False, vanleer=False, label="none"):
 
     model = shamrock.get_Model_Zeus(context=ctx, vector_type="f64_3", grid_repr="i64_3")
 
-    model.init_scheduler(int(1e7), 1)
-
     multx = 1
     multy = 1
     multz = 1
 
     sz = 1 << 1
     base = 32
-    model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
     cfg = model.gen_default_config()
     scale_fact = 1 / (sz * base * multx)
@@ -31,6 +28,9 @@ def run_sim(ctp=False, vanleer=False, label="none"):
     cfg.set_consistent_transport(ctp)
     cfg.set_van_leer(vanleer)
     model.set_solver_config(cfg)
+
+    model.init_scheduler(int(1e7), 1)
+    model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
     kx, ky, kz = 2 * np.pi, 0, 0
     delta_rho = 0

--- a/exemples/zeus_sod.py
+++ b/exemples/zeus_sod.py
@@ -10,7 +10,6 @@ ctx.pdata_layout_new()
 
 model = shamrock.get_Model_Zeus(context=ctx, vector_type="f64_3", grid_repr="i64_3")
 
-model.init_scheduler(int(1e7), 1)
 
 multx = 4
 multy = 1
@@ -18,7 +17,6 @@ multz = 1
 
 sz = 1 << 1
 base = 32
-model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
 cfg = model.gen_default_config()
 scale_fact = 2 / (sz * base * multx)
@@ -30,6 +28,9 @@ cfg.set_consistent_transport(True)
 cfg.set_van_leer(True)
 model.set_solver_config(cfg)
 
+
+model.init_scheduler(int(1e7), 1)
+model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
 kx, ky, kz = 2 * np.pi, 0, 0
 delta_rho = 1e-2

--- a/exemples/zeus_sod.py
+++ b/exemples/zeus_sod.py
@@ -28,7 +28,7 @@ gamma = 1.4
 cfg.set_eos_gamma(gamma)
 cfg.set_consistent_transport(True)
 cfg.set_van_leer(True)
-model.set_config(cfg)
+model.set_solver_config(cfg)
 
 
 kx, ky, kz = 2 * np.pi, 0, 0

--- a/exemples/zeus_soundwave.py
+++ b/exemples/zeus_soundwave.py
@@ -10,7 +10,6 @@ ctx.pdata_layout_new()
 
 model = shamrock.get_Model_Zeus(context=ctx, vector_type="f64_3", grid_repr="i64_3")
 
-model.init_scheduler(int(1e7), 1)
 
 multx = 1
 multy = 1
@@ -18,7 +17,6 @@ multz = 1
 
 sz = 1 << 1
 base = 32
-model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
 cfg = model.gen_default_config()
 scale_fact = 1 / (sz * base * multx)
@@ -27,6 +25,9 @@ cfg.set_scale_factor(scale_fact)
 cfg.set_eos_gamma(5.0 / 3.0)
 model.set_solver_config(cfg)
 
+
+model.init_scheduler(int(1e7), 1)
+model.make_base_grid((0, 0, 0), (sz, sz, sz), (base * multx, base * multy, base * multz))
 
 gamma = 5.0 / 3.0
 

--- a/exemples/zeus_soundwave.py
+++ b/exemples/zeus_soundwave.py
@@ -25,7 +25,7 @@ scale_fact = 1 / (sz * base * multx)
 cfg.set_scale_factor(scale_fact)
 
 cfg.set_eos_gamma(5.0 / 3.0)
-model.set_config(cfg)
+model.set_solver_config(cfg)
 
 
 gamma = 5.0 / 3.0

--- a/src/shammodels/ramses/include/shammodels/ramses/SolverConfig.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/SolverConfig.hpp
@@ -17,6 +17,7 @@
  */
 
 #include "shambackends/vec.hpp"
+#include "shamcomm/logs.hpp"
 #include "shammodels/common/amr/AMRBlock.hpp"
 #include "shamrock/io/units_json.hpp"
 #include "shamrock/scheduler/SerialPatchTree.hpp"
@@ -185,7 +186,18 @@ struct shammodels::basegodunov::SolverConfig {
     //////////////////////////////////////////////////////////////////////////////////////////////
     // Solver status variables (END)
     //////////////////////////////////////////////////////////////////////////////////////////////
-}; // struct SolverConfig
+
+    inline void check_config() {
+        if (grid_coord_to_pos_fact <= 0) {
+            shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                "grid_coord_to_pos_fact must be > 0, got {}", grid_coord_to_pos_fact));
+        }
+
+        if (is_dust_on()) {
+            logger::warn_ln("Ramses::SolverConfig", "Dust is experimental");
+        }
+    }
+};
 
 namespace shammodels::basegodunov {
 

--- a/src/shammodels/ramses/src/pyRamsesModel.cpp
+++ b/src/shammodels/ramses/src/pyRamsesModel.cpp
@@ -211,7 +211,7 @@ namespace shammodels::basegodunov {
                     return TConfig();
                 })
             .def(
-                "set_config",
+                "set_solver_config",
                 [](T &self, TConfig cfg) {
                     self.solver.solver_config = cfg;
                 })

--- a/src/shammodels/ramses/src/pyRamsesModel.cpp
+++ b/src/shammodels/ramses/src/pyRamsesModel.cpp
@@ -213,6 +213,11 @@ namespace shammodels::basegodunov {
             .def(
                 "set_solver_config",
                 [](T &self, TConfig cfg) {
+                    if (self.ctx.is_scheduler_initialized()) {
+                        shambase::throw_with_loc<std::runtime_error>(
+                            "Cannot change solver config after scheduler is initialized");
+                    }
+                    cfg.check_config();
                     self.solver.solver_config = cfg;
                 })
             .def(

--- a/src/shammodels/sph/include/shammodels/sph/Model.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/Model.hpp
@@ -714,8 +714,12 @@ namespace shammodels::sph {
         // }
 
         inline void set_solver_config(typename Solver::Config cfg) {
+            if (ctx.is_scheduler_initialized()) {
+                shambase::throw_with_loc<std::runtime_error>(
+                    "Cannot change solver config after scheduler is initialized");
+            }
+            cfg.check_config();
             solver.solver_config = cfg;
-            solver.solver_config.check_config();
         }
 
         inline f64 solver_logs_last_rate() { return solver.solve_logs.get_last_rate(); }

--- a/src/shammodels/zeus/include/shammodels/zeus/SolverConfig.hpp
+++ b/src/shammodels/zeus/include/shammodels/zeus/SolverConfig.hpp
@@ -16,6 +16,8 @@
  *
  */
 
+#include "shambase/exception.hpp"
+#include "shambase/string.hpp"
 #include "shambackends/vec.hpp"
 #include "shammodels/common/amr/AMRBlock.hpp"
 #include "shammodels/zeus/modules/SolverStorage.hpp"
@@ -40,6 +42,13 @@ namespace shammodels::zeus {
 
         bool use_consistent_transport = false;
         bool use_van_leer             = true;
+
+        inline void check_config() {
+            if (grid_coord_to_pos_fact <= 0) {
+                shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                    "grid_coord_to_pos_fact must be > 0, got {}", grid_coord_to_pos_fact));
+            }
+        }
     };
 
 } // namespace shammodels::zeus

--- a/src/shammodels/zeus/src/pyAMRZeusModel.cpp
+++ b/src/shammodels/zeus/src/pyAMRZeusModel.cpp
@@ -75,6 +75,11 @@ namespace shammodels::zeus {
             .def(
                 "set_solver_config",
                 [](T &self, TConfig cfg) {
+                    if (self.ctx.is_scheduler_initialized()) {
+                        shambase::throw_with_loc<std::runtime_error>(
+                            "Cannot change solver config after scheduler is initialized");
+                    }
+                    cfg.check_config();
                     self.solver.solver_config = cfg;
                 })
             .def(

--- a/src/shammodels/zeus/src/pyAMRZeusModel.cpp
+++ b/src/shammodels/zeus/src/pyAMRZeusModel.cpp
@@ -73,7 +73,7 @@ namespace shammodels::zeus {
                     return TConfig();
                 })
             .def(
-                "set_config",
+                "set_solver_config",
                 [](T &self, TConfig cfg) {
                     self.solver.solver_config = cfg;
                 })

--- a/src/shamrock/include/shamrock/scheduler/ShamrockCtx.hpp
+++ b/src/shamrock/include/shamrock/scheduler/ShamrockCtx.hpp
@@ -179,4 +179,7 @@ class ShamrockCtx {
         }
         sched->scheduler_step(do_split_merge, do_load_balancing);
     }
+
+    /// returns true if the scheduler is initialized
+    inline bool is_scheduler_initialized() { return bool(sched); }
 };


### PR DESCRIPTION
There was some inconsistency between models in the way SolverConfig was set. In SPH the function was `set_solver_config` whereas it was `set_config` in zeus and ramses. This PR use `set_solver_config` across all 3 of them (You might be impacted in your personal scripts @y-lapeyre @Akos299). 

Additionally `set_solver_config` now raise an error if the scheduler was initialized (prevent some dust related error we had with @Akos299).

Close #963 