### PR TITLE
[SPH] make neigh cache a solvergraph edge

### DIFF
--- a/src/shammodels/sph/include/shammodels/sph/Solver.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/Solver.hpp
@@ -163,6 +163,8 @@ namespace shammodels::sph {
 
         Solver(ShamrockCtx &context) : context(context) {}
 
+        void init_solver_graph();
+
         void vtk_do_dump(std::string filename, bool add_patch_world_id);
 
         void set_debug_dump(bool _do_debug_dump, std::string _debug_dump_filename) {

--- a/src/shammodels/sph/include/shammodels/sph/SolverConfig.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/SolverConfig.hpp
@@ -299,14 +299,11 @@ struct shammodels::sph::SolverConfig {
 
     u32 tree_reduction_level  = 3;    ///< Reduction level to be used in the tree build
     bool use_two_stage_search = true; ///< Use two stage neighbors search (see shamrock paper)
-    u64 max_neigh_cache_size  = 10e9; ///< Maximum size of the neighbors cache
 
     /// Setter for the tree reduction level
     inline void set_tree_reduction_level(u32 level) { tree_reduction_level = level; }
     /// Setter for the two stage search
     inline void set_two_stage_search(bool enable) { use_two_stage_search = enable; }
-    /// Setter for the maximum size of the neighbors cache
-    inline void set_max_neigh_cache_size(u64 val) { max_neigh_cache_size = val; }
 
     //////////////////////////////////////////////////////////////////////////////////////////////
     // Tree config (END)
@@ -772,7 +769,6 @@ namespace shammodels::sph {
             // tree config
             {"tree_reduction_level", p.tree_reduction_level},
             {"use_two_stage_search", p.use_two_stage_search},
-            {"max_neigh_cache_size", p.max_neigh_cache_size},
             // solver behavior config
             {"combined_dtdiv_divcurlv_compute", p.combined_dtdiv_divcurlv_compute},
             {"htol_up_tol", p.htol_up_tol},
@@ -839,7 +835,6 @@ namespace shammodels::sph {
 
         j.at("tree_reduction_level").get_to(p.tree_reduction_level);
         j.at("use_two_stage_search").get_to(p.use_two_stage_search);
-        j.at("max_neigh_cache_size").get_to(p.max_neigh_cache_size);
 
         j.at("combined_dtdiv_divcurlv_compute").get_to(p.combined_dtdiv_divcurlv_compute);
         j.at("htol_up_tol").get_to(p.htol_up_tol);

--- a/src/shammodels/sph/include/shammodels/sph/modules/SolverStorage.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/SolverStorage.hpp
@@ -22,11 +22,13 @@
 #include "shammodels/sph/BasicSPHGhosts.hpp"
 #include "shammodels/sph/SinkPartStruct.hpp"
 #include "shammodels/sph/SolverConfig.hpp"
+#include "shammodels/sph/solvergraph/NeighCache.hpp"
 #include "shamrock/scheduler/SerialPatchTree.hpp"
 #include "shamrock/scheduler/ShamrockCtx.hpp"
 #include "shamsys/legacy/log.hpp"
 #include "shamtree/RadixTree.hpp"
 #include "shamtree/TreeTraversalCache.hpp"
+#include <memory>
 
 namespace shammodels::sph {
 
@@ -45,6 +47,8 @@ namespace shammodels::sph {
 
         using RTree = RadixTree<Tmorton, Tvec>;
 
+        std::shared_ptr<shammodels::sph::solvergraph::NeighCache> neigh_cache;
+
         Component<SerialPatchTree<Tvec>> serial_patch_tree;
 
         Component<GhostHandle> ghost_handler;
@@ -57,7 +61,7 @@ namespace shammodels::sph {
 
         Component<shambase::DistributedData<RadixTreeField<Tscal>>> rtree_rint_field;
 
-        Component<shamrock::tree::ObjectCacheHandler> neighbors_cache;
+        // Component<shamrock::tree::ObjectCacheHandler> neighbors_cache;
 
         Component<shamrock::ComputeField<Tscal>> omega;
 

--- a/src/shammodels/sph/include/shammodels/sph/solvergraph/NeighCache.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/solvergraph/NeighCache.hpp
@@ -1,0 +1,36 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2024 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file NeighCache.hpp
+ * @author Timothée David--Cléris (timothee.david--cleris@ens-lyon.fr)
+ * @brief
+ *
+ */
+
+#include "shambase/DistributedData.hpp"
+#include "shamrock/solvergraph/IDataEdgeNamed.hpp"
+#include "shamtree/TreeTraversal.hpp"
+
+namespace shammodels::sph::solvergraph {
+
+    class NeighCache : public shamrock::solvergraph::IDataEdgeNamed {
+        public:
+        using IDataEdgeNamed::IDataEdgeNamed;
+
+        shambase::DistributedData<shamrock::tree::ObjectCache> neigh_cache;
+
+        shamrock::tree::ObjectCache &get_cache(u64 id) { return neigh_cache.get(id); }
+
+        inline virtual void free_alloc() { neigh_cache = {}; }
+    };
+
+} // namespace shammodels::sph::solvergraph

--- a/src/shammodels/sph/src/Model.cpp
+++ b/src/shammodels/sph/src/Model.cpp
@@ -69,6 +69,8 @@ void shammodels::sph::Model<Tvec, SPHKernel>::init_scheduler(u32 crit_split, u32
         return sched.patch_data.owned_data.get(p.id_patch).get_obj_cnt();
     });
     solver.init_ghost_layout();
+
+    solver.init_solver_graph();
 }
 
 template<class Tvec, template<class> class SPHKernel>

--- a/src/shammodels/sph/src/modules/ComputeOmega.cpp
+++ b/src/shammodels/sph/src/modules/ComputeOmega.cpp
@@ -47,7 +47,8 @@ auto shammodels::sph::modules::ComputeOmega<Tvec, SPHKernel>::compute_omega()
 
         sycl::range range_npart{pdat.get_obj_cnt()};
 
-        tree::ObjectCache &neigh_cache = storage.neighbors_cache.get().get_cache(p.id_patch);
+        tree::ObjectCache &neigh_cache
+            = shambase::get_check_ref(storage.neigh_cache).get_cache(p.id_patch);
 
         sph_utils.compute_omega(
             merged_r, hnew, omega_h, range_npart, neigh_cache, solver_config.gpart_mass);

--- a/src/shammodels/sph/src/modules/DiffOperator.cpp
+++ b/src/shammodels/sph/src/modules/DiffOperator.cpp
@@ -57,7 +57,8 @@ void shammodels::sph::modules::DiffOperators<Tvec, SPHKernel>::update_divv() {
 
         sycl::range range_npart{pdat.get_obj_cnt()};
 
-        tree::ObjectCache &pcache = storage.neighbors_cache.get().get_cache(cur_p.id_patch);
+        tree::ObjectCache &pcache
+            = shambase::get_check_ref(storage.neigh_cache).get_cache(cur_p.id_patch);
 
         /////////////////////////////////////////////
 
@@ -178,7 +179,8 @@ void shammodels::sph::modules::DiffOperators<Tvec, SPHKernel>::update_curlv() {
 
         sycl::range range_npart{pdat.get_obj_cnt()};
 
-        tree::ObjectCache &pcache = storage.neighbors_cache.get().get_cache(cur_p.id_patch);
+        tree::ObjectCache &pcache
+            = shambase::get_check_ref(storage.neigh_cache).get_cache(cur_p.id_patch);
 
         /////////////////////////////////////////////
 

--- a/src/shammodels/sph/src/modules/DiffOperatorDtDivv.cpp
+++ b/src/shammodels/sph/src/modules/DiffOperatorDtDivv.cpp
@@ -76,7 +76,8 @@ void shammodels::sph::modules::DiffOperatorDtDivv<Tvec, SPHKernel>::update_dtdiv
 
         sycl::range range_npart{pdat.get_obj_cnt()};
 
-        tree::ObjectCache &pcache = storage.neighbors_cache.get().get_cache(cur_p.id_patch);
+        tree::ObjectCache &pcache
+            = shambase::get_check_ref(storage.neigh_cache).get_cache(cur_p.id_patch);
 
         /////////////////////////////////////////////
 

--- a/src/shammodels/sph/src/modules/NeighbourCache.cpp
+++ b/src/shammodels/sph/src/modules/NeighbourCache.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "shambase/aliases_int.hpp"
+#include "shambase/memory.hpp"
 #include "shammath/sphkernels.hpp"
 #include "shammodels/sph/modules/NeighbourCache.hpp"
 #include "shamsys/legacy/log.hpp"
@@ -37,184 +38,186 @@ void shammodels::sph::modules::NeighbourCache<Tvec, Tmorton, SPHKernel>::start_n
     StackEntry stack_loc{};
 
     // do cache
-    storage.neighbors_cache.set(
-        shamrock::tree::ObjectCacheHandler(solver_config.max_neigh_cache_size, [&](u64 patch_id) {
-            shamlog_debug_ln("BasicSPH", "build particle cache id =", patch_id);
+    auto build_neigh_cache = [&](u64 patch_id) {
+        shamlog_debug_ln("BasicSPH", "build particle cache id =", patch_id);
 
-            NamedStackEntry cache_build_stack_loc{"build cache"};
+        NamedStackEntry cache_build_stack_loc{"build cache"};
 
-            PreStepMergedField &mfield = storage.merged_xyzh.get().get(patch_id);
+        PreStepMergedField &mfield = storage.merged_xyzh.get().get(patch_id);
 
-            sham::DeviceBuffer<Tvec> &buf_xyz    = mfield.field_pos.get_buf();
-            sham::DeviceBuffer<Tscal> &buf_hpart = mfield.field_hpart.get_buf();
-            sycl::buffer<Tscal> &tree_field_rint = shambase::get_check_ref(
-                storage.rtree_rint_field.get().get(patch_id).radix_tree_field_buf);
+        sham::DeviceBuffer<Tvec> &buf_xyz    = mfield.field_pos.get_buf();
+        sham::DeviceBuffer<Tscal> &buf_hpart = mfield.field_hpart.get_buf();
+        sycl::buffer<Tscal> &tree_field_rint = shambase::get_check_ref(
+            storage.rtree_rint_field.get().get(patch_id).radix_tree_field_buf);
 
-            sycl::range range_npart{mfield.original_elements};
+        sycl::range range_npart{mfield.original_elements};
 
-            RTree &tree = storage.merged_pos_trees.get().get(patch_id);
+        RTree &tree = storage.merged_pos_trees.get().get(patch_id);
 
-            u32 obj_cnt       = mfield.original_elements;
-            Tscal h_tolerance = solver_config.htol_up_tol;
+        u32 obj_cnt       = mfield.original_elements;
+        Tscal h_tolerance = solver_config.htol_up_tol;
 
-            NamedStackEntry stack_loc1{"init cache"};
+        NamedStackEntry stack_loc1{"init cache"};
 
-            using namespace shamrock;
+        using namespace shamrock;
 
-            sham::DeviceBuffer<u32> neigh_count(
-                obj_cnt, shamsys::instance::get_compute_scheduler_ptr());
+        sham::DeviceBuffer<u32> neigh_count(
+            obj_cnt, shamsys::instance::get_compute_scheduler_ptr());
 
-            shamsys::instance::get_compute_queue().wait_and_throw();
+        shamsys::instance::get_compute_queue().wait_and_throw();
 
-            shamlog_debug_sycl_ln("Cache", "generate cache for N=", obj_cnt);
-            {
-                sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
-                sham::EventList depends_list;
+        shamlog_debug_sycl_ln("Cache", "generate cache for N=", obj_cnt);
+        {
+            sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+            sham::EventList depends_list;
 
-                auto xyz       = buf_xyz.get_read_access(depends_list);
-                auto hpart     = buf_hpart.get_read_access(depends_list);
-                auto neigh_cnt = neigh_count.get_write_access(depends_list);
+            auto xyz       = buf_xyz.get_read_access(depends_list);
+            auto hpart     = buf_hpart.get_read_access(depends_list);
+            auto neigh_cnt = neigh_count.get_write_access(depends_list);
 
-                auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
-                    tree::ObjectIterator particle_looper(tree, cgh);
+            auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
+                tree::ObjectIterator particle_looper(tree, cgh);
 
-                    // tree::LeafCacheObjectIterator
-                    // particle_looper(tree,*xyz_cell_id,leaf_cache,cgh);
+                // tree::LeafCacheObjectIterator
+                // particle_looper(tree,*xyz_cell_id,leaf_cache,cgh);
 
-                    sycl::accessor rint_tree{tree_field_rint, cgh, sycl::read_only};
+                sycl::accessor rint_tree{tree_field_rint, cgh, sycl::read_only};
 
-                    // sycl::stream out {4096,1024,cgh};
+                // sycl::stream out {4096,1024,cgh};
 
-                    constexpr Tscal Rker2 = Kernel::Rkern * Kernel::Rkern;
+                constexpr Tscal Rker2 = Kernel::Rkern * Kernel::Rkern;
 
-                    shambase::parralel_for(cgh, obj_cnt, "compute neigh cache 1", [=](u64 gid) {
-                        u32 id_a = (u32) gid;
+                shambase::parralel_for(cgh, obj_cnt, "compute neigh cache 1", [=](u64 gid) {
+                    u32 id_a = (u32) gid;
 
-                        Tscal rint_a = hpart[id_a] * h_tolerance;
+                    Tscal rint_a = hpart[id_a] * h_tolerance;
 
-                        Tvec xyz_a = xyz[id_a];
+                    Tvec xyz_a = xyz[id_a];
 
-                        Tvec inter_box_a_min = xyz_a - rint_a * Kernel::Rkern;
-                        Tvec inter_box_a_max = xyz_a + rint_a * Kernel::Rkern;
+                    Tvec inter_box_a_min = xyz_a - rint_a * Kernel::Rkern;
+                    Tvec inter_box_a_max = xyz_a + rint_a * Kernel::Rkern;
 
-                        u32 cnt = 0;
+                    u32 cnt = 0;
 
-                        particle_looper.rtree_for(
-                            [&](u32 node_id, Tvec bmin, Tvec bmax) -> bool {
-                                Tscal int_r_max_cell = rint_tree[node_id] * Kernel::Rkern;
+                    particle_looper.rtree_for(
+                        [&](u32 node_id, Tvec bmin, Tvec bmax) -> bool {
+                            Tscal int_r_max_cell = rint_tree[node_id] * Kernel::Rkern;
 
-                                using namespace walker::interaction_crit;
+                            using namespace walker::interaction_crit;
 
-                                return sph_radix_cell_crit(
-                                    xyz_a,
-                                    inter_box_a_min,
-                                    inter_box_a_max,
-                                    bmin,
-                                    bmax,
-                                    int_r_max_cell);
-                            },
-                            [&](u32 id_b) {
-                                // particle_looper.for_each_object(id_a,[&](u32 id_b){
-                                //  compute only omega_a
-                                Tvec dr      = xyz_a - xyz[id_b];
-                                Tscal rab2   = sycl::dot(dr, dr);
-                                Tscal rint_b = hpart[id_b] * h_tolerance;
+                            return sph_radix_cell_crit(
+                                xyz_a,
+                                inter_box_a_min,
+                                inter_box_a_max,
+                                bmin,
+                                bmax,
+                                int_r_max_cell);
+                        },
+                        [&](u32 id_b) {
+                            // particle_looper.for_each_object(id_a,[&](u32 id_b){
+                            //  compute only omega_a
+                            Tvec dr      = xyz_a - xyz[id_b];
+                            Tscal rab2   = sycl::dot(dr, dr);
+                            Tscal rint_b = hpart[id_b] * h_tolerance;
 
-                                bool no_interact = rab2 > rint_a * rint_a * Rker2
-                                                   && rab2 > rint_b * rint_b * Rker2;
+                            bool no_interact
+                                = rab2 > rint_a * rint_a * Rker2 && rab2 > rint_b * rint_b * Rker2;
 
-                                cnt += (no_interact) ? 0 : 1;
-                            });
+                            cnt += (no_interact) ? 0 : 1;
+                        });
 
-                        neigh_cnt[id_a] = cnt;
-                    });
+                    neigh_cnt[id_a] = cnt;
                 });
+            });
 
-                buf_xyz.complete_event_state(e);
-                buf_hpart.complete_event_state(e);
-                neigh_count.complete_event_state(e);
-            }
+            buf_xyz.complete_event_state(e);
+            buf_hpart.complete_event_state(e);
+            neigh_count.complete_event_state(e);
+        }
 
-            tree::ObjectCache pcache = tree::prepare_object_cache(std::move(neigh_count), obj_cnt);
+        tree::ObjectCache pcache = tree::prepare_object_cache(std::move(neigh_count), obj_cnt);
 
-            NamedStackEntry stack_loc2{"fill cache"};
-            {
-                sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
-                sham::EventList depends_list;
+        NamedStackEntry stack_loc2{"fill cache"};
+        {
+            sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+            sham::EventList depends_list;
 
-                auto xyz               = buf_xyz.get_read_access(depends_list);
-                auto hpart             = buf_hpart.get_read_access(depends_list);
-                auto scanned_neigh_cnt = pcache.scanned_cnt.get_read_access(depends_list);
-                auto neigh             = pcache.index_neigh_map.get_write_access(depends_list);
+            auto xyz               = buf_xyz.get_read_access(depends_list);
+            auto hpart             = buf_hpart.get_read_access(depends_list);
+            auto scanned_neigh_cnt = pcache.scanned_cnt.get_read_access(depends_list);
+            auto neigh             = pcache.index_neigh_map.get_write_access(depends_list);
 
-                auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
-                    tree::ObjectIterator particle_looper(tree, cgh);
+            auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
+                tree::ObjectIterator particle_looper(tree, cgh);
 
-                    // tree::LeafCacheObjectIterator
-                    // particle_looper(tree,*xyz_cell_id,leaf_cache,cgh);
+                // tree::LeafCacheObjectIterator
+                // particle_looper(tree,*xyz_cell_id,leaf_cache,cgh);
 
-                    sycl::accessor rint_tree{tree_field_rint, cgh, sycl::read_only};
+                sycl::accessor rint_tree{tree_field_rint, cgh, sycl::read_only};
 
-                    // sycl::stream out {4096,1024,cgh};
+                // sycl::stream out {4096,1024,cgh};
 
-                    constexpr Tscal Rker2 = Kernel::Rkern * Kernel::Rkern;
+                constexpr Tscal Rker2 = Kernel::Rkern * Kernel::Rkern;
 
-                    shambase::parralel_for(cgh, obj_cnt, "compute neigh cache 2", [=](u64 gid) {
-                        u32 id_a = (u32) gid;
+                shambase::parralel_for(cgh, obj_cnt, "compute neigh cache 2", [=](u64 gid) {
+                    u32 id_a = (u32) gid;
 
-                        Tscal rint_a = hpart[id_a] * h_tolerance;
+                    Tscal rint_a = hpart[id_a] * h_tolerance;
 
-                        Tvec xyz_a = xyz[id_a];
+                    Tvec xyz_a = xyz[id_a];
 
-                        Tvec inter_box_a_min = xyz_a - rint_a * Kernel::Rkern;
-                        Tvec inter_box_a_max = xyz_a + rint_a * Kernel::Rkern;
+                    Tvec inter_box_a_min = xyz_a - rint_a * Kernel::Rkern;
+                    Tvec inter_box_a_max = xyz_a + rint_a * Kernel::Rkern;
 
-                        u32 cnt = scanned_neigh_cnt[id_a];
+                    u32 cnt = scanned_neigh_cnt[id_a];
 
-                        particle_looper.rtree_for(
-                            [&](u32 node_id, Tvec bmin, Tvec bmax) -> bool {
-                                Tscal int_r_max_cell = rint_tree[node_id] * Kernel::Rkern;
+                    particle_looper.rtree_for(
+                        [&](u32 node_id, Tvec bmin, Tvec bmax) -> bool {
+                            Tscal int_r_max_cell = rint_tree[node_id] * Kernel::Rkern;
 
-                                using namespace walker::interaction_crit;
+                            using namespace walker::interaction_crit;
 
-                                return sph_radix_cell_crit(
-                                    xyz_a,
-                                    inter_box_a_min,
-                                    inter_box_a_max,
-                                    bmin,
-                                    bmax,
-                                    int_r_max_cell);
-                            },
-                            [&](u32 id_b) {
-                                // particle_looper.for_each_object(id_a,[&](u32 id_b){
-                                //  compute only omega_a
-                                Tvec dr      = xyz_a - xyz[id_b];
-                                Tscal rab2   = sycl::dot(dr, dr);
-                                Tscal rint_b = hpart[id_b] * h_tolerance;
+                            return sph_radix_cell_crit(
+                                xyz_a,
+                                inter_box_a_min,
+                                inter_box_a_max,
+                                bmin,
+                                bmax,
+                                int_r_max_cell);
+                        },
+                        [&](u32 id_b) {
+                            // particle_looper.for_each_object(id_a,[&](u32 id_b){
+                            //  compute only omega_a
+                            Tvec dr      = xyz_a - xyz[id_b];
+                            Tscal rab2   = sycl::dot(dr, dr);
+                            Tscal rint_b = hpart[id_b] * h_tolerance;
 
-                                bool no_interact = rab2 > rint_a * rint_a * Rker2
-                                                   && rab2 > rint_b * rint_b * Rker2;
+                            bool no_interact
+                                = rab2 > rint_a * rint_a * Rker2 && rab2 > rint_b * rint_b * Rker2;
 
-                                if (!no_interact) {
-                                    neigh[cnt] = id_b;
-                                }
-                                cnt += (no_interact) ? 0 : 1;
-                            });
-                    });
+                            if (!no_interact) {
+                                neigh[cnt] = id_b;
+                            }
+                            cnt += (no_interact) ? 0 : 1;
+                        });
                 });
+            });
 
-                buf_xyz.complete_event_state(e);
-                buf_hpart.complete_event_state(e);
-                pcache.scanned_cnt.complete_event_state(e);
-                pcache.index_neigh_map.complete_event_state(e);
-            }
+            buf_xyz.complete_event_state(e);
+            buf_hpart.complete_event_state(e);
+            pcache.scanned_cnt.complete_event_state(e);
+            pcache.index_neigh_map.complete_event_state(e);
+        }
 
-            return pcache;
-        }));
+        return pcache;
+    };
+
+    shambase::get_check_ref(storage.neigh_cache).free_alloc();
 
     using namespace shamrock::patch;
     scheduler().for_each_patchdata_nonempty([&](Patch cur_p, PatchData &pdat) {
-        storage.neighbors_cache.get().preload(cur_p.id_patch);
+        auto &ncache = shambase::get_check_ref(storage.neigh_cache);
+        ncache.neigh_cache.add_obj(cur_p.id_patch, build_neigh_cache(cur_p.id_patch));
     });
 
     time_neigh.end();
@@ -237,355 +240,354 @@ void shammodels::sph::modules::NeighbourCache<Tvec, Tmorton, SPHKernel>::
     StackEntry stack_loc{};
 
     // do cache
-    storage.neighbors_cache.set(
-        shamrock::tree::ObjectCacheHandler(solver_config.max_neigh_cache_size, [&](u64 patch_id) {
-            shamlog_debug_ln("BasicSPH", "build particle cache id =", patch_id);
+    auto build_neigh_cache = [&](u64 patch_id) {
+        shamlog_debug_ln("BasicSPH", "build particle cache id =", patch_id);
 
-            NamedStackEntry cache_build_stack_loc{"build cache"};
+        NamedStackEntry cache_build_stack_loc{"build cache"};
 
-            PreStepMergedField &mfield = storage.merged_xyzh.get().get(patch_id);
+        PreStepMergedField &mfield = storage.merged_xyzh.get().get(patch_id);
 
-            sham::DeviceBuffer<Tvec> &buf_xyz    = mfield.field_pos.get_buf();
-            sham::DeviceBuffer<Tscal> &buf_hpart = mfield.field_hpart.get_buf();
-            sycl::buffer<Tscal> &tree_field_rint = shambase::get_check_ref(
-                storage.rtree_rint_field.get().get(patch_id).radix_tree_field_buf);
+        sham::DeviceBuffer<Tvec> &buf_xyz    = mfield.field_pos.get_buf();
+        sham::DeviceBuffer<Tscal> &buf_hpart = mfield.field_hpart.get_buf();
+        sycl::buffer<Tscal> &tree_field_rint = shambase::get_check_ref(
+            storage.rtree_rint_field.get().get(patch_id).radix_tree_field_buf);
 
-            RTree &tree = storage.merged_pos_trees.get().get(patch_id);
+        RTree &tree = storage.merged_pos_trees.get().get(patch_id);
 
-            u32 leaf_cnt    = tree.tree_reduced_morton_codes.tree_leaf_count;
-            u32 intnode_cnt = tree.tree_struct.internal_cell_count;
-            u32 obj_cnt     = mfield.original_elements;
+        u32 leaf_cnt    = tree.tree_reduced_morton_codes.tree_leaf_count;
+        u32 intnode_cnt = tree.tree_struct.internal_cell_count;
+        u32 obj_cnt     = mfield.original_elements;
 
-            sycl::range range_nleaf{leaf_cnt};
-            sycl::range range_nobj{obj_cnt};
-            using namespace shamrock;
+        sycl::range range_nleaf{leaf_cnt};
+        sycl::range range_nobj{obj_cnt};
+        using namespace shamrock;
 
-            Tscal h_tolerance = solver_config.htol_up_tol;
+        Tscal h_tolerance = solver_config.htol_up_tol;
 
-            NamedStackEntry stack_loc1{"init cache"};
+        NamedStackEntry stack_loc1{"init cache"};
 
-            // start by counting number of leaf neighbours
+        // start by counting number of leaf neighbours
 
-            sham::DeviceBuffer<u32> neigh_count_leaf(
-                leaf_cnt, shamsys::instance::get_compute_scheduler_ptr());
+        sham::DeviceBuffer<u32> neigh_count_leaf(
+            leaf_cnt, shamsys::instance::get_compute_scheduler_ptr());
 
-            shamsys::instance::get_compute_queue().wait_and_throw();
+        shamsys::instance::get_compute_queue().wait_and_throw();
 
-            shamlog_debug_sycl_ln("Cache", "generate cache for Nleaf=", leaf_cnt);
+        shamlog_debug_sycl_ln("Cache", "generate cache for Nleaf=", leaf_cnt);
 
-            {
-                sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
-                sham::EventList depends_list;
+        {
+            sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+            sham::EventList depends_list;
 
-                auto xyz       = buf_xyz.get_read_access(depends_list);
-                auto hpart     = buf_hpart.get_read_access(depends_list);
-                auto neigh_cnt = neigh_count_leaf.get_write_access(depends_list);
+            auto xyz       = buf_xyz.get_read_access(depends_list);
+            auto hpart     = buf_hpart.get_read_access(depends_list);
+            auto neigh_cnt = neigh_count_leaf.get_write_access(depends_list);
 
-                auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
-                    tree::LeafIterator leaf_looper(tree, cgh);
+            auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
+                tree::LeafIterator leaf_looper(tree, cgh);
 
-                    sycl::accessor rint_tree{tree_field_rint, cgh, sycl::read_only};
+                sycl::accessor rint_tree{tree_field_rint, cgh, sycl::read_only};
 
-                    u32 offset_leaf = intnode_cnt;
+                u32 offset_leaf = intnode_cnt;
 
-                    shambase::parralel_for(cgh, leaf_cnt, "compute neigh cache 1", [=](u64 gid) {
-                        u32 id_a = (u32) gid;
+                shambase::parralel_for(cgh, leaf_cnt, "compute neigh cache 1", [=](u64 gid) {
+                    u32 id_a = (u32) gid;
 
-                        Tscal leaf_a_rint    = rint_tree[offset_leaf + gid] * Kernel::Rkern;
-                        Tvec leaf_a_bmin     = leaf_looper.pos_min_cell[offset_leaf + gid];
-                        Tvec leaf_a_bmax     = leaf_looper.pos_max_cell[offset_leaf + gid];
-                        Tvec leaf_a_bmin_ext = leaf_a_bmin - leaf_a_rint;
-                        Tvec leaf_a_bmax_ext = leaf_a_bmax + leaf_a_rint;
+                    Tscal leaf_a_rint    = rint_tree[offset_leaf + gid] * Kernel::Rkern;
+                    Tvec leaf_a_bmin     = leaf_looper.pos_min_cell[offset_leaf + gid];
+                    Tvec leaf_a_bmax     = leaf_looper.pos_max_cell[offset_leaf + gid];
+                    Tvec leaf_a_bmin_ext = leaf_a_bmin - leaf_a_rint;
+                    Tvec leaf_a_bmax_ext = leaf_a_bmax + leaf_a_rint;
 
-                        u32 cnt = 0;
+                    u32 cnt = 0;
 
-                        leaf_looper.rtree_for(
-                            [&](u32 node_id, Tvec bmin, Tvec bmax) -> bool {
-                                Tscal int_r_max_cell = rint_tree[node_id] * Kernel::Rkern;
+                    leaf_looper.rtree_for(
+                        [&](u32 node_id, Tvec bmin, Tvec bmax) -> bool {
+                            Tscal int_r_max_cell = rint_tree[node_id] * Kernel::Rkern;
 
-                                Tvec ext_bmin = bmin - int_r_max_cell;
-                                Tvec ext_bmax = bmax + int_r_max_cell;
+                            Tvec ext_bmin = bmin - int_r_max_cell;
+                            Tvec ext_bmax = bmax + int_r_max_cell;
 
-                                return BBAA::cella_neigh_b(
-                                           leaf_a_bmin, leaf_a_bmax, ext_bmin, ext_bmax)
-                                       || BBAA::cella_neigh_b(
-                                           leaf_a_bmin_ext, leaf_a_bmax_ext, bmin, bmax);
-                            },
-                            [&](u32 leaf_b) {
-                                cnt++;
-                            });
-
-                        neigh_cnt[id_a] = cnt;
-                    });
-                });
-
-                buf_xyz.complete_event_state(e);
-                buf_hpart.complete_event_state(e);
-                neigh_count_leaf.complete_event_state(e);
-            }
-
-            //{
-            //    u32 offset_leaf = intnode_cnt;
-            //    sycl::host_accessor neigh_cnt{neigh_count_leaf};
-            //    sycl::host_accessor pos_min_cell
-            //    {shambase::get_check_ref(tree.tree_cell_ranges.buf_pos_min_cell_flt)};
-            //    sycl::host_accessor pos_max_cell
-            //    {shambase::get_check_ref(tree.tree_cell_ranges.buf_pos_max_cell_flt)};
-            //
-            //    for (u32 i = 0; i < 1000; i++) {
-            //        if(neigh_cnt[i] > 30){
-            //            logger::raw_ln(i, neigh_cnt[i], pos_max_cell[i+offset_leaf] -
-            //            pos_min_cell[i+offset_leaf]);
-            //        }
-            //    }
-            //}
-
-            tree::ObjectCache pleaf_cache
-                = tree::prepare_object_cache(std::move(neigh_count_leaf), leaf_cnt);
-
-            // fill ids of leaf neighbours
-
-            NamedStackEntry stack_loc2{"fill cache"};
-
-            {
-                sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
-                sham::EventList depends_list;
-
-                auto xyz               = buf_xyz.get_read_access(depends_list);
-                auto hpart             = buf_hpart.get_read_access(depends_list);
-                auto scanned_neigh_cnt = pleaf_cache.scanned_cnt.get_read_access(depends_list);
-                auto neigh             = pleaf_cache.index_neigh_map.get_write_access(depends_list);
-
-                auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
-                    tree::LeafIterator leaf_looper(tree, cgh);
-
-                    sycl::accessor rint_tree{tree_field_rint, cgh, sycl::read_only};
-
-                    u32 offset_leaf = intnode_cnt;
-
-                    shambase::parralel_for(cgh, leaf_cnt, "compute neigh cache 2", [=](u64 gid) {
-                        u32 id_a = (u32) gid;
-
-                        Tscal leaf_a_rint    = rint_tree[offset_leaf + gid] * Kernel::Rkern;
-                        Tvec leaf_a_bmin     = leaf_looper.pos_min_cell[offset_leaf + gid];
-                        Tvec leaf_a_bmax     = leaf_looper.pos_max_cell[offset_leaf + gid];
-                        Tvec leaf_a_bmin_ext = leaf_a_bmin - leaf_a_rint;
-                        Tvec leaf_a_bmax_ext = leaf_a_bmax + leaf_a_rint;
-
-                        u32 cnt = scanned_neigh_cnt[id_a];
-
-                        leaf_looper.rtree_for(
-                            [&](u32 node_id, Tvec bmin, Tvec bmax) -> bool {
-                                Tscal int_r_max_cell = rint_tree[node_id] * Kernel::Rkern;
-
-                                Tvec ext_bmin = bmin - int_r_max_cell;
-                                Tvec ext_bmax = bmax + int_r_max_cell;
-
-                                return BBAA::cella_neigh_b(
-                                           leaf_a_bmin, leaf_a_bmax, ext_bmin, ext_bmax)
-                                       || BBAA::cella_neigh_b(
-                                           leaf_a_bmin_ext, leaf_a_bmax_ext, bmin, bmax);
-                            },
-                            [&](u32 leaf_b) {
-                                neigh[cnt] = leaf_b;
-                                cnt++;
-                            });
-                    });
-                });
-
-                buf_xyz.complete_event_state(e);
-                buf_hpart.complete_event_state(e);
-                pleaf_cache.scanned_cnt.complete_event_state(e);
-                pleaf_cache.index_neigh_map.complete_event_state(e);
-            }
-            // search in which leaf each parts are
-            sycl::buffer<u32> leaf_part_id(obj_cnt);
-
-            {
-                sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
-                sham::EventList depends_list;
-
-                auto xyz = buf_xyz.get_read_access(depends_list);
-
-                auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
-                    tree::LeafIterator leaf_looper(tree, cgh);
-
-                    sycl::accessor found_id{leaf_part_id, cgh, sycl::write_only, sycl::no_init};
-                    u32 offset_leaf = intnode_cnt;
-                    // sycl::stream out {4096,4096,cgh};
-                    shambase::parralel_for(
-                        cgh, obj_cnt, "search particles parent leaf", [=](u64 gid) {
-                            u32 id_a = (u32) gid;
-
-                            Tvec r_a = xyz[id_a];
-
-                            u32 found_id_ = i32_max; // to ensure a crash because of out of bound
-                                                     // access if not found
-
-                            leaf_looper.rtree_for(
-                                [&](u32 node_id, Tvec bmin, Tvec bmax) -> bool {
-                                    bool ret = BBAA::is_coord_in_range_incl_max(r_a, bmin, bmax);
-
-                                    // error : i= 44245 r=
-                                    // (0.3495433344162232,-0.005627362002766546,-0.21312104638358176)
-                                    // leaf_id= 2147483647 if(id_a == 44245) {out << node_id << " "
-                                    // << bmin
-                                    // << " " << bmax << " " << ret << "\n";};
-                                    return ret;
-                                },
-                                [&](u32 leaf_b) {
-                                    found_id_ = leaf_b - offset_leaf;
-                                });
-
-                            found_id[id_a] = found_id_;
-                        });
-                });
-
-                buf_xyz.complete_event_state(e);
-            }
-
-            //{
-            //    sycl::host_accessor xyz{buf_xyz};
-            //    sycl::host_accessor acc {leaf_part_id};
-            //
-            //    for(u32 i = 0; i < obj_cnt; i++){
-            //        u32 leaf_id = acc[i];
-            //        if(leaf_id >= leaf_cnt){
-            //            logger::raw_ln("error : i=",i,"r=",xyz[i],"leaf_id=",leaf_id);
-            //        }
-            //    }
-            //}
-
-            sham::DeviceBuffer<u32> neigh_count(
-                obj_cnt, shamsys::instance::get_compute_scheduler_ptr());
-
-            shamsys::instance::get_compute_queue().wait_and_throw();
-
-            shamlog_debug_sycl_ln("Cache", "generate cache for N=", obj_cnt);
-
-            {
-                sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
-                sham::EventList depends_list;
-
-                auto xyz                   = buf_xyz.get_read_access(depends_list);
-                auto hpart                 = buf_hpart.get_read_access(depends_list);
-                auto acc_neigh_leaf_looper = pleaf_cache.get_read_access(depends_list);
-                auto neigh_cnt             = neigh_count.get_write_access(depends_list);
-
-                auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
-                    tree::ObjectCacheIterator neigh_leaf_looper(acc_neigh_leaf_looper);
-                    tree::ObjectIterator particle_looper(tree, cgh);
-
-                    sycl::accessor leaf_owner{leaf_part_id, cgh, sycl::read_only};
-
-                    u32 offset_leaf = intnode_cnt;
-                    // sycl::stream out {4096,1024,cgh};
-
-                    constexpr Tscal Rker2 = Kernel::Rkern * Kernel::Rkern;
-
-                    shambase::parralel_for(cgh, obj_cnt, "compute neigh cache 1", [=](u64 gid) {
-                        u32 id_a = (u32) gid;
-
-                        Tscal rint_a = hpart[id_a] * h_tolerance;
-
-                        Tvec xyz_a = xyz[id_a];
-
-                        u32 cnt = 0;
-
-                        u32 leaf_own_a = leaf_owner[id_a];
-
-                        neigh_leaf_looper.for_each_object(leaf_own_a, [&](u32 leaf_b) {
-                            particle_looper.iter_object_in_cell(leaf_b, [&](u32 id_b) {
-                                Tvec dr      = xyz_a - xyz[id_b];
-                                Tscal rab2   = sycl::dot(dr, dr);
-                                Tscal rint_b = hpart[id_b] * h_tolerance;
-
-                                bool no_interact = rab2 > rint_a * rint_a * Rker2
-                                                   && rab2 > rint_b * rint_b * Rker2;
-
-                                cnt += (no_interact) ? 0 : 1;
-                            });
+                            return BBAA::cella_neigh_b(leaf_a_bmin, leaf_a_bmax, ext_bmin, ext_bmax)
+                                   || BBAA::cella_neigh_b(
+                                       leaf_a_bmin_ext, leaf_a_bmax_ext, bmin, bmax);
+                        },
+                        [&](u32 leaf_b) {
+                            cnt++;
                         });
 
-                        neigh_cnt[id_a] = cnt;
-                    });
+                    neigh_cnt[id_a] = cnt;
                 });
+            });
 
-                sham::EventList resulting_events;
-                resulting_events.add_event(e);
+            buf_xyz.complete_event_state(e);
+            buf_hpart.complete_event_state(e);
+            neigh_count_leaf.complete_event_state(e);
+        }
 
-                buf_xyz.complete_event_state(resulting_events);
-                buf_hpart.complete_event_state(resulting_events);
-                pleaf_cache.complete_event_state(resulting_events);
-                neigh_count.complete_event_state(resulting_events);
-            }
+        //{
+        //    u32 offset_leaf = intnode_cnt;
+        //    sycl::host_accessor neigh_cnt{neigh_count_leaf};
+        //    sycl::host_accessor pos_min_cell
+        //    {shambase::get_check_ref(tree.tree_cell_ranges.buf_pos_min_cell_flt)};
+        //    sycl::host_accessor pos_max_cell
+        //    {shambase::get_check_ref(tree.tree_cell_ranges.buf_pos_max_cell_flt)};
+        //
+        //    for (u32 i = 0; i < 1000; i++) {
+        //        if(neigh_cnt[i] > 30){
+        //            logger::raw_ln(i, neigh_cnt[i], pos_max_cell[i+offset_leaf] -
+        //            pos_min_cell[i+offset_leaf]);
+        //        }
+        //    }
+        //}
 
-            tree::ObjectCache pcache = tree::prepare_object_cache(std::move(neigh_count), obj_cnt);
+        tree::ObjectCache pleaf_cache
+            = tree::prepare_object_cache(std::move(neigh_count_leaf), leaf_cnt);
 
-            NamedStackEntry stack_loc3{"fill cache"};
+        // fill ids of leaf neighbours
 
-            {
-                sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
-                sham::EventList depends_list;
+        NamedStackEntry stack_loc2{"fill cache"};
 
-                auto xyz                   = buf_xyz.get_read_access(depends_list);
-                auto hpart                 = buf_hpart.get_read_access(depends_list);
-                auto acc_neigh_leaf_looper = pleaf_cache.get_read_access(depends_list);
-                auto scanned_neigh_cnt     = pcache.scanned_cnt.get_read_access(depends_list);
-                auto neigh                 = pcache.index_neigh_map.get_write_access(depends_list);
+        {
+            sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+            sham::EventList depends_list;
 
-                auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
-                    tree::ObjectCacheIterator neigh_leaf_looper(acc_neigh_leaf_looper);
-                    tree::ObjectIterator particle_looper(tree, cgh);
+            auto xyz               = buf_xyz.get_read_access(depends_list);
+            auto hpart             = buf_hpart.get_read_access(depends_list);
+            auto scanned_neigh_cnt = pleaf_cache.scanned_cnt.get_read_access(depends_list);
+            auto neigh             = pleaf_cache.index_neigh_map.get_write_access(depends_list);
 
-                    sycl::accessor leaf_owner{leaf_part_id, cgh, sycl::read_only};
+            auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
+                tree::LeafIterator leaf_looper(tree, cgh);
 
-                    u32 offset_leaf = intnode_cnt;
+                sycl::accessor rint_tree{tree_field_rint, cgh, sycl::read_only};
 
-                    constexpr Tscal Rker2 = Kernel::Rkern * Kernel::Rkern;
+                u32 offset_leaf = intnode_cnt;
 
-                    shambase::parralel_for(cgh, obj_cnt, "compute neigh cache 2", [=](u64 gid) {
-                        u32 id_a = (u32) gid;
+                shambase::parralel_for(cgh, leaf_cnt, "compute neigh cache 2", [=](u64 gid) {
+                    u32 id_a = (u32) gid;
 
-                        Tscal rint_a = hpart[id_a] * h_tolerance;
+                    Tscal leaf_a_rint    = rint_tree[offset_leaf + gid] * Kernel::Rkern;
+                    Tvec leaf_a_bmin     = leaf_looper.pos_min_cell[offset_leaf + gid];
+                    Tvec leaf_a_bmax     = leaf_looper.pos_max_cell[offset_leaf + gid];
+                    Tvec leaf_a_bmin_ext = leaf_a_bmin - leaf_a_rint;
+                    Tvec leaf_a_bmax_ext = leaf_a_bmax + leaf_a_rint;
 
-                        Tvec xyz_a = xyz[id_a];
+                    u32 cnt = scanned_neigh_cnt[id_a];
 
-                        u32 cnt = scanned_neigh_cnt[id_a];
+                    leaf_looper.rtree_for(
+                        [&](u32 node_id, Tvec bmin, Tvec bmax) -> bool {
+                            Tscal int_r_max_cell = rint_tree[node_id] * Kernel::Rkern;
 
-                        neigh_leaf_looper.for_each_object(leaf_owner[id_a], [&](u32 leaf_b) {
-                            particle_looper.iter_object_in_cell(leaf_b, [&](u32 id_b) {
-                                Tvec dr      = xyz_a - xyz[id_b];
-                                Tscal rab2   = sycl::dot(dr, dr);
-                                Tscal rint_b = hpart[id_b] * h_tolerance;
+                            Tvec ext_bmin = bmin - int_r_max_cell;
+                            Tvec ext_bmax = bmax + int_r_max_cell;
 
-                                bool no_interact = rab2 > rint_a * rint_a * Rker2
-                                                   && rab2 > rint_b * rint_b * Rker2;
+                            return BBAA::cella_neigh_b(leaf_a_bmin, leaf_a_bmax, ext_bmin, ext_bmax)
+                                   || BBAA::cella_neigh_b(
+                                       leaf_a_bmin_ext, leaf_a_bmax_ext, bmin, bmax);
+                        },
+                        [&](u32 leaf_b) {
+                            neigh[cnt] = leaf_b;
+                            cnt++;
+                        });
+                });
+            });
 
-                                if (!no_interact) {
-                                    neigh[cnt] = id_b;
-                                }
-                                cnt += (no_interact) ? 0 : 1;
-                            });
+            buf_xyz.complete_event_state(e);
+            buf_hpart.complete_event_state(e);
+            pleaf_cache.scanned_cnt.complete_event_state(e);
+            pleaf_cache.index_neigh_map.complete_event_state(e);
+        }
+        // search in which leaf each parts are
+        sycl::buffer<u32> leaf_part_id(obj_cnt);
+
+        {
+            sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+            sham::EventList depends_list;
+
+            auto xyz = buf_xyz.get_read_access(depends_list);
+
+            auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
+                tree::LeafIterator leaf_looper(tree, cgh);
+
+                sycl::accessor found_id{leaf_part_id, cgh, sycl::write_only, sycl::no_init};
+                u32 offset_leaf = intnode_cnt;
+                // sycl::stream out {4096,4096,cgh};
+                shambase::parralel_for(cgh, obj_cnt, "search particles parent leaf", [=](u64 gid) {
+                    u32 id_a = (u32) gid;
+
+                    Tvec r_a = xyz[id_a];
+
+                    u32 found_id_ = i32_max; // to ensure a crash because of out of bound
+                                             // access if not found
+
+                    leaf_looper.rtree_for(
+                        [&](u32 node_id, Tvec bmin, Tvec bmax) -> bool {
+                            bool ret = BBAA::is_coord_in_range_incl_max(r_a, bmin, bmax);
+
+                            // error : i= 44245 r=
+                            // (0.3495433344162232,-0.005627362002766546,-0.21312104638358176)
+                            // leaf_id= 2147483647 if(id_a == 44245) {out << node_id << " "
+                            // << bmin
+                            // << " " << bmax << " " << ret << "\n";};
+                            return ret;
+                        },
+                        [&](u32 leaf_b) {
+                            found_id_ = leaf_b - offset_leaf;
+                        });
+
+                    found_id[id_a] = found_id_;
+                });
+            });
+
+            buf_xyz.complete_event_state(e);
+        }
+
+        //{
+        //    sycl::host_accessor xyz{buf_xyz};
+        //    sycl::host_accessor acc {leaf_part_id};
+        //
+        //    for(u32 i = 0; i < obj_cnt; i++){
+        //        u32 leaf_id = acc[i];
+        //        if(leaf_id >= leaf_cnt){
+        //            logger::raw_ln("error : i=",i,"r=",xyz[i],"leaf_id=",leaf_id);
+        //        }
+        //    }
+        //}
+
+        sham::DeviceBuffer<u32> neigh_count(
+            obj_cnt, shamsys::instance::get_compute_scheduler_ptr());
+
+        shamsys::instance::get_compute_queue().wait_and_throw();
+
+        shamlog_debug_sycl_ln("Cache", "generate cache for N=", obj_cnt);
+
+        {
+            sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+            sham::EventList depends_list;
+
+            auto xyz                   = buf_xyz.get_read_access(depends_list);
+            auto hpart                 = buf_hpart.get_read_access(depends_list);
+            auto acc_neigh_leaf_looper = pleaf_cache.get_read_access(depends_list);
+            auto neigh_cnt             = neigh_count.get_write_access(depends_list);
+
+            auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
+                tree::ObjectCacheIterator neigh_leaf_looper(acc_neigh_leaf_looper);
+                tree::ObjectIterator particle_looper(tree, cgh);
+
+                sycl::accessor leaf_owner{leaf_part_id, cgh, sycl::read_only};
+
+                u32 offset_leaf = intnode_cnt;
+                // sycl::stream out {4096,1024,cgh};
+
+                constexpr Tscal Rker2 = Kernel::Rkern * Kernel::Rkern;
+
+                shambase::parralel_for(cgh, obj_cnt, "compute neigh cache 1", [=](u64 gid) {
+                    u32 id_a = (u32) gid;
+
+                    Tscal rint_a = hpart[id_a] * h_tolerance;
+
+                    Tvec xyz_a = xyz[id_a];
+
+                    u32 cnt = 0;
+
+                    u32 leaf_own_a = leaf_owner[id_a];
+
+                    neigh_leaf_looper.for_each_object(leaf_own_a, [&](u32 leaf_b) {
+                        particle_looper.iter_object_in_cell(leaf_b, [&](u32 id_b) {
+                            Tvec dr      = xyz_a - xyz[id_b];
+                            Tscal rab2   = sycl::dot(dr, dr);
+                            Tscal rint_b = hpart[id_b] * h_tolerance;
+
+                            bool no_interact
+                                = rab2 > rint_a * rint_a * Rker2 && rab2 > rint_b * rint_b * Rker2;
+
+                            cnt += (no_interact) ? 0 : 1;
+                        });
+                    });
+
+                    neigh_cnt[id_a] = cnt;
+                });
+            });
+
+            sham::EventList resulting_events;
+            resulting_events.add_event(e);
+
+            buf_xyz.complete_event_state(resulting_events);
+            buf_hpart.complete_event_state(resulting_events);
+            pleaf_cache.complete_event_state(resulting_events);
+            neigh_count.complete_event_state(resulting_events);
+        }
+
+        tree::ObjectCache pcache = tree::prepare_object_cache(std::move(neigh_count), obj_cnt);
+
+        NamedStackEntry stack_loc3{"fill cache"};
+
+        {
+            sham::DeviceQueue &q = shamsys::instance::get_compute_scheduler().get_queue();
+            sham::EventList depends_list;
+
+            auto xyz                   = buf_xyz.get_read_access(depends_list);
+            auto hpart                 = buf_hpart.get_read_access(depends_list);
+            auto acc_neigh_leaf_looper = pleaf_cache.get_read_access(depends_list);
+            auto scanned_neigh_cnt     = pcache.scanned_cnt.get_read_access(depends_list);
+            auto neigh                 = pcache.index_neigh_map.get_write_access(depends_list);
+
+            auto e = q.submit(depends_list, [&, h_tolerance](sycl::handler &cgh) {
+                tree::ObjectCacheIterator neigh_leaf_looper(acc_neigh_leaf_looper);
+                tree::ObjectIterator particle_looper(tree, cgh);
+
+                sycl::accessor leaf_owner{leaf_part_id, cgh, sycl::read_only};
+
+                u32 offset_leaf = intnode_cnt;
+
+                constexpr Tscal Rker2 = Kernel::Rkern * Kernel::Rkern;
+
+                shambase::parralel_for(cgh, obj_cnt, "compute neigh cache 2", [=](u64 gid) {
+                    u32 id_a = (u32) gid;
+
+                    Tscal rint_a = hpart[id_a] * h_tolerance;
+
+                    Tvec xyz_a = xyz[id_a];
+
+                    u32 cnt = scanned_neigh_cnt[id_a];
+
+                    neigh_leaf_looper.for_each_object(leaf_owner[id_a], [&](u32 leaf_b) {
+                        particle_looper.iter_object_in_cell(leaf_b, [&](u32 id_b) {
+                            Tvec dr      = xyz_a - xyz[id_b];
+                            Tscal rab2   = sycl::dot(dr, dr);
+                            Tscal rint_b = hpart[id_b] * h_tolerance;
+
+                            bool no_interact
+                                = rab2 > rint_a * rint_a * Rker2 && rab2 > rint_b * rint_b * Rker2;
+
+                            if (!no_interact) {
+                                neigh[cnt] = id_b;
+                            }
+                            cnt += (no_interact) ? 0 : 1;
                         });
                     });
                 });
+            });
 
-                sham::EventList resulting_events;
-                resulting_events.add_event(e);
+            sham::EventList resulting_events;
+            resulting_events.add_event(e);
 
-                buf_xyz.complete_event_state(resulting_events);
-                buf_hpart.complete_event_state(resulting_events);
-                pleaf_cache.complete_event_state(resulting_events);
-                pcache.scanned_cnt.complete_event_state(resulting_events);
-                pcache.index_neigh_map.complete_event_state(resulting_events);
-            }
-            return pcache;
-        }));
+            buf_xyz.complete_event_state(resulting_events);
+            buf_hpart.complete_event_state(resulting_events);
+            pleaf_cache.complete_event_state(resulting_events);
+            pcache.scanned_cnt.complete_event_state(resulting_events);
+            pcache.index_neigh_map.complete_event_state(resulting_events);
+        }
+        return pcache;
+    };
+
+    shambase::get_check_ref(storage.neigh_cache).free_alloc();
 
     using namespace shamrock::patch;
     scheduler().for_each_patchdata_nonempty([&](Patch cur_p, PatchData &pdat) {
-        storage.neighbors_cache.get().preload(cur_p.id_patch);
+        auto &ncache = shambase::get_check_ref(storage.neigh_cache);
+        ncache.neigh_cache.add_obj(cur_p.id_patch, build_neigh_cache(cur_p.id_patch));
     });
 
     time_neigh.end();

