### PR TITLE
[Backends] Provide a variant of DeviceBuffer::resize that skip data copy

### DIFF
--- a/src/shambackends/include/shambackends/DeviceBuffer.hpp
+++ b/src/shambackends/include/shambackends/DeviceBuffer.hpp
@@ -960,11 +960,10 @@ namespace sham {
          * @brief Resizes the buffer to a given size.
          *
          * @param new_size The new size of the buffer.
+         * @param keep_data If `true`, the content of the  buffer is preserved up to the minimum of
+         * the old and new sizes. If `false`, the content may be discarded if a reallocation occurs.
          */
-        *@param new_size The new size of the buffer.*@param keep_data If `true`,
-            the content of the buffer is preserved up to the minimum of
-                the old and new sizes.If `false`,
-            the content may be discarded if a reallocation occurs.* / inline void resize(size_t new_size, bool keep_data = true) {
+        inline void resize(size_t new_size, bool keep_data = true) {
 
             auto dev_sched = hold.get_dev_scheduler_ptr();
 


### PR DESCRIPTION
closing issue #1502