### PR TITLE
[Algs] add binned_average and binned_computation for histogram calculations

### DIFF
--- a/src/shamalgs/include/shamalgs/details/numeric/numeric.hpp
+++ b/src/shamalgs/include/shamalgs/details/numeric/numeric.hpp
@@ -12,6 +12,7 @@
 /**
  * @file numeric.hpp
  * @author Timothée David--Cléris (tim.shamrock@proton.me)
+ * @author Yona Lapeyre (yona.lapeyre@ens-lyon.fr)
  * @brief
  *
  */
@@ -377,6 +378,107 @@ namespace shamalgs::numeric {
                 });
                 return sum;
             });
+    }
+
+    /**
+     * @brief Compute the average of values in each bin.
+     *
+     * This function calculates the average of all values in each bin, using the keys to assign
+     * values to bins. It returns a buffer containing the average for each bin.
+     *
+     * @tparam T The data type of the values and keys.
+     * @param sched The device scheduler to run on.
+     * @param bin_edges The edges of the bins (length == nbins + 1).
+     * @param nbins The number of bins.
+     * @param values The values to be averaged (e.g., f(r)).
+     * @param keys The keys used for binning (e.g., r).
+     * @param len The number of elements in values/keys.
+     * @return sham::DeviceBuffer<T> Buffer of averages, one per bin.
+     *
+     * Example:
+     *   ```cpp
+     *   auto dev_sched = shamsys::instance::get_compute_scheduler_ptr();
+     *   sham::DeviceBuffer<double> bin_edges = ...;
+     *   sham::DeviceBuffer<double> values = ...;
+     *   sham::DeviceBuffer<double> keys = ...;
+     *   u64 nbins = bin_edges.get_size() - 1;
+     *   auto averages = shamalgs::numeric::binned_average(dev_sched, bin_edges, nbins, values,
+     * keys, values.get_size());
+     *   ```
+     */
+
+    template<class T>
+    sham::DeviceBuffer<T> binned_average(
+        const sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceBuffer<T> &bin_edges, // r bins
+        u64 nbins,
+        const sham::DeviceBuffer<T> &values, // ie f(r)
+        const sham::DeviceBuffer<T> &keys,   // ie r
+        u32 len) {
+
+        return binned_compute<T, T>(
+            sched,
+            bin_edges,
+            nbins,
+            values,
+            keys,
+            len,
+            [](auto for_each_values, u32 bin_count) -> T {
+                T sum = 0;
+                for_each_values([&](T val) {
+                    sum += val;
+                });
+                if (bin_count == 0) {
+                    return 0;
+                } else {
+                    return sum / bin_count;
+                }
+            });
+    }
+
+    /**
+     * @brief Perform a custom computation on values in each bin.
+     *
+     * This function applies a user-defined computation on values in each bin, using the keys to
+     * assign values to bins. It allows for custom per-bin operations by passing a computation
+     * function.
+     *
+     * @tparam T The data type of the values and keys.
+     * @tparam F The type of the computation function.
+     * @param sched The device scheduler to run on.
+     * @param bin_edges The edges of the bins (length == nbins + 1).
+     * @param nbins The number of bins.
+     * @param values The values to be processed (e.g., f(r)).
+     * @param keys The keys used for binning (e.g., r).
+     * @param len The number of elements in values/keys.
+     * @param computation_func The user-defined function to compute a result for each bin.
+     * @return sham::DeviceBuffer<T> Buffer containing the result of computation for each bin.
+     *
+     * Example:
+     *   ```cpp
+     *   auto dev_sched = shamsys::instance::get_compute_scheduler_ptr();
+     *   sham::DeviceBuffer<double> bin_edges = ...;
+     *   sham::DeviceBuffer<double> values = ...;
+     *   sham::DeviceBuffer<double> keys = ...;
+     *   u64 nbins = bin_edges.get_size() - 1;
+     *   auto custom_results = shamalgs::numeric::binned_computation(dev_sched, bin_edges, nbins,
+     * values, keys, values.get_size(), [](auto for_each_values, u32 bin_count) {
+     *       // Custom computation logic
+     *   });
+     *   ```
+     */
+
+    template<class T, class F>
+    sham::DeviceBuffer<T> binned_computation(
+        const sham::DeviceScheduler_ptr &sched,
+        const sham::DeviceBuffer<T> &bin_edges, // r bins
+        u64 nbins,
+        const sham::DeviceBuffer<T> &values, // ie f(r)
+        const sham::DeviceBuffer<T> &keys,   // ie r
+        u32 len,
+        F computation_func) {
+
+        return binned_compute<T, T>(sched, bin_edges, nbins, values, keys, len, computation_func);
     }
 
 } // namespace shamalgs::numeric


### PR DESCRIPTION
binned_average does basically the same thing as binned_sum but decides by the counter.
binned_computation takes as a parameter a function and similarly conducts a computation. I created it because I had type issues (inferring the Tret type) when I tried to directly use binned_compute. binned_computation is for instance used to compute the surface density of a disc.