--- a/src/shammodels/sph/src/modules/UpdateDerivs.cpp
+++ b/src/shammodels/sph/src/modules/UpdateDerivs.cpp
@@ -98,7 +98,8 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_cons
 
         sycl::range range_npart{pdat.get_obj_cnt()};
 
-        tree::ObjectCache &pcache = storage.neighbors_cache.get().get_cache(cur_p.id_patch);
+        tree::ObjectCache &pcache
+            = shambase::get_check_ref(storage.neigh_cache).get_cache(cur_p.id_patch);
 
         /////////////////////////////////////////////
 
@@ -299,7 +300,8 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_mm97
 
         sycl::range range_npart{pdat.get_obj_cnt()};
 
-        tree::ObjectCache &pcache = storage.neighbors_cache.get().get_cache(cur_p.id_patch);
+        tree::ObjectCache &pcache
+            = shambase::get_check_ref(storage.neigh_cache).get_cache(cur_p.id_patch);
 
         /////////////////////////////////////////////
 
@@ -510,7 +512,8 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_cd10
 
         sycl::range range_npart{pdat.get_obj_cnt()};
 
-        tree::ObjectCache &pcache = storage.neighbors_cache.get().get_cache(cur_p.id_patch);
+        tree::ObjectCache &pcache
+            = shambase::get_check_ref(storage.neigh_cache).get_cache(cur_p.id_patch);
 
         /////////////////////////////////////////////
 
