### PR TITLE
sod_tube_zeus.py: Fix undefined name vx

### DIFF
--- a/exemples/ci_tests/sod_tube_zeus.py
+++ b/exemples/ci_tests/sod_tube_zeus.py
@@ -152,7 +152,7 @@ if False:
     fig, axs = plt.subplots(nrows=1, ncols=1, figsize=(9, 6), dpi=125)
 
     plt.scatter(X, rho, rasterized=True, label="rho")
-    plt.scatter(X, vx, rasterized=True, label="v")
+    plt.scatter(X, velx, rasterized=True, label="v")
     plt.scatter(X, P, rasterized=True, label="P")
     # plt.scatter(X,rhoetot, rasterized=True,label="rhoetot")
     plt.legend()

--- a/src/shambindings/src/run_ipython.py
+++ b/src/shambindings/src/run_ipython.py
@@ -1,4 +1,5 @@
 import signal
+import sys
 
 # here the signal interup for sigint is None
 # this make ipython freaks out for weird reasons


### PR DESCRIPTION
% `ruff check`
```
Error: exemples/ci_tests/sod_tube_zeus.py:155:20: F821 Undefined name `vx`
Error: src/shambindings/src/run_ipython.py:15:58: F821 Undefined name `sys`
```

Undefined names can raise NameError at runtime.