### PR TITLE
[CI] run update authors only in post merge checks

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -29,11 +29,6 @@ jobs:
       - uses: pre-commit/action@v3.0.1
         continue-on-error: true
 
-      - name: "Run author update script"
-        continue-on-error: true
-        run: |
-          python3 buildbot/update_authors.py
-
       - name: Commit and push if changed
         if: env.FIX_MODE == 'fix'
         uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27

--- a/.github/workflows/source_checks.yml
+++ b/.github/workflows/source_checks.yml
@@ -44,10 +44,6 @@ jobs:
 
     - uses: pre-commit/action@v3.0.1
 
-    - name: "Run author update script"
-      run: |
-        python3 buildbot/update_authors.py
-
     - name: rerun precommit for logs
       if: success()
       run: pre-commit run --all-files > out


### PR DESCRIPTION
Essentially during most PRs we end up adding stuff removing them in review, which create a git blame that does not exist after the squash. Simple solution -> forget the author update during PR but keep in auto generated PRs