@@ -708,7 +711,8 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_disc
 
         sycl::range range_npart{pdat.get_obj_cnt()};
 
-        tree::ObjectCache &pcache = storage.neighbors_cache.get().get_cache(cur_p.id_patch);
+        tree::ObjectCache &pcache
+            = shambase::get_check_ref(storage.neigh_cache).get_cache(cur_p.id_patch);
 
         /////////////////////////////////////////////
 
@@ -939,7 +943,8 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_MHD(
 
         sycl::range range_npart{pdat.get_obj_cnt()};
 
-        tree::ObjectCache &pcache = storage.neighbors_cache.get().get_cache(cur_p.id_patch);
+        tree::ObjectCache &pcache
+            = shambase::get_check_ref(storage.neigh_cache).get_cache(cur_p.id_patch);
 
         /////////////////////////////////////////////
 

--- a/src/shammodels/sph/src/pySPHModel.cpp
+++ b/src/shammodels/sph/src/pySPHModel.cpp
@@ -17,6 +17,7 @@
 #include "shambase/logs/loglevels.hpp"
 #include "shambindings/pybindaliases.hpp"
 #include "shambindings/pytypealias.hpp"
+#include "shamcomm/worldInfo.hpp"
 #include "shammath/sphkernels.hpp"
 #include "shammodels/sph/Model.hpp"
 #include "shammodels/sph/io/PhantomDump.hpp"
@@ -50,10 +51,10 @@ void add_instance(py::module &m, std::string name_config, std::string name_model
         .def(
             "set_max_neigh_cache_size",
             [](TConfig &self, u32 max_neigh_cache_size) {
-                shamlog_warn_ln(
-                    "SPH",
-                    "max_neigh_cache_size is deprecated, calling this is a noop, \n"
-                    "you can remove the call to that function");
+                ON_RANK_0(shamlog_warn_ln(
+                              "SPH",
+                              "max_neigh_cache_size is deprecated, calling this is a noop, \n"
+                              "you can remove the call to that function"););
             })
         .def("set_eos_isothermal", &TConfig::set_eos_isothermal)
         .def("set_eos_adiabatic", &TConfig::set_eos_adiabatic)

--- a/src/shammodels/sph/src/pySPHModel.cpp
+++ b/src/shammodels/sph/src/pySPHModel.cpp
@@ -50,7 +50,7 @@ void add_instance(py::module &m, std::string name_config, std::string name_model
         .def("set_two_stage_search", &TConfig::set_two_stage_search)
         .def(
             "set_max_neigh_cache_size",
-            [](TConfig &self, u32 max_neigh_cache_size) {
+            [](TConfig &self, py::object max_neigh_cache_size) {
                 ON_RANK_0(shamlog_warn_ln(
                               "SPH",
                               "max_neigh_cache_size is deprecated, calling this is a noop, \n"

--- a/src/shammodels/sph/src/pySPHModel.cpp
+++ b/src/shammodels/sph/src/pySPHModel.cpp
@@ -53,8 +53,9 @@ void add_instance(py::module &m, std::string name_config, std::string name_model
             [](TConfig &self, py::object max_neigh_cache_size) {
                 ON_RANK_0(shamlog_warn_ln(
                               "SPH",
-                              "max_neigh_cache_size is deprecated, calling this is a noop, \n"
-                              "you can remove the call to that function"););
+                              ".set_max_neigh_cache_size() is deprecated,\n"
+                              "    -> calling this is a no-op,\n"
+                              "    -> you can remove the call to that function"););
             })
         .def("set_eos_isothermal", &TConfig::set_eos_isothermal)
         .def("set_eos_adiabatic", &TConfig::set_eos_adiabatic)

--- a/src/shammodels/sph/src/pySPHModel.cpp
+++ b/src/shammodels/sph/src/pySPHModel.cpp
@@ -14,6 +14,7 @@
  * @brief
  */
 
+#include "shambase/logs/loglevels.hpp"
 #include "shambindings/pybindaliases.hpp"
 #include "shambindings/pytypealias.hpp"
 #include "shammath/sphkernels.hpp"
@@ -46,7 +47,14 @@ void add_instance(py::module &m, std::string name_config, std::string name_model
         .def("print_status", &TConfig::print_status)
         .def("set_tree_reduction_level", &TConfig::set_tree_reduction_level)
         .def("set_two_stage_search", &TConfig::set_two_stage_search)
-        .def("set_max_neigh_cache_size", &TConfig::set_max_neigh_cache_size)
+        .def(
+            "set_max_neigh_cache_size",
+            [](TConfig &self, u32 max_neigh_cache_size) {
+                shamlog_warn_ln(
+                    "SPH",
+                    "max_neigh_cache_size is deprecated, calling this is a noop, \n"
+                    "you can remove the call to that function");
+            })
         .def("set_eos_isothermal", &TConfig::set_eos_isothermal)
         .def("set_eos_adiabatic", &TConfig::set_eos_adiabatic)
         .def("set_eos_locally_isothermal", &TConfig::set_eos_locally_isothermal)


### PR DESCRIPTION
This PR migrates the actual neighbor cache object to a solvergraph edge. In the process, I'm removing the "more annoying and confusing than useful" function `set_max_neigh_cache_size`. 

@DavidFang03 @y-lapeyre your setups will still work without any change, you will only get a warning saying that the function is deprecated and does nothing.