### PR TITLE
[Ramses][DragIntegrator] Ajuste work-group-size

### DIFF
--- a/src/shammodels/ramses/src/modules/DragIntegrator.cpp
+++ b/src/shammodels/ramses/src/modules/DragIntegrator.cpp
@@ -393,10 +393,11 @@ void shammodels::basegodunov::modules::DragIntegrator<Tvec, TgridVec>::enable_ex
 
         auto acc_alphas = alphas_buf.get_read_access(depend_list);
 
-        size_t group_size       = 32;
         size_t mat_size         = ndust + 1;
         size_t mat_size_squared = mat_size * mat_size;
-        size_t loc_acc_size     = mat_size_squared * group_size;
+        size_t group_size
+            = (q.get_device_prop().local_mem_size) / (5 * mat_size_squared * sizeof(f64));
+        size_t loc_acc_size = mat_size_squared * group_size;
 
         size_t loc_mem_size = 5 * sizeof(f64) * loc_acc_size;
 


### PR DESCRIPTION
Compute work-group size w.r.t the devices shared memory size and number of dust fluids.
This is validate on Dusty Collision test with 20 dust species.
![dusty_collision_test_exp_20f](https://github.com/user-attachments/assets/0a0c3b9b-0075-4ad1-85ab-ed7eb7a00b19)

Even if this fix the precedent issue it's not optimal for large Ndust.
