### PR TITLE
Add PEP723 headers to examples

### DIFF
--- a/exemples/bardeen_peterson.py
+++ b/exemples/bardeen_peterson.py
@@ -1,3 +1,12 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "matplotlib",
+#     "numpy",
+#     "shamrock @ git+https://github.com/Shamrock-code/Shamrock.git"
+# ]
+# ///
+
 import matplotlib.pyplot as plt
 import numpy as np
 


### PR DESCRIPTION
Would it make sense to add PEP723 headers to the examples to encourage initial exploration?

Enable `uv run exemples/bardeen_peterson.py` or `pipx run exemples/bardeen_peterson.py`
* https://peps.python.org/pep-0723
* https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies
* https://thisdavej.com/share-python-scripts-like-a-pro-uv-and-pep-723-for-easy-deployment

`exemples/bardeen_peterson.py`:
```diff
+ # /// script
+ # requires-python = ">=3.9"
+ # dependencies = [
+ #     "matplotlib",
+ #     "numpy",
+ #     "shamrock @ git+https://github.com/Shamrock-code/Shamrock.git"
+ # ]
+ # ///
```