### PR TITLE
Add TGauss3 and TGauss5 truncated Gaussian SPH kernels

### DIFF
--- a/src/shammath/include/shammath/sphkernels.hpp
+++ b/src/shammath/include/shammath/sphkernels.hpp
@@ -11,6 +11,7 @@
 
 /**
  * @file sphkernels.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
  * @author Timothée David--Cléris (tim.shamrock@proton.me)
  * @brief sph kernels
  */


### PR DESCRIPTION
## Summary

Add two new truncated Gaussian SPH kernels to the shammath kernel library:

- **TGauss3**: Truncated Gaussian kernel with compact support R=3h
  - `W(q) = exp(-q²)` for `q < 3`, `0` otherwise
  
- **TGauss5**: Truncated Gaussian kernel with compact support R=5h  
  - `W(q) = exp(-q²)` for `q < 5`, `0` otherwise

These kernels provide smooth derivatives and are well-suited for relativistic SPH simulations where gradient accuracy is important.

## Changes

- Added `KernelDefTGauss3` and `KernelDefTGauss5` class definitions with:
  - Compact support radius (Rkern = 3 or 5)
  - Default hfact = 1.5
  - Normalization constants for 1D, 2D, and 3D
  - f(q), df(q), and ddf(q) implementations
- Added `TGauss3` and `TGauss5` type aliases
- Added `TypeNameInfo` specializations for type reflection

## Test plan

- [ ] Verify kernel normalization integrates to 1
- [ ] Test kernel derivatives are correct
- [ ] Verify compilation on CI