### PR TITLE
[Backends] log kernel_call callsite on exception

### DIFF
--- a/src/shambackends/include/shambackends/kernel_call.hpp
+++ b/src/shambackends/include/shambackends/kernel_call.hpp
@@ -287,13 +287,12 @@ namespace sham {
             Functor &&kernel_gen,
             SourceLocation &&callsite = SourceLocation{}) {
 
-            __shamrock_stack_entry_callsite(callsite);
+            __shamrock_stack_entry_with_callsite(callsite);
 
             if (n == 0) {
                 shambase::throw_with_loc<std::runtime_error>("kernel call with : n == 0");
             }
 
-            __shamrock_stack_entry();
             sham::EventList depends_list;
 
             auto acc_in     = in.get_read_access(depends_list);
@@ -327,7 +326,7 @@ namespace sham {
             Functor &&func,
             SourceLocation &&callsite = SourceLocation{}) {
 
-            __shamrock_stack_entry_callsite(callsite);
+            __shamrock_log_callsite(callsite);
 
             typed_index_kernel_call_lambda(
                 q,
@@ -520,7 +519,7 @@ namespace sham {
         Functor &&func,
         SourceLocation &&callsite = SourceLocation{}) {
 
-        __shamrock_stack_entry_callsite(callsite);
+        __shamrock_log_callsite(callsite);
 
         details::typed_index_kernel_call<u32, RefIn, RefOut>(
             q, in, in_out, n, std::forward<Functor>(func));
@@ -536,7 +535,7 @@ namespace sham {
         Functor &&func,
         SourceLocation &&callsite = SourceLocation{}) {
 
-        __shamrock_stack_entry_callsite(callsite);
+        __shamrock_log_callsite(callsite);
 
         details::typed_index_kernel_call<u64, RefIn, RefOut>(
             q, in, in_out, n, std::forward<Functor>(func));
@@ -552,7 +551,7 @@ namespace sham {
         Functor &&kernel_gen,
         SourceLocation &&callsite = SourceLocation{}) {
 
-        __shamrock_stack_entry_callsite(callsite);
+        __shamrock_log_callsite(callsite);
 
         details::typed_index_kernel_call_lambda<u32, RefIn, RefOut>(
             q, in, in_out, n, std::forward<Functor>(kernel_gen));
@@ -568,7 +567,7 @@ namespace sham {
         Functor &&kernel_gen,
         SourceLocation &&callsite = SourceLocation{}) {
 
-        __shamrock_stack_entry_callsite(callsite);
+        __shamrock_log_callsite(callsite);
 
         details::typed_index_kernel_call_lambda<u64, RefIn, RefOut>(
             q, in, in_out, n, std::forward<Functor>(kernel_gen));

--- a/src/shambase/include/shambase/stacktrace.hpp
+++ b/src/shambase/include/shambase/stacktrace.hpp
@@ -83,6 +83,26 @@ namespace shambase::details {
      */
     inline std::stack<SourceLocation> call_stack;
 
+    /// Helper class to manage the call stack entry
+    struct CallStackEntry {
+        inline CallStackEntry(SourceLocation &loc) {
+            // Push the source location to the call stack
+            call_stack.emplace(loc);
+        }
+
+        // This class is not safe if copied or moved
+
+        CallStackEntry(const CallStackEntry &)            = delete;
+        CallStackEntry &operator=(const CallStackEntry &) = delete;
+        CallStackEntry(CallStackEntry &&)                 = delete;
+        CallStackEntry &operator=(CallStackEntry &&)      = delete;
+
+        inline ~CallStackEntry() {
+            // Pop the source location from the call stack
+            call_stack.pop();
+        }
+    };
+
     struct BasicStackEntry {
         SourceLocation loc; ///< Source location attached to the entry
         bool do_timer;      ///< is the timer enabled for this entry
@@ -90,6 +110,9 @@ namespace shambase::details {
 #ifdef SHAMROCK_USE_PROFILING
         f64 wtime_start; ///< start time of the entry
 #endif
+
+        CallStackEntry scoped_callstack_entry; ///< scoped call stack entry
+
         /**
          * @brief Construct a new Basic Stack Entry object.
          *
@@ -97,7 +120,7 @@ namespace shambase::details {
          * @param loc Source location attached to the entry (default: SourceLocation{})
          */
         inline BasicStackEntry(bool do_timer = true, SourceLocation &&loc = SourceLocation{})
-            : loc(loc), do_timer(do_timer) {
+            : loc(loc), do_timer(do_timer), scoped_callstack_entry(loc) {
 #ifdef SHAMROCK_USE_PROFILING
             if (do_timer) {
                 wtime_start = get_wtime();
@@ -106,8 +129,25 @@ namespace shambase::details {
                 shambase::profiling::stack_entry_start_no_time(loc);
             }
 #endif
-            // Push the source location to the call stack
-            call_stack.emplace(loc);
+        }
+
+        /**
+         * @brief Construct a new Basic Stack Entry object.
+         *
+         * @param do_timer Is the timer enabled for this entry (default: true)
+         * @param loc Source location attached to the entry (default: SourceLocation{})
+         */
+        inline BasicStackEntry(
+            SourceLocation &callsite, bool do_timer = true, SourceLocation &&loc = SourceLocation{})
+            : loc(loc), do_timer(do_timer), scoped_callstack_entry(callsite) {
+#ifdef SHAMROCK_USE_PROFILING
+            if (do_timer) {
+                wtime_start = get_wtime();
+                shambase::profiling::stack_entry_start(loc, wtime_start);
+            } else {
+                shambase::profiling::stack_entry_start_no_time(loc);
+            }
+#endif
         }
 
         /**
@@ -124,8 +164,6 @@ namespace shambase::details {
                 shambase::profiling::stack_entry_end_no_time(loc);
             }
 #endif
-            // Pop the source location from the call stack
-            call_stack.pop();
         }
     };
 
@@ -138,6 +176,8 @@ namespace shambase::details {
         f64 wtime_start; ///< start time of the entry
 #endif
 
+        CallStackEntry scoped_callstack_entry; ///< scoped call stack entry
+
         /**
          * @brief Construct a new Named Basic Stack Entry object
          *
@@ -147,7 +187,7 @@ namespace shambase::details {
          */
         inline NamedBasicStackEntry(
             std::string name, bool do_timer = true, SourceLocation &&loc = SourceLocation{})
-            : name(name), loc(loc), do_timer(do_timer) {
+            : name(name), loc(loc), do_timer(do_timer), scoped_callstack_entry(loc) {
 #ifdef SHAMROCK_USE_PROFILING
             if (do_timer) {
                 wtime_start = get_wtime();
@@ -156,7 +196,6 @@ namespace shambase::details {
                 shambase::profiling::stack_entry_start_no_time(loc, name);
             }
 #endif
-            call_stack.emplace(loc);
         }
 
         /**
@@ -173,7 +212,6 @@ namespace shambase::details {
                 shambase::profiling::stack_entry_end_no_time(loc);
             }
 #endif
-            call_stack.pop();
         }
     };
 
@@ -216,21 +254,21 @@ using NamedStackEntry = shambase::details::NamedBasicStackEntry;
     [[maybe_unused]] StackEntry __shamrock_unique_name(stack_loc_) {}
 
 /**
- * @brief Macro to create a stack entry from a given location. Can be used with any source
- *
- * This macro defines a `StackEntry` variable with a unique name by leveraging
- * the `__shamrock_unique_name` macro.
- */
-#define __shamrock_stack_entry_at(callsite)                                                        \
-    [[maybe_unused]] StackEntry __shamrock_unique_name(stack_loc_) {                               \
-        false, SourceLocation { callsite }                                                         \
-    }
-
-/**
  * @brief Macro to create a stack entry from a given location. Can be used only on SourceLocation &&
  *
  * This macro defines a `StackEntry` variable with a unique name by leveraging
  * the `__shamrock_unique_name` macro.
  */
-#define __shamrock_stack_entry_callsite(callsite)                                                  \
-    [[maybe_unused]] StackEntry __shamrock_unique_name(stack_loc_) { false, std::move(callsite) }
+#define __shamrock_log_callsite(callsite)                                                          \
+    [[maybe_unused]] shambase::details::CallStackEntry __shamrock_unique_name(call_site_loc) {     \
+        callsite                                                                                   \
+    }
+
+/**
+ * @brief Macro to create a stack entry.
+ *
+ * This macro defines a `StackEntry` variable with a unique name by leveraging
+ * the `__shamrock_unique_name` macro.
+ */
+#define __shamrock_stack_entry_with_callsite(callsite)                                             \
+    [[maybe_unused]] StackEntry __shamrock_unique_name(stack_loc_) { callsite }


### PR DESCRIPTION
This will allow the stacktracer to report the correct callsite on kernel_call exceptions