### PR TITLE
[Shamrock] add a experimental feature switch

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@
 #include "shamcmdopt/env.hpp"
 #include "shamcomm/logs.hpp"
 #include "shamcomm/worldInfo.hpp"
+#include "shamrock/experimental_features.hpp"
 #include "shamrock/version.hpp"
 #include "shamsys/MicroBenchmark.hpp"
 #include "shamsys/NodeInstance.hpp"
@@ -176,6 +177,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (shamsys::instance::is_initialized()) {
+        bool _ = shamrock::are_experimental_features_allowed();
         shamcomm::logs::code_init_done_log();
 
         if (opts::has_option("--pypath")) {

--- a/src/main_test.cpp
+++ b/src/main_test.cpp
@@ -21,6 +21,7 @@
 #include "shamcmdopt/cmdopt.hpp"
 #include "shamcmdopt/env.hpp"
 #include "shamcomm/worldInfo.hpp"
+#include "shamrock/experimental_features.hpp"
 #include "shamrock/version.hpp"
 #include "shamsys/MicroBenchmark.hpp"
 #include "shamsys/NodeInstance.hpp"
@@ -166,6 +167,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (shamsys::instance::is_initialized()) {
+        bool _ = shamrock::are_experimental_features_allowed();
         shamcomm::logs::code_init_done_log();
 
         if (opts::has_option("--pypath")) {

--- a/src/shammodels/ramses/include/shammodels/ramses/SolverConfig.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/SolverConfig.hpp
@@ -21,6 +21,7 @@
 #include "shambackends/vec.hpp"
 #include "shamcomm/logs.hpp"
 #include "shammodels/common/amr/AMRBlock.hpp"
+#include "shamrock/experimental_features.hpp"
 #include "shamrock/io/units_json.hpp"
 #include "shamrock/scheduler/SerialPatchTree.hpp"
 #include <shamunits/Constants.hpp>
@@ -84,7 +85,7 @@ namespace shammodels::basegodunov {
     struct PassiveScalarGasConfig {
         u32 npscal_gas = 0;
 
-        inline bool is_gas_passive_scalar_on() { return npscal_gas == 0; }
+        inline bool is_gas_passive_scalar_on() { return npscal_gas > 0; }
     };
 
     enum GravityMode {
@@ -271,15 +272,25 @@ struct shammodels::basegodunov::SolverConfig {
         if (is_gravity_on()) {
             logger::warn_ln("Ramses::SolverConfig", "Self gravity is experimental");
             u32 mode = gravity_config.gravity_mode;
-            shambase::throw_with_loc<std::runtime_error>(shambase::format(
-                "self gravity mode is not enabled but gravity mode is set to {} (> 0 whith 0 "
-                "== "
-                "NoGravity mode)",
-                mode));
+
+            if (!shamrock::are_experimental_features_allowed()) {
+                shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                    "self gravity mode is not enabled but gravity mode is set to {} (> 0 whith 0 "
+                    "== "
+                    "NoGravity mode)",
+                    mode));
+            }
         }
 
         if (is_gas_passive_scalar_on()) {
             logger::warn_ln("Ramses::SolverConfig", "Passive scalars are experimental");
+            if (!shamrock::are_experimental_features_allowed()) {
+                shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                    "gas passive scalars mode is not enabled but gas passive scalars mode is set "
+                    "to {}"
+                    "> 0",
+                    npscal_gas_config.npscal_gas));
+            }
         }
     }
 };
@@ -313,6 +324,8 @@ namespace shammodels::basegodunov {
             {"type_id", shambase::get_type_name<Tvec>()},
             {"RiemmanSolverMode", p.riemman_config},
             {"SlopeMode", p.slope_config},
+            {"GravityMode", p.gravity_config.gravity_mode},
+            {"PassiveScalarMode", p.npscal_gas_config.npscal_gas},
             {"face_half_time_interpolation", p.face_half_time_interpolation},
             {"eos_gamma", p.eos_gamma},
             {"grid_coord_to_pos_fact", p.grid_coord_to_pos_fact},
@@ -342,6 +355,8 @@ namespace shammodels::basegodunov {
         // actual data stored in the json
         j.at("RiemmanSolverMode").get_to(p.riemman_config);
         j.at("SlopeMode").get_to(p.slope_config);
+        j.at("GravityMode").get_to(p.gravity_config.gravity_mode);
+        j.at("PassiveScalarMode").get_to(p.npscal_gas_config.npscal_gas);
         j.at("face_half_time_interpolation").get_to(p.face_half_time_interpolation);
         j.at("eos_gamma").get_to(p.eos_gamma);
         j.at("grid_coord_to_pos_fact").get_to(p.grid_coord_to_pos_fact);

--- a/src/shamrock/include/shamrock/experimental_features.hpp
+++ b/src/shamrock/include/shamrock/experimental_features.hpp
@@ -1,0 +1,26 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2024 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file experimental_features.hpp
+ * @author Timothée David--Cléris (timothee.david--cleris@ens-lyon.fr)
+ * @brief
+ *
+ */
+
+#include "shamcmdopt/env.hpp"
+
+namespace shamrock {
+
+    /// Allow the use of experimental features
+    bool are_experimental_features_allowed();
+
+} // namespace shamrock

--- a/src/shamrock/src/experimental_features.cpp
+++ b/src/shamrock/src/experimental_features.cpp
@@ -1,0 +1,53 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2024 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+/**
+ * @file experimental_features.cpp
+ * @author Timothée David--Cléris (timothee.david--cleris@ens-lyon.fr)
+ * @brief
+ *
+ */
+
+#include "shamrock/experimental_features.hpp"
+#include "shamcmdopt/env.hpp"
+#include "shamcmdopt/term_colors.hpp"
+#include "shamcomm/logs.hpp"
+#include "shamcomm/worldInfo.hpp"
+
+namespace {
+    bool _env_allow_experimental_features
+        = shamcmdopt::getenv_str_default_register(
+              "SHAM_EXPERIMENTAL", "0", "Allow the use of experimental features")
+          == "1";
+
+    bool warning_printed = false;
+} // namespace
+
+namespace shamrock {
+    bool are_experimental_features_allowed() {
+        if (!warning_printed && _env_allow_experimental_features) {
+            if (shamcomm::world_rank() == 0) {
+
+                std::string color = shambase::term_colors::col8b_yellow();
+                std::string reset = shambase::term_colors::reset();
+
+                shamcomm::logs::raw_ln(
+                    "\n" + color
+                    + "---------------------------- WARNING ----------------------------" + reset
+                    + "\n" + color + "Warning:" + reset + " Experimental features are enabled\n"
+                    + color + "-----------------------------------------------------------------"
+                    + reset);
+            }
+            warning_printed = true;
+        }
+
+        return _env_allow_experimental_features;
+    }
+
+} // namespace shamrock


### PR DESCRIPTION
![Screenshot_20250625_184707](https://github.com/user-attachments/assets/1c4c79b4-4438-4a18-a6e4-111492cbe7a9)

Some features are disabled by default in Shamrock. This PR add the `SHAM_EXPERIMENTAL` env variable to enable them.

simply setting `SHAM_EXPERIMENTAL=1` will allow experimental features.

PS: @bcommerc a small typo made its way in your PR for passive scalars. They were always considered on ... So i fixed the check to `npascalgas > 0`.