### PR TITLE
[GSPH] Add physics composition framework and solvergraph node stubs

### DIFF
--- a/src/shammodels/gsph/include/shammodels/gsph/modes/SolverModes.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/modes/SolverModes.hpp
@@ -1,0 +1,185 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2025 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file SolverModes.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Solver mode modifiers for GSPH
+ *
+ * Defines how the solver evolves:
+ * - NormalEvolution: Standard time evolution
+ * - RelaxationMode: Damped evolution toward equilibrium (Lane-Emden)
+ * - DustMode: Pressureless limit
+ *
+ * Modes can modify the computed derivatives before time integration.
+ */
+
+#include "shambackends/sycl.hpp"
+#include "shambackends/vec.hpp"
+
+namespace shammodels::gsph::modes {
+
+    // ========================================================================
+    // NormalEvolution: Standard time evolution
+    // ========================================================================
+
+    /**
+     * @brief Normal time evolution mode
+     *
+     * No modifications to computed derivatives. This is the default mode
+     * for production simulations.
+     */
+    struct NormalEvolution {
+        /// No convergence checking
+        static constexpr bool has_convergence_check = false;
+
+        /**
+         * @brief Modify derivatives (no-op for normal evolution)
+         *
+         * @tparam Derivs Derivative container type
+         * @tparam State State container type
+         * @param derivs Derivatives to potentially modify
+         * @param state Current state
+         */
+        template<class Derivs, class State>
+        static void modify_derivatives(Derivs & /* derivs */, const State & /* state */) {
+            // No-op
+        }
+    };
+
+    // ========================================================================
+    // RelaxationMode: Damped evolution toward equilibrium
+    // ========================================================================
+
+    /**
+     * @brief Relaxation mode for finding equilibrium configurations
+     *
+     * Adds velocity damping to accelerate convergence toward equilibrium.
+     * Useful for:
+     * - Lane-Emden polytropic spheres
+     * - Disk equilibria
+     * - Stellar structure relaxation
+     *
+     * @tparam Tvec Vector type
+     */
+    template<class Tvec>
+    struct RelaxationMode {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        /// This mode has convergence checking
+        static constexpr bool has_convergence_check = true;
+
+        // =====================================================================
+        // Damping parameters
+        // =====================================================================
+
+        /// Velocity damping coefficient: dv/dt += -velocity_damping * v
+        Tscal velocity_damping = Tscal{0.1};
+
+        /// Optional thermal damping coefficient
+        Tscal energy_damping = Tscal{0};
+
+        /// Force isothermal evolution (du/dt = 0)
+        bool isothermal = false;
+
+        /// Target temperature for isothermal or thermal damping
+        Tscal target_temperature = Tscal{0};
+
+        // =====================================================================
+        // Convergence criteria
+        // =====================================================================
+
+        /// Maximum velocity threshold for convergence
+        Tscal velocity_threshold = Tscal{1e-6};
+
+        /// Virial ratio threshold: |2K/W + 1| < virial_threshold
+        Tscal virial_threshold = Tscal{0.01};
+
+        /// Maximum relative density change threshold
+        Tscal density_threshold = Tscal{1e-6};
+
+        // =====================================================================
+        // Methods
+        // =====================================================================
+
+        /**
+         * @brief Apply damping to derivatives
+         *
+         * @tparam Derivs Derivative container type (must have acceleration, energy_rate)
+         * @tparam State State container type (must have velocity)
+         * @param derivs Derivatives to modify
+         * @param state Current state
+         */
+        template<class Derivs, class State>
+        void modify_derivatives(Derivs &derivs, const State &state) const {
+            // Velocity damping: dv/dt += -eta * v
+            derivs.acceleration -= velocity_damping * state.velocity;
+
+            if (isothermal) {
+                // Force constant temperature
+                derivs.energy_rate = Tscal{0};
+            } else if (energy_damping > Tscal{0}) {
+                // Damp toward target temperature
+                // Note: This requires temperature access in state
+                // For now, just zero energy rate if damping is set
+                derivs.energy_rate *= (Tscal{1} - energy_damping);
+            }
+        }
+
+        /**
+         * @brief Check if relaxation has converged
+         *
+         * @param max_velocity Maximum velocity magnitude across all particles
+         * @param virial_ratio Current virial ratio (2K/|W|)
+         * @param max_drho_rel Maximum relative density change rate
+         * @return true if all criteria are met
+         */
+        bool is_converged(Tscal max_velocity, Tscal virial_ratio, Tscal max_drho_rel) const {
+            return (max_velocity < velocity_threshold)
+                   && (sycl::fabs(virial_ratio - Tscal{1}) < virial_threshold)
+                   && (max_drho_rel < density_threshold);
+        }
+    };
+
+    // ========================================================================
+    // DustMode: Pressureless limit
+    // ========================================================================
+
+    /**
+     * @brief Dust (pressureless) mode
+     *
+     * Forces zero pressure contribution. Useful for:
+     * - Cold dark matter simulations
+     * - Pressureless collapse problems
+     */
+    struct DustMode {
+        /// No convergence checking
+        static constexpr bool has_convergence_check = false;
+
+        /**
+         * @brief Modify derivatives for dust limit
+         *
+         * Sets energy rate to zero (no thermal evolution).
+         *
+         * @tparam Derivs Derivative container type
+         * @tparam State State container type
+         * @param derivs Derivatives to modify
+         * @param state Current state (unused)
+         */
+        template<class Derivs, class State>
+        static void modify_derivatives(Derivs &derivs, const State & /* state */) {
+            // No thermal evolution in dust limit
+            derivs.energy_rate = 0;
+            // Note: Pressure = 0 is handled in EOS, not here
+        }
+    };
+
+} // namespace shammodels::gsph::modes

--- a/src/shammodels/gsph/include/shammodels/gsph/physics/MatterTraits.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/physics/MatterTraits.hpp
@@ -1,0 +1,169 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2025 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file MatterTraits.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Matter model traits for GSPH physics composition
+ *
+ * Defines the structure of matter models:
+ * - HydroMatter: Pure hydrodynamics (density, velocity, pressure, internal energy)
+ * - MHDMatter: Magnetohydrodynamics (adds B-field, divergence cleaning)
+ * - RadHydroMatter: Radiation hydrodynamics (adds cooling/heating)
+ *
+ * Each matter model specifies:
+ * - Field types (primitives, conserved variables)
+ * - Static flags for compile-time feature detection
+ * - Field name mappings
+ */
+
+#include "shambackends/sycl.hpp"
+#include "shambackends/vec.hpp"
+#include "shammodels/gsph/config/FieldNames.hpp"
+
+namespace shammodels::gsph::physics {
+
+    // ========================================================================
+    // HydroMatter: Pure hydrodynamics
+    // ========================================================================
+
+    /**
+     * @brief Pure hydrodynamics matter model
+     *
+     * Contains density, velocity, pressure, and internal energy.
+     * This is the simplest matter model, suitable for:
+     * - Shock tubes (Sod, Sedov)
+     * - Stellar structure (Lane-Emden)
+     * - Basic fluid dynamics
+     *
+     * @tparam Tvec Vector type (e.g., f64_3)
+     */
+    template<class Tvec>
+    struct HydroMatter {
+        using Tscal              = shambase::VecComponent<Tvec>;
+        static constexpr u32 dim = shambase::VectorProperties<Tvec>::dimension;
+
+        /// Primitive variables (physical quantities)
+        struct PrimitiveVars {
+            Tscal rho;      ///< Density \rho
+            Tvec velocity;  ///< 3-velocity v (Newtonian) or spatial 4-velocity (relativistic)
+            Tscal pressure; ///< Pressure P
+            Tscal uint;     ///< Specific internal energy u
+        };
+
+        /// Feature flags (compile-time)
+        static constexpr bool has_magnetic_field        = false;
+        static constexpr bool has_divergence_constraint = false;
+        static constexpr bool has_radiation_cooling     = false;
+        static constexpr u32 n_evolved_scalars          = 1; ///< Internal energy only
+
+        /// Field names from FieldNames.hpp
+        struct FieldNames {
+            static constexpr const char *velocity = names::newtonian::vxyz;
+            static constexpr const char *uint     = names::newtonian::uint;
+            static constexpr const char *density  = names::newtonian::density;
+            static constexpr const char *pressure = names::newtonian::pressure;
+        };
+    };
+
+    // ========================================================================
+    // MHDMatter: Magnetohydrodynamics (STUB)
+    // ========================================================================
+
+    /**
+     * @brief Magnetohydrodynamics matter model (STUB - not yet implemented)
+     *
+     * Extends HydroMatter with:
+     * - Magnetic field B
+     * - Divergence cleaning scalar psi (Dedner et al.)
+     *
+     * @tparam Tvec Vector type
+     */
+    template<class Tvec>
+    struct MHDMatter {
+        using Tscal              = shambase::VecComponent<Tvec>;
+        static constexpr u32 dim = shambase::VectorProperties<Tvec>::dimension;
+
+        struct PrimitiveVars {
+            Tscal rho;
+            Tvec velocity;
+            Tscal pressure;
+            Tscal uint;
+            Tvec B;    ///< Magnetic field
+            Tscal psi; ///< Dedner cleaning scalar
+        };
+
+        static constexpr bool has_magnetic_field        = true;
+        static constexpr bool has_divergence_constraint = true;
+        static constexpr bool has_radiation_cooling     = false;
+        static constexpr u32 n_evolved_scalars          = 2; ///< uint + psi
+
+        /// Dedner cleaning parameters
+        struct CleaningParams {
+            Tscal ch;      ///< Hyperbolic cleaning wave speed
+            Tscal cp;      ///< Parabolic damping coefficient
+            Tscal sigma_c; ///< ch/cp ratio parameter (typically 0.18)
+        };
+
+        /// Compute cleaning wave speed from local properties
+        SYCL_EXTERNAL static Tscal compute_ch(Tscal cs, Tscal v_alfven) {
+            return sycl::sqrt(cs * cs + v_alfven * v_alfven);
+        }
+
+        /// Alfven velocity
+        SYCL_EXTERNAL static Tscal alfven_speed(Tvec B, Tscal rho) {
+            return sycl::length(B) / sycl::sqrt(rho);
+        }
+    };
+
+    // ========================================================================
+    // RadHydroMatter: Radiation hydrodynamics (STUB)
+    // ========================================================================
+
+    /**
+     * @brief Radiation hydrodynamics matter model (STUB - not yet implemented)
+     *
+     * Adds optically thin cooling/heating to hydrodynamics.
+     * Suitable for:
+     * - ISM thermal instability (Koyama-Inutsuka, Inoue-Inutsuka)
+     * - Stellar atmospheres
+     *
+     * @tparam Tvec Vector type
+     */
+    template<class Tvec>
+    struct RadHydroMatter {
+        using Tscal              = shambase::VecComponent<Tvec>;
+        static constexpr u32 dim = shambase::VectorProperties<Tvec>::dimension;
+
+        struct PrimitiveVars {
+            Tscal rho;
+            Tvec velocity;
+            Tscal pressure;
+            Tscal uint;
+            // No explicit radiation field in optically thin limit
+            // Cooling is handled as source term in energy equation
+        };
+
+        static constexpr bool has_magnetic_field        = false;
+        static constexpr bool has_divergence_constraint = false;
+        static constexpr bool has_radiation_cooling     = true;
+        static constexpr bool is_optically_thin         = true;
+        static constexpr u32 n_evolved_scalars          = 1;
+
+        /// Cooling function model selection
+        enum class CoolingModel {
+            KoyamaInutsuka2000, ///< Equilibrium thermal instability
+            InoueInutsuka2006,  ///< Non-equilibrium atomic cooling
+            Tabulated           ///< User-provided table
+        };
+    };
+
+} // namespace shammodels::gsph::physics

--- a/src/shammodels/gsph/include/shammodels/gsph/physics/PhysicsComposition.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/physics/PhysicsComposition.hpp
@@ -1,0 +1,185 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2025 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file PhysicsComposition.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Compose physics from orthogonal traits
+ *
+ * This file provides the main template for combining:
+ * - Matter model (HydroMatter, MHDMatter, RadHydroMatter)
+ * - Relativity level (Newtonian, SR, GR)
+ * - Spacetime (Minkowski, Schwarzschild, Kerr, Numerical)
+ * - Solver mode (NormalEvolution, RelaxationMode, DustMode)
+ *
+ * The composition provides compile-time feature flags that control
+ * which solvergraph nodes are instantiated.
+ */
+
+#include "shammodels/gsph/physics/MatterTraits.hpp"
+#include "shammodels/gsph/physics/RelativityTraits.hpp"
+#include "shammodels/gsph/physics/SpacetimeTraits.hpp"
+#include <type_traits>
+
+// Forward declaration of solver modes (defined in SolverModes.hpp)
+namespace shammodels::gsph::modes {
+    struct NormalEvolution;
+    template<class Tvec>
+    struct RelaxationMode;
+    struct DustMode;
+} // namespace shammodels::gsph::modes
+
+namespace shammodels::gsph {
+
+    /**
+     * @brief Compose physics from orthogonal choices
+     *
+     * This is the main physics configuration template. Each template parameter
+     * represents an independent axis of physics choices:
+     *
+     * - MatterModel: What fields exist (hydro, MHD, radiation)
+     * - RelativityLevel: How equations transform (Newtonian, SR, GR)
+     * - SpacetimeModel: Geometry (flat, curved)
+     * - SolverMode: Evolution behavior (normal, relaxation, dust)
+     *
+     * @tparam Tvec Vector type (e.g., f64_3)
+     * @tparam MatterModel Matter traits template (e.g., physics::HydroMatter)
+     * @tparam RelativityLevel Relativity traits template
+     * @tparam SpacetimeModel Spacetime traits (default: MinkowskiSpacetime)
+     * @tparam SolverMode Solver mode (default: NormalEvolution)
+     */
+    template<
+        class Tvec,
+        template<class> class MatterModel,
+        template<class, class, class...> class RelativityLevel,
+        class SpacetimeModel = physics::MinkowskiSpacetime<Tvec>,
+        class SolverMode     = modes::NormalEvolution>
+    struct PhysicsComposition {
+        using Tscal              = shambase::VecComponent<Tvec>;
+        static constexpr u32 dim = shambase::VectorProperties<Tvec>::dimension;
+
+        // =====================================================================
+        // Component types
+        // =====================================================================
+
+        using Matter     = MatterModel<Tvec>;
+        using Spacetime  = SpacetimeModel;
+        using Relativity = RelativityLevel<Tvec, Matter, Spacetime>;
+        using Mode       = SolverMode;
+
+        // =====================================================================
+        // Derived types
+        // =====================================================================
+
+        using PrimitiveVars = typename Matter::PrimitiveVars;
+        using ConservedVars = typename Relativity::ConservedVars;
+
+        // =====================================================================
+        // Compile-time feature flags
+        // These control which solvergraph nodes are instantiated
+        // =====================================================================
+
+        /// Does this physics require primitive variable recovery?
+        /// (True for SR/GR, false for Newtonian)
+        static constexpr bool needs_primitive_recovery = Relativity::needs_primitive_recovery;
+
+        /// Does this physics have a Lorentz factor?
+        static constexpr bool needs_lorentz_factor = Relativity::needs_lorentz_factor;
+
+        /// Does this physics need metric data at each particle?
+        static constexpr bool needs_metric = Spacetime::is_curved;
+
+        /// Does this physics have divergence constraints (div B = 0)?
+        static constexpr bool needs_divergence_cleaning = Matter::has_divergence_constraint;
+
+        /// Does this physics have geometric source terms?
+        static constexpr bool needs_geometric_source = Spacetime::is_curved;
+
+        /// Does this physics have radiation cooling?
+        static constexpr bool needs_radiation_cooling = Matter::has_radiation_cooling;
+
+        /// Does this mode have convergence checking (relaxation)?
+        /// Uses SFINAE to check if SolverMode has static constexpr has_convergence_check
+        template<class T, class = void>
+        struct has_convergence_check_trait : std::false_type {};
+
+        template<class T>
+        struct has_convergence_check_trait<T, std::void_t<decltype(T::has_convergence_check)>>
+            : std::bool_constant<T::has_convergence_check> {};
+
+        static constexpr bool has_convergence_check
+            = has_convergence_check_trait<SolverMode>::value;
+    };
+
+    // =========================================================================
+    // Convenient type aliases for common configurations
+    // =========================================================================
+
+    // -------------------------------------------------------------------------
+    // Pure Hydrodynamics
+    // -------------------------------------------------------------------------
+
+    /// Newtonian hydrodynamics (default, most common)
+    template<class Tvec>
+    using NewtonianHydro
+        = PhysicsComposition<Tvec, physics::HydroMatter, physics::NewtonianPhysics>;
+
+    /// Special Relativistic hydrodynamics (STUB)
+    template<class Tvec>
+    using SRHydro = PhysicsComposition<Tvec, physics::HydroMatter, physics::SRPhysics>;
+
+    // GRHydro requires a metric type parameter, so it's not a simple alias
+    // Usage: PhysicsComposition<Tvec, HydroMatter, GRPhysics, SchwarzschildSpacetime<Tvec>>
+
+    // -------------------------------------------------------------------------
+    // Magnetohydrodynamics (STUBS)
+    // -------------------------------------------------------------------------
+
+    /// Newtonian MHD
+    template<class Tvec>
+    using NewtonianMHD = PhysicsComposition<Tvec, physics::MHDMatter, physics::NewtonianPhysics>;
+
+    /// Special Relativistic MHD
+    template<class Tvec>
+    using SRMHD = PhysicsComposition<Tvec, physics::MHDMatter, physics::SRPhysics>;
+
+    // -------------------------------------------------------------------------
+    // Radiation Hydrodynamics (STUBS)
+    // -------------------------------------------------------------------------
+
+    /// Newtonian radiation hydrodynamics
+    template<class Tvec>
+    using NewtonianRadHydro
+        = PhysicsComposition<Tvec, physics::RadHydroMatter, physics::NewtonianPhysics>;
+
+    // -------------------------------------------------------------------------
+    // Special Modes
+    // -------------------------------------------------------------------------
+
+    /// Newtonian hydrodynamics with relaxation damping (Lane-Emden equilibrium)
+    template<class Tvec>
+    using NewtonianHydroRelaxation = PhysicsComposition<
+        Tvec,
+        physics::HydroMatter,
+        physics::NewtonianPhysics,
+        physics::MinkowskiSpacetime<Tvec>,
+        modes::RelaxationMode<Tvec>>;
+
+    /// Newtonian hydrodynamics in dust (pressureless) limit
+    template<class Tvec>
+    using NewtonianHydroDust = PhysicsComposition<
+        Tvec,
+        physics::HydroMatter,
+        physics::NewtonianPhysics,
+        physics::MinkowskiSpacetime<Tvec>,
+        modes::DustMode>;
+
+} // namespace shammodels::gsph

--- a/src/shammodels/gsph/include/shammodels/gsph/physics/RelativityTraits.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/physics/RelativityTraits.hpp
@@ -1,0 +1,262 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2025 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file RelativityTraits.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Relativity level traits for GSPH physics composition
+ *
+ * Defines the relativity treatment:
+ * - NewtonianPhysics: Classical mechanics, trivial primitive recovery
+ * - SRPhysics: Special Relativity, 1D/2D root finding for primitives
+ * - GRPhysics: General Relativity, metric-dependent recovery
+ *
+ * Each relativity level provides:
+ * - Conserved variable structure
+ * - Primitive recovery algorithm
+ * - Signal speed calculation
+ */
+
+#include "shambackends/sycl.hpp"
+#include "shambackends/vec.hpp"
+#include "shammodels/gsph/physics/SpacetimeTraits.hpp"
+
+namespace shammodels::gsph::physics {
+
+    // ========================================================================
+    // NewtonianPhysics: Classical mechanics
+    // ========================================================================
+
+    /**
+     * @brief Newtonian (classical) physics
+     *
+     * In Newtonian physics:
+     * - Conserved = Primitive (trivial inversion)
+     * - No Lorentz factor
+     * - Signal speed = |v| + c_s
+     *
+     * @tparam Tvec Vector type
+     * @tparam MatterT Matter model (HydroMatter, MHDMatter, etc.)
+     * @tparam SpacetimeT Spacetime (must be MinkowskiSpacetime for Newtonian)
+     */
+    template<class Tvec, class MatterT, class SpacetimeT = MinkowskiSpacetime<Tvec>>
+    struct NewtonianPhysics {
+        using Tscal              = shambase::VecComponent<Tvec>;
+        static constexpr u32 dim = shambase::VectorProperties<Tvec>::dimension;
+
+        using Matter    = MatterT;
+        using Spacetime = SpacetimeT;
+
+        /// Feature flags
+        static constexpr bool needs_primitive_recovery = false;
+        static constexpr bool needs_lorentz_factor     = false;
+        static constexpr bool needs_metric             = false;
+
+        /// Conserved variables (same as primitive for Newtonian hydro)
+        struct ConservedVars {
+            Tscal rho;     ///< Density
+            Tvec momentum; ///< Momentum density rho * v
+            Tscal E;       ///< Total energy density (kinetic + internal)
+        };
+
+        /**
+         * @brief Recover primitive variables from conserved (trivial for Newtonian)
+         *
+         * @param U Conserved variables
+         * @param W_old Previous primitives (unused, for interface compatibility)
+         * @param gamma Adiabatic index (for pressure calculation)
+         * @return Primitive variables
+         */
+        template<class EOSType>
+        SYCL_EXTERNAL static auto recover_primitives(
+            const ConservedVars &U,
+            const typename Matter::PrimitiveVars & /* W_old */,
+            const EOSType &eos) -> typename Matter::PrimitiveVars {
+
+            typename Matter::PrimitiveVars W;
+            W.rho      = U.rho;
+            W.velocity = U.momentum / U.rho;
+
+            Tscal v2 = sycl::dot(W.velocity, W.velocity);
+            Tscal ke = Tscal{0.5} * v2;
+            W.uint   = U.E / U.rho - ke;
+
+            W.pressure = eos.pressure_from_rho_u(W.rho, W.uint);
+
+            return W;
+        }
+
+        /**
+         * @brief Maximum signal speed for CFL condition
+         *
+         * @param W Primitive variables
+         * @param cs Sound speed
+         * @return Maximum wave speed |v| + c_s
+         */
+        SYCL_EXTERNAL static Tscal max_signal_speed(
+            const typename Matter::PrimitiveVars &W, Tscal cs) {
+            return sycl::length(W.velocity) + cs;
+        }
+
+        /**
+         * @brief Convert primitives to conserved
+         *
+         * @param W Primitive variables
+         * @return Conserved variables
+         */
+        SYCL_EXTERNAL static ConservedVars to_conserved(const typename Matter::PrimitiveVars &W) {
+            ConservedVars U;
+            U.rho      = W.rho;
+            U.momentum = W.rho * W.velocity;
+
+            Tscal v2 = sycl::dot(W.velocity, W.velocity);
+            U.E      = W.rho * (W.uint + Tscal{0.5} * v2);
+
+            return U;
+        }
+    };
+
+    // ========================================================================
+    // SRPhysics: Special Relativity (STUB)
+    // ========================================================================
+
+    /**
+     * @brief Special Relativistic physics (STUB - not yet implemented)
+     *
+     * In SR:
+     * - Conserved: D = rho W, S = rho h W^2 v, tau = rho h W^2 - P - D
+     * - Primitive recovery: 1D root find for hydro, 2D for MHD
+     * - Signal speed: relativistic addition
+     *
+     * @tparam Tvec Vector type
+     * @tparam MatterT Matter model
+     */
+    template<class Tvec, class MatterT>
+    struct SRPhysics {
+        using Tscal              = shambase::VecComponent<Tvec>;
+        static constexpr u32 dim = shambase::VectorProperties<Tvec>::dimension;
+
+        using Matter    = MatterT;
+        using Spacetime = MinkowskiSpacetime<Tvec>; // Always flat for SR
+
+        static constexpr bool needs_primitive_recovery = true;
+        static constexpr bool needs_lorentz_factor     = true;
+        static constexpr bool needs_metric             = false;
+
+        /// Conserved variables (relativistic)
+        struct ConservedVars {
+            Tscal D;   ///< D = rho * W (relativistic mass density)
+            Tvec S;    ///< S^i = rho * h * W^2 * v^i (momentum density)
+            Tscal tau; ///< tau = rho * h * W^2 - P - D (energy - rest mass)
+        };
+
+        /// Lorentz factor from velocity
+        SYCL_EXTERNAL static Tscal lorentz_factor(Tvec v) {
+            Tscal v2 = sycl::dot(v, v);
+            return Tscal{1} / sycl::sqrt(Tscal{1} - v2); // c = 1
+        }
+
+        /**
+         * @brief Recover primitive variables (STUB)
+         *
+         * Uses Newton-Raphson iteration to solve for pressure.
+         * For hydro: 1D solve
+         * For MHD: 2D solve for (P, W) or similar
+         */
+        template<class EOSType>
+        SYCL_EXTERNAL static auto recover_primitives(
+            const ConservedVars &U,
+            const typename Matter::PrimitiveVars &W_old,
+            const EOSType &eos,
+            u32 max_iter = 50,
+            Tscal tol    = Tscal{1e-10}) -> typename Matter::PrimitiveVars {
+            // STUB: Not implemented
+            (void) U;
+            (void) eos;
+            (void) max_iter;
+            (void) tol;
+            return W_old;
+        }
+
+        /// Maximum signal speed (relativistic addition)
+        SYCL_EXTERNAL static Tscal max_signal_speed(
+            const typename Matter::PrimitiveVars &W, Tscal cs) {
+            Tscal v = sycl::length(W.velocity);
+            // Relativistic velocity addition: (v + cs) / (1 + v*cs)
+            return (v + cs) / (Tscal{1} + v * cs);
+        }
+    };
+
+    // ========================================================================
+    // GRPhysics: General Relativity (STUB)
+    // ========================================================================
+
+    /**
+     * @brief General Relativistic physics (STUB - not yet implemented)
+     *
+     * In GR with fixed spacetime:
+     * - Conserved variables include metric factors (sqrt(gamma))
+     * - Primitive recovery requires metric at each point
+     * - Geometric source terms from Christoffel symbols
+     *
+     * @tparam Tvec Vector type
+     * @tparam MatterT Matter model
+     * @tparam SpacetimeT Spacetime model (must be curved)
+     */
+    template<class Tvec, class MatterT, class SpacetimeT>
+    struct GRPhysics {
+        using Tscal              = shambase::VecComponent<Tvec>;
+        static constexpr u32 dim = shambase::VectorProperties<Tvec>::dimension;
+
+        using Matter    = MatterT;
+        using Spacetime = SpacetimeT;
+
+        static constexpr bool needs_primitive_recovery = true;
+        static constexpr bool needs_lorentz_factor     = true;
+        static constexpr bool needs_metric             = true;
+
+        /// Conserved variables (GR form)
+        struct ConservedVars {
+            Tscal D;   ///< sqrt(gamma) * rho * W
+            Tvec S;    ///< sqrt(gamma) * T^0_i
+            Tscal tau; ///< sqrt(gamma) * (T^00 - D)
+        };
+
+        /**
+         * @brief Recover primitives with metric (STUB)
+         *
+         * @param U Conserved variables
+         * @param W_old Previous primitives (initial guess)
+         * @param eos Equation of state
+         * @param spacetime Spacetime geometry
+         * @param position Particle position (for metric evaluation)
+         */
+        template<class EOSType>
+        SYCL_EXTERNAL static auto recover_primitives(
+            const ConservedVars &U,
+            const typename Matter::PrimitiveVars &W_old,
+            const EOSType &eos,
+            const Spacetime &spacetime,
+            Tvec position,
+            u32 max_iter = 50,
+            Tscal tol    = Tscal{1e-10}) -> typename Matter::PrimitiveVars {
+            // STUB: Not implemented
+            (void) U;
+            (void) eos;
+            (void) spacetime;
+            (void) position;
+            (void) max_iter;
+            (void) tol;
+            return W_old;
+        }
+    };
+
+} // namespace shammodels::gsph::physics

--- a/src/shammodels/gsph/include/shammodels/gsph/physics/SpacetimeTraits.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/physics/SpacetimeTraits.hpp
@@ -1,0 +1,197 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2025 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file SpacetimeTraits.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Spacetime traits for GSPH physics composition
+ *
+ * Defines spacetime geometry:
+ * - MinkowskiSpacetime: Flat spacetime (Newtonian limit or SR)
+ * - SchwarzschildSpacetime: Static black hole (STUB)
+ * - KerrSpacetime: Rotating black hole (STUB)
+ * - NumericalSpacetime: Tabulated metric from GR solver (STUB)
+ *
+ * Each spacetime provides:
+ * - Metric components (lapse, shift, spatial metric)
+ * - Index raising/lowering operations
+ * - Geometric source terms (Christoffel contractions)
+ */
+
+#include "shambackends/sycl.hpp"
+#include "shambackends/vec.hpp"
+
+namespace shammodels::gsph::physics {
+
+    // ========================================================================
+    // MinkowskiSpacetime: Flat spacetime
+    // ========================================================================
+
+    /**
+     * @brief Flat Minkowski spacetime
+     *
+     * Used for Newtonian physics (trivial metric) and Special Relativity.
+     * All metric operations are identity/trivial - zero overhead.
+     *
+     * @tparam Tvec Vector type
+     */
+    template<class Tvec>
+    struct MinkowskiSpacetime {
+        using Tscal              = shambase::VecComponent<Tvec>;
+        static constexpr u32 dim = shambase::VectorProperties<Tvec>::dimension;
+
+        /// Feature flags
+        static constexpr bool is_curved            = false;
+        static constexpr bool is_dynamic           = false;
+        static constexpr bool needs_metric_storage = false;
+
+        /// Lapse function alpha = 1
+        SYCL_EXTERNAL static Tscal lapse(Tvec /* x */) { return Tscal{1}; }
+
+        /// Shift vector beta^i = 0
+        SYCL_EXTERNAL static Tvec shift(Tvec /* x */) { return Tvec{0, 0, 0}; }
+
+        /// Spatial metric determinant sqrt(gamma) = 1
+        SYCL_EXTERNAL static Tscal spatial_metric_det(Tvec /* x */) { return Tscal{1}; }
+
+        /// Dot product with 3-metric: gamma_ij a^i b^j = delta_ij a^i b^j
+        SYCL_EXTERNAL static Tscal dot_3metric(Tvec a, Tvec b) { return sycl::dot(a, b); }
+
+        /// Raise index: v^i = gamma^{ij} v_j = delta^{ij} v_j = v_i
+        SYCL_EXTERNAL static Tvec raise_index(Tvec v_lower) { return v_lower; }
+
+        /// Lower index: v_i = gamma_{ij} v^j = delta_{ij} v^j = v^i
+        SYCL_EXTERNAL static Tvec lower_index(Tvec v_upper) { return v_upper; }
+
+        /// Geometric source terms (none for flat spacetime)
+        template<class Derivs, class State>
+        SYCL_EXTERNAL static void add_geometric_source(
+            Derivs & /* derivs */, Tvec /* x */, const State & /* W */) {
+            // No-op for flat spacetime
+        }
+    };
+
+    // ========================================================================
+    // SchwarzschildSpacetime: Static black hole (STUB)
+    // ========================================================================
+
+    /**
+     * @brief Schwarzschild spacetime (STUB - not yet implemented)
+     *
+     * Static, spherically symmetric black hole.
+     * Metric in Schwarzschild coordinates:
+     *   ds^2 = -(1 - r_s/r) dt^2 + (1 - r_s/r)^{-1} dr^2 + r^2 d\Omega^2
+     *
+     * @tparam Tvec Vector type
+     */
+    template<class Tvec>
+    struct SchwarzschildSpacetime {
+        using Tscal              = shambase::VecComponent<Tvec>;
+        static constexpr u32 dim = shambase::VectorProperties<Tvec>::dimension;
+
+        static constexpr bool is_curved            = true;
+        static constexpr bool is_dynamic           = false;
+        static constexpr bool needs_metric_storage = false; // Analytic
+
+        Tscal M;     ///< Black hole mass (geometric units G=c=1)
+        Tvec center; ///< Black hole position
+
+        SchwarzschildSpacetime(Tscal mass, Tvec center = Tvec{0, 0, 0}) : M(mass), center(center) {}
+
+        /// Lapse: alpha = sqrt(1 - r_s/r)
+        SYCL_EXTERNAL Tscal lapse(Tvec x) const {
+            Tscal r  = sycl::length(x - center);
+            Tscal rs = Tscal{2} * M;
+            return sycl::sqrt(Tscal{1} - rs / r);
+        }
+
+        /// Shift: beta^i = 0 in Schwarzschild coordinates
+        SYCL_EXTERNAL Tvec shift(Tvec /* x */) const { return Tvec{0, 0, 0}; }
+
+        /// Geometric source terms
+        template<class Derivs, class State>
+        SYCL_EXTERNAL void add_geometric_source(Derivs &derivs, Tvec x, const State &W) const {
+            // Christoffel contraction: -Gamma^i_{mu nu} T^{mu nu}
+            // Implementation requires full stress-energy tensor
+            (void) derivs;
+            (void) x;
+            (void) W;
+            // STUB: Not implemented
+        }
+    };
+
+    // ========================================================================
+    // KerrSpacetime: Rotating black hole (STUB)
+    // ========================================================================
+
+    /**
+     * @brief Kerr spacetime (STUB - not yet implemented)
+     *
+     * Rotating black hole with spin parameter a = J/M.
+     * Frame dragging effects near the ergosphere.
+     *
+     * @tparam Tvec Vector type
+     */
+    template<class Tvec>
+    struct KerrSpacetime {
+        using Tscal              = shambase::VecComponent<Tvec>;
+        static constexpr u32 dim = shambase::VectorProperties<Tvec>::dimension;
+
+        static constexpr bool is_curved            = true;
+        static constexpr bool is_dynamic           = false;
+        static constexpr bool needs_metric_storage = false;
+
+        Tscal M;        ///< Black hole mass
+        Tscal a;        ///< Spin parameter (a = J/M, |a| <= M)
+        Tvec center;    ///< Black hole position
+        Tvec spin_axis; ///< Spin axis direction (unit vector)
+
+        KerrSpacetime(
+            Tscal mass, Tscal spin, Tvec center = Tvec{0, 0, 0}, Tvec axis = Tvec{0, 0, 1})
+            : M(mass), a(spin), center(center), spin_axis(axis) {}
+
+        // STUB: Metric functions not yet implemented
+        SYCL_EXTERNAL Tscal lapse(Tvec /* x */) const { return Tscal{1}; }
+        SYCL_EXTERNAL Tvec shift(Tvec /* x */) const { return Tvec{0, 0, 0}; }
+    };
+
+    // ========================================================================
+    // NumericalSpacetime: Tabulated metric (STUB)
+    // ========================================================================
+
+    /**
+     * @brief Numerical/tabulated spacetime (STUB - not yet implemented)
+     *
+     * Metric data interpolated from an external grid, e.g., from a GR
+     * evolution code (Einstein Toolkit, BAM, etc.).
+     *
+     * @tparam Tvec Vector type
+     */
+    template<class Tvec>
+    struct NumericalSpacetime {
+        using Tscal              = shambase::VecComponent<Tvec>;
+        static constexpr u32 dim = shambase::VectorProperties<Tvec>::dimension;
+
+        static constexpr bool is_curved            = true;
+        static constexpr bool is_dynamic           = true; // May evolve in time
+        static constexpr bool needs_metric_storage = true;
+
+        /// Interpolation methods
+        enum class InterpMethod { NGP, CIC, TSC };
+        InterpMethod interp_method = InterpMethod::CIC;
+
+        // STUB: Metric field storage would be added here
+        // std::shared_ptr<solvergraph::Field<Tscal>> lapse_field;
+        // std::shared_ptr<solvergraph::Field<Tvec>> shift_field;
+        // etc.
+    };
+
+} // namespace shammodels::gsph::physics

--- a/src/shammodels/gsph/include/shammodels/gsph/solvergraph/edges/GradientsEdge.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/solvergraph/edges/GradientsEdge.hpp
@@ -1,0 +1,108 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2025 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file GradientsEdge.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Solvergraph edge for MUSCL gradient fields
+ *
+ * Bundles all gradient fields used in MUSCL reconstruction:
+ * - grad_density: \nabla \rho
+ * - grad_pressure: \nabla P
+ * - grad_vx, grad_vy, grad_vz: \nabla v
+ */
+
+#include "shamrock/solvergraph/Field.hpp"
+#include "shamrock/solvergraph/IEdgeNamed.hpp"
+
+namespace shammodels::gsph::solvergraph {
+
+    /**
+     * @brief Edge bundling MUSCL gradient fields
+     *
+     * Groups all gradient fields together for cleaner storage management.
+     * Only allocated when MUSCL reconstruction is enabled.
+     *
+     * @tparam Tvec Vector type (e.g., f64_3)
+     */
+    template<class Tvec>
+    class GradientsEdge : public shamrock::solvergraph::IEdgeNamed {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        public:
+        /// Gradient fields (each stores vector gradient per particle)
+        std::shared_ptr<shamrock::solvergraph::Field<Tvec>> grad_density;
+        std::shared_ptr<shamrock::solvergraph::Field<Tvec>> grad_pressure;
+        std::shared_ptr<shamrock::solvergraph::Field<Tvec>> grad_vx;
+        std::shared_ptr<shamrock::solvergraph::Field<Tvec>> grad_vy;
+        std::shared_ptr<shamrock::solvergraph::Field<Tvec>> grad_vz;
+
+        /**
+         * @brief Construct gradient edge
+         *
+         * @param name Edge name
+         * @param tex_symbol TeX symbol for visualization
+         */
+        GradientsEdge(std::string name, std::string tex_symbol)
+            : IEdgeNamed(std::move(name), std::move(tex_symbol)) {
+            initialize_fields();
+        }
+
+        /**
+         * @brief Ensure all gradient fields are sized correctly
+         *
+         * @param sizes Particle counts per patch
+         */
+        void ensure_sizes(const shambase::DistributedData<u32> &sizes) {
+            grad_density->ensure_sizes(sizes);
+            grad_pressure->ensure_sizes(sizes);
+            grad_vx->ensure_sizes(sizes);
+            grad_vy->ensure_sizes(sizes);
+            grad_vz->ensure_sizes(sizes);
+        }
+
+        /**
+         * @brief Free all allocations
+         */
+        void free_alloc() override {
+            if (grad_density) {
+                grad_density->free_alloc();
+            }
+            if (grad_pressure) {
+                grad_pressure->free_alloc();
+            }
+            if (grad_vx) {
+                grad_vx->free_alloc();
+            }
+            if (grad_vy) {
+                grad_vy->free_alloc();
+            }
+            if (grad_vz) {
+                grad_vz->free_alloc();
+            }
+        }
+
+        private:
+        void initialize_fields() {
+            grad_density = std::make_shared<shamrock::solvergraph::Field<Tvec>>(
+                1, "grad_density", "\\nabla\\rho");
+            grad_pressure = std::make_shared<shamrock::solvergraph::Field<Tvec>>(
+                1, "grad_pressure", "\\nabla P");
+            grad_vx
+                = std::make_shared<shamrock::solvergraph::Field<Tvec>>(1, "grad_vx", "\\nabla v_x");
+            grad_vy
+                = std::make_shared<shamrock::solvergraph::Field<Tvec>>(1, "grad_vy", "\\nabla v_y");
+            grad_vz
+                = std::make_shared<shamrock::solvergraph::Field<Tvec>>(1, "grad_vz", "\\nabla v_z");
+        }
+    };
+
+} // namespace shammodels::gsph::solvergraph

--- a/src/shammodels/gsph/include/shammodels/gsph/solvergraph/edges/RiemannResultEdge.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/solvergraph/edges/RiemannResultEdge.hpp
@@ -1,0 +1,104 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2025 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file RiemannResultEdge.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Solvergraph edge for Riemann solver results
+ *
+ * Stores the interface state (p*, v*) from Riemann problem solutions.
+ * For Newtonian hydro, this is a scalar pressure and velocity.
+ * For MHD/relativistic, this would include full flux.
+ */
+
+#include "shambackends/vec.hpp"
+#include "shamrock/solvergraph/IEdgeNamed.hpp"
+
+namespace shammodels::gsph::solvergraph {
+
+    /**
+     * @brief Result from Riemann solver for a particle pair
+     *
+     * Newtonian hydro version: just p* and v* (scalar along pair axis).
+     *
+     * @tparam Tscal Scalar type
+     */
+    template<class Tscal>
+    struct RiemannResult {
+        Tscal p_star; ///< Interface pressure
+        Tscal v_star; ///< Interface velocity (along pair axis)
+    };
+
+    /**
+     * @brief Edge holding Riemann solver results
+     *
+     * This edge stores the results of Riemann problems for all particle pairs.
+     * Currently a placeholder - the actual storage depends on the neighbor
+     * cache structure and how pair data is organized.
+     *
+     * For now, Riemann results are computed and consumed within UpdateDerivs
+     * without explicit storage. This edge is provided for future refactoring
+     * to separate Riemann solving from force accumulation.
+     *
+     * @tparam Tvec Vector type
+     */
+    template<class Tvec>
+    class RiemannResultEdge : public shamrock::solvergraph::IEdgeNamed {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        public:
+        using Result = RiemannResult<Tscal>;
+
+        RiemannResultEdge(std::string name, std::string tex_symbol)
+            : IEdgeNamed(std::move(name), std::move(tex_symbol)) {}
+
+        void free_alloc() override {
+            // Placeholder: storage not yet implemented
+        }
+    };
+
+    // =========================================================================
+    // Stubs for extended Riemann results
+    // =========================================================================
+
+    /**
+     * @brief MHD Riemann result (STUB)
+     *
+     * For MHD, the Riemann problem returns additional quantities:
+     * - B_star: Interface magnetic field
+     * - Full flux state for HLLD solver
+     */
+    template<class Tvec>
+    struct MHDRiemannResult {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        Tscal p_star;
+        Tscal v_star;
+        Tvec B_star; ///< Interface magnetic field
+        // Additional flux components for HLLD
+    };
+
+    /**
+     * @brief SR Riemann result (STUB)
+     *
+     * For special relativity, includes relativistic corrections.
+     */
+    template<class Tvec>
+    struct SRRiemannResult {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        Tscal p_star;
+        Tscal v_star;
+        Tscal W_star; ///< Interface Lorentz factor
+        // Full flux for relativistic HLLC
+    };
+
+} // namespace shammodels::gsph::solvergraph

--- a/src/shammodels/gsph/include/shammodels/gsph/solvergraph/nodes/ComputeEOSNode.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/solvergraph/nodes/ComputeEOSNode.hpp
@@ -1,0 +1,181 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2025 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file ComputeEOSNode.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Solvergraph node for equation of state computation
+ *
+ * Computes thermodynamic quantities (pressure, sound speed) from
+ * density and internal energy using the configured EOS.
+ *
+ * For Newtonian: P = (\gamma - 1) \rho u, c_s = \sqrt{\gamma P / \rho}
+ * For SR: Extended to include enthalpy and relativistic sound speed
+ */
+
+#include "shamrock/solvergraph/Field.hpp"
+#include "shamrock/solvergraph/INode.hpp"
+#include "shamrock/solvergraph/Indexes.hpp"
+
+namespace shammodels::gsph::solvergraph {
+
+    /**
+     * @brief Compute thermodynamic quantities from EOS
+     *
+     * This node wraps EOS evaluation for all particles.
+     * Different EOS types (ideal gas, polytrope, tabulated) are handled
+     * via the EOSType template parameter.
+     *
+     * Inputs:
+     * - density: SPH-summed density
+     * - uint: Specific internal energy
+     * - part_counts: Particle counts per patch
+     *
+     * Outputs:
+     * - pressure: Thermodynamic pressure
+     * - soundspeed: Local sound speed
+     *
+     * @tparam Tvec Vector type
+     * @tparam EOSType Equation of state type (must have P(rho, u), cs(rho, u))
+     */
+    template<class Tvec, class EOSType>
+    class ComputeEOSNode : public shamrock::solvergraph::INode {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        /// EOS instance
+        EOSType eos;
+
+        public:
+        /**
+         * @brief Edge container for type-safe access
+         */
+        struct Edges {
+            const shamrock::solvergraph::Indexes<u32> &part_counts;
+            const shamrock::solvergraph::Field<Tscal> &density;
+            const shamrock::solvergraph::Field<Tscal> &uint;
+            shamrock::solvergraph::Field<Tscal> &pressure;
+            shamrock::solvergraph::Field<Tscal> &soundspeed;
+        };
+
+        /**
+         * @brief Construct EOS computation node
+         *
+         * @param eos Equation of state instance
+         */
+        explicit ComputeEOSNode(EOSType eos) : eos(std::move(eos)) {}
+
+        /**
+         * @brief Set input/output edges
+         */
+        void set_edges(
+            std::shared_ptr<shamrock::solvergraph::Indexes<u32>> part_counts,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> density,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> uint,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> pressure,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> soundspeed) {
+            __internal_set_ro_edges({part_counts, density, uint});
+            __internal_set_rw_edges({pressure, soundspeed});
+        }
+
+        /**
+         * @brief Get typed edge references
+         */
+        Edges get_edges() {
+            return Edges{
+                get_ro_edge<shamrock::solvergraph::Indexes<u32>>(0),
+                get_ro_edge<shamrock::solvergraph::Field<Tscal>>(1),
+                get_ro_edge<shamrock::solvergraph::Field<Tscal>>(2),
+                get_rw_edge<shamrock::solvergraph::Field<Tscal>>(0),
+                get_rw_edge<shamrock::solvergraph::Field<Tscal>>(1)};
+        }
+
+        /**
+         * @brief Get the EOS instance
+         */
+        const EOSType &get_eos() const { return eos; }
+
+        std::string _impl_get_label() const override { return "ComputeEOS"; }
+
+        std::string _impl_get_tex() const override { return "P, c_s \\leftarrow \\rho, u"; }
+
+        protected:
+        /**
+         * @brief Execute the computation
+         *
+         * Evaluates EOS for all particles to compute pressure and sound speed.
+         */
+        void _impl_evaluate_internal() override;
+    };
+
+    // =========================================================================
+    // Extended EOS nodes for different physics (STUBS)
+    // =========================================================================
+
+    /**
+     * @brief SR EOS node (STUB)
+     *
+     * For special relativity, EOS evaluation also computes:
+     * - Specific enthalpy h = 1 + u + P/\rho
+     * - Relativistic sound speed
+     *
+     * @tparam Tvec Vector type
+     * @tparam EOSType Equation of state type
+     */
+    template<class Tvec, class EOSType>
+    class ComputeEOSSRNode : public shamrock::solvergraph::INode {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        EOSType eos;
+
+        public:
+        struct Edges {
+            const shamrock::solvergraph::Indexes<u32> &part_counts;
+            const shamrock::solvergraph::Field<Tscal> &density;
+            const shamrock::solvergraph::Field<Tscal> &uint;
+            shamrock::solvergraph::Field<Tscal> &pressure;
+            shamrock::solvergraph::Field<Tscal> &soundspeed;
+            shamrock::solvergraph::Field<Tscal> &enthalpy;
+        };
+
+        explicit ComputeEOSSRNode(EOSType eos) : eos(std::move(eos)) {}
+
+        void set_edges(
+            std::shared_ptr<shamrock::solvergraph::Indexes<u32>> part_counts,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> density,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> uint,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> pressure,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> soundspeed,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> enthalpy) {
+            __internal_set_ro_edges({part_counts, density, uint});
+            __internal_set_rw_edges({pressure, soundspeed, enthalpy});
+        }
+
+        Edges get_edges() {
+            return Edges{
+                get_ro_edge<shamrock::solvergraph::Indexes<u32>>(0),
+                get_ro_edge<shamrock::solvergraph::Field<Tscal>>(1),
+                get_ro_edge<shamrock::solvergraph::Field<Tscal>>(2),
+                get_rw_edge<shamrock::solvergraph::Field<Tscal>>(0),
+                get_rw_edge<shamrock::solvergraph::Field<Tscal>>(1),
+                get_rw_edge<shamrock::solvergraph::Field<Tscal>>(2)};
+        }
+
+        std::string _impl_get_label() const override { return "ComputeEOS_SR"; }
+
+        std::string _impl_get_tex() const override { return "P, c_s, h \\leftarrow \\rho, u"; }
+
+        protected:
+        void _impl_evaluate_internal() override {
+            // STUB: SR EOS computation not yet implemented
+        }
+    };
+
+} // namespace shammodels::gsph::solvergraph

--- a/src/shammodels/gsph/include/shammodels/gsph/solvergraph/nodes/ComputeGradientsNode.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/solvergraph/nodes/ComputeGradientsNode.hpp
@@ -1,0 +1,184 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2025 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file ComputeGradientsNode.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Solvergraph node for MUSCL gradient computation
+ *
+ * Computes SPH gradients of primitive variables for second-order
+ * MUSCL reconstruction at particle pair interfaces.
+ *
+ * Gradients computed:
+ * - \nabla \rho (density gradient)
+ * - \nabla P (pressure gradient)
+ * - \nabla v_x, \nabla v_y, \nabla v_z (velocity gradients)
+ *
+ * For MHD: additional \nabla B_x, \nabla B_y, \nabla B_z
+ */
+
+#include "shambackends/vec.hpp"
+#include "shammodels/gsph/solvergraph/edges/GradientsEdge.hpp"
+#include "shamrock/solvergraph/Field.hpp"
+#include "shamrock/solvergraph/FieldRefs.hpp"
+#include "shamrock/solvergraph/INode.hpp"
+#include "shamrock/solvergraph/Indexes.hpp"
+
+namespace shammodels::gsph::solvergraph {
+
+    /**
+     * @brief Compute MUSCL reconstruction gradients
+     *
+     * Uses SPH gradient estimation to compute gradients of primitive
+     * variables. These gradients are used for linear reconstruction
+     * at particle pair interfaces.
+     *
+     * The gradient formula uses the omega-corrected kernel gradient:
+     * \nabla f_a = (1/\Omega_a) \sum_b (m_b/\rho_b) (f_b - f_a) \nabla W_{ab}
+     *
+     * Slope limiters are applied to prevent oscillations.
+     *
+     * Inputs:
+     * - positions_with_ghosts: Particle positions (merged with ghosts)
+     * - hpart_with_ghosts: Smoothing lengths (merged with ghosts)
+     * - omega: Grad-h correction factor
+     * - density: SPH density
+     * - pressure: Thermodynamic pressure
+     * - velocity: Particle velocities (FieldRefs for component access)
+     * - part_counts: Particle counts per patch
+     *
+     * Outputs:
+     * - gradients: GradientsEdge containing all gradient fields
+     *
+     * @tparam Tvec Vector type
+     * @tparam SPHKernel SPH kernel template
+     */
+    template<class Tvec, template<class> class SPHKernel>
+    class ComputeGradientsNode : public shamrock::solvergraph::INode {
+        using Tscal  = shambase::VecComponent<Tvec>;
+        using Kernel = SPHKernel<Tscal>;
+
+        /// Slope limiter type (0 = none, 1 = minmod, 2 = van Leer, 3 = MC)
+        u32 limiter_type;
+
+        /// Slope limiter parameter (typically 1.0-2.0)
+        Tscal limiter_param;
+
+        public:
+        /**
+         * @brief Edge container for type-safe access
+         */
+        struct Edges {
+            const shamrock::solvergraph::Indexes<u32> &part_counts;
+            const shamrock::solvergraph::FieldRefs<Tvec> &positions_with_ghosts;
+            const shamrock::solvergraph::FieldRefs<Tscal> &hpart_with_ghosts;
+            const shamrock::solvergraph::Field<Tscal> &omega;
+            const shamrock::solvergraph::Field<Tscal> &density;
+            const shamrock::solvergraph::Field<Tscal> &pressure;
+            const shamrock::solvergraph::FieldRefs<Tvec> &velocity_with_ghosts;
+            GradientsEdge<Tvec> &gradients;
+        };
+
+        /**
+         * @brief Construct gradient computation node
+         *
+         * @param limiter_type Slope limiter type (default: 1 = minmod)
+         * @param limiter_param Limiter parameter (default: 1.5)
+         */
+        ComputeGradientsNode(u32 limiter_type = 1, Tscal limiter_param = Tscal{1.5})
+            : limiter_type(limiter_type), limiter_param(limiter_param) {}
+
+        /**
+         * @brief Set input/output edges
+         */
+        void set_edges(
+            std::shared_ptr<shamrock::solvergraph::Indexes<u32>> part_counts,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tvec>> positions_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tscal>> hpart_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> omega,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> density,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> pressure,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tvec>> velocity_with_ghosts,
+            std::shared_ptr<GradientsEdge<Tvec>> gradients) {
+            __internal_set_ro_edges(
+                {part_counts,
+                 positions_with_ghosts,
+                 hpart_with_ghosts,
+                 omega,
+                 density,
+                 pressure,
+                 velocity_with_ghosts});
+            __internal_set_rw_edges({gradients});
+        }
+
+        /**
+         * @brief Get typed edge references
+         */
+        Edges get_edges() {
+            return Edges{
+                get_ro_edge<shamrock::solvergraph::Indexes<u32>>(0),
+                get_ro_edge<shamrock::solvergraph::FieldRefs<Tvec>>(1),
+                get_ro_edge<shamrock::solvergraph::FieldRefs<Tscal>>(2),
+                get_ro_edge<shamrock::solvergraph::Field<Tscal>>(3),
+                get_ro_edge<shamrock::solvergraph::Field<Tscal>>(4),
+                get_ro_edge<shamrock::solvergraph::Field<Tscal>>(5),
+                get_ro_edge<shamrock::solvergraph::FieldRefs<Tvec>>(6),
+                get_rw_edge<GradientsEdge<Tvec>>(0)};
+        }
+
+        std::string _impl_get_label() const override { return "ComputeGradients"; }
+
+        std::string _impl_get_tex() const override {
+            return "\\nabla\\rho, \\nabla P, \\nabla v \\leftarrow \\text{SPH}";
+        }
+
+        protected:
+        /**
+         * @brief Execute the computation
+         *
+         * Computes SPH gradients with slope limiting for MUSCL reconstruction.
+         */
+        void _impl_evaluate_internal() override;
+    };
+
+    // =========================================================================
+    // MHD Gradient Node (STUB)
+    // =========================================================================
+
+    /**
+     * @brief Compute MUSCL gradients for MHD (STUB)
+     *
+     * Extends hydro gradients with magnetic field gradients:
+     * - \nabla B_x, \nabla B_y, \nabla B_z
+     *
+     * @tparam Tvec Vector type
+     * @tparam SPHKernel SPH kernel template
+     */
+    template<class Tvec, template<class> class SPHKernel>
+    class ComputeGradientsMHDNode : public shamrock::solvergraph::INode {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        public:
+        ComputeGradientsMHDNode() = default;
+
+        std::string _impl_get_label() const override { return "ComputeGradients_MHD"; }
+
+        std::string _impl_get_tex() const override {
+            return "\\nabla\\rho, \\nabla P, \\nabla v, \\nabla B \\leftarrow \\text{SPH}";
+        }
+
+        protected:
+        void _impl_evaluate_internal() override {
+            // STUB: MHD gradient computation not yet implemented
+        }
+    };
+
+} // namespace shammodels::gsph::solvergraph

--- a/src/shammodels/gsph/include/shammodels/gsph/solvergraph/nodes/ComputeOmegaNode.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/solvergraph/nodes/ComputeOmegaNode.hpp
@@ -1,0 +1,136 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2025 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file ComputeOmegaNode.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Solvergraph node for computing grad-h correction factor (omega)
+ *
+ * This node computes the grad-h correction factor omega and density
+ * via SPH summation with smoothing length iteration.
+ *
+ * The computation is physics-independent (same for Newtonian, SR, GR).
+ */
+
+#include "shamrock/solvergraph/Field.hpp"
+#include "shamrock/solvergraph/FieldRefs.hpp"
+#include "shamrock/solvergraph/INode.hpp"
+#include "shamrock/solvergraph/Indexes.hpp"
+
+namespace shammodels::gsph::solvergraph {
+
+    /**
+     * @brief Compute grad-h correction factor omega and density
+     *
+     * This node wraps the smoothing length iteration and omega computation.
+     * It is physics-independent as it only depends on particle positions
+     * and smoothing lengths.
+     *
+     * Inputs:
+     * - positions_with_ghosts: Particle positions (merged with ghosts)
+     * - hpart_with_ghosts: Smoothing lengths (merged with ghosts)
+     * - neigh_cache: Pre-computed neighbor cache
+     * - part_counts: Particle counts per patch
+     *
+     * Outputs:
+     * - omega: Grad-h correction factor
+     * - density: SPH-summed density
+     *
+     * @tparam Tvec Vector type
+     * @tparam SPHKernel SPH kernel template
+     */
+    template<class Tvec, template<class> class SPHKernel>
+    class ComputeOmegaNode : public shamrock::solvergraph::INode {
+        using Tscal  = shambase::VecComponent<Tvec>;
+        using Kernel = SPHKernel<Tscal>;
+
+        /// Particle mass (uniform for now)
+        Tscal particle_mass;
+
+        /// Smoothing length tolerance for iteration
+        Tscal htol_up_coarse;
+        Tscal htol_up_fine;
+
+        /// Convergence parameters
+        Tscal epsilon_h;
+        u32 h_iter_per_subcycles;
+
+        public:
+        /**
+         * @brief Edge container for type-safe access
+         */
+        struct Edges {
+            const shamrock::solvergraph::Indexes<u32> &part_counts;
+            const shamrock::solvergraph::FieldRefs<Tvec> &positions_with_ghosts;
+            const shamrock::solvergraph::FieldRefs<Tscal> &hpart_with_ghosts;
+            shamrock::solvergraph::Field<Tscal> &omega;
+            shamrock::solvergraph::Field<Tscal> &density;
+        };
+
+        /**
+         * @brief Construct compute omega node
+         *
+         * @param particle_mass Uniform particle mass
+         * @param htol_up_coarse Coarse tolerance for h iteration
+         * @param htol_up_fine Fine tolerance for h iteration
+         * @param epsilon_h Convergence threshold for h
+         * @param h_iter_per_subcycles Iterations per subcycle
+         */
+        ComputeOmegaNode(
+            Tscal particle_mass,
+            Tscal htol_up_coarse     = Tscal{1.1},
+            Tscal htol_up_fine       = Tscal{1.05},
+            Tscal epsilon_h          = Tscal{1e-4},
+            u32 h_iter_per_subcycles = 30)
+            : particle_mass(particle_mass), htol_up_coarse(htol_up_coarse),
+              htol_up_fine(htol_up_fine), epsilon_h(epsilon_h),
+              h_iter_per_subcycles(h_iter_per_subcycles) {}
+
+        /**
+         * @brief Set input/output edges
+         */
+        void set_edges(
+            std::shared_ptr<shamrock::solvergraph::Indexes<u32>> part_counts,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tvec>> positions_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tscal>> hpart_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> omega,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> density) {
+            __internal_set_ro_edges({part_counts, positions_with_ghosts, hpart_with_ghosts});
+            __internal_set_rw_edges({omega, density});
+        }
+
+        /**
+         * @brief Get typed edge references
+         */
+        Edges get_edges() {
+            return Edges{
+                get_ro_edge<shamrock::solvergraph::Indexes<u32>>(0),
+                get_ro_edge<shamrock::solvergraph::FieldRefs<Tvec>>(1),
+                get_ro_edge<shamrock::solvergraph::FieldRefs<Tscal>>(2),
+                get_rw_edge<shamrock::solvergraph::Field<Tscal>>(0),
+                get_rw_edge<shamrock::solvergraph::Field<Tscal>>(1)};
+        }
+
+        std::string _impl_get_label() const override { return "ComputeOmega"; }
+
+        std::string _impl_get_tex() const override { return "\\Omega, \\rho \\leftarrow h"; }
+
+        protected:
+        /**
+         * @brief Execute the computation
+         *
+         * This is a placeholder - the actual implementation calls
+         * the existing Solver::compute_omega() method.
+         */
+        void _impl_evaluate_internal() override;
+    };
+
+} // namespace shammodels::gsph::solvergraph

--- a/src/shammodels/gsph/include/shammodels/gsph/solvergraph/nodes/RiemannSolverNode.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/solvergraph/nodes/RiemannSolverNode.hpp
@@ -1,0 +1,286 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2025 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file RiemannSolverNode.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Solvergraph node for Riemann problem solving
+ *
+ * Solves Riemann problems at particle pair interfaces to obtain
+ * the interface state (p*, v*) used for flux computation.
+ *
+ * For Newtonian hydro: iterative or approximate Riemann solver
+ * For MHD: HLLD solver
+ * For SR: relativistic HLLC
+ */
+
+#include "shambackends/vec.hpp"
+#include "shammodels/gsph/solvergraph/edges/GradientsEdge.hpp"
+#include "shammodels/gsph/solvergraph/edges/RiemannResultEdge.hpp"
+#include "shamrock/solvergraph/Field.hpp"
+#include "shamrock/solvergraph/FieldRefs.hpp"
+#include "shamrock/solvergraph/INode.hpp"
+#include "shamrock/solvergraph/Indexes.hpp"
+
+namespace shammodels::gsph::solvergraph {
+
+    /**
+     * @brief Riemann solver configuration
+     */
+    struct RiemannSolverConfig {
+        /// Maximum iterations for iterative solver
+        u32 max_iterations = 100;
+
+        /// Convergence tolerance
+        f64 tolerance = 1e-6;
+
+        /// Use acoustic approximation for initial guess
+        bool use_acoustic_guess = true;
+    };
+
+    /**
+     * @brief Solve Riemann problems at particle interfaces
+     *
+     * For each particle pair (a, b), this node:
+     * 1. Reconstructs left/right states at the interface using MUSCL
+     * 2. Solves the 1D Riemann problem along the pair axis
+     * 3. Returns the interface state (p*, v*)
+     *
+     * The Riemann solver type depends on the physics:
+     * - Newtonian hydro: iterative exact solver (default) or HLL/HLLC
+     * - MHD: HLLD solver
+     * - SR: relativistic HLLC
+     *
+     * Inputs:
+     * - positions_with_ghosts: Particle positions
+     * - hpart_with_ghosts: Smoothing lengths
+     * - density, pressure, velocity: Primitive variables
+     * - soundspeed: Local sound speed
+     * - gradients: MUSCL gradients (optional, for 2nd order)
+     * - part_counts: Particle counts per patch
+     *
+     * Outputs:
+     * - riemann_result: Interface states for all pairs
+     *
+     * @tparam Tvec Vector type
+     * @tparam SPHKernel SPH kernel template
+     * @tparam RiemannSolverType Riemann solver implementation
+     */
+    template<class Tvec, template<class> class SPHKernel, class RiemannSolverType>
+    class RiemannSolverNode : public shamrock::solvergraph::INode {
+        using Tscal  = shambase::VecComponent<Tvec>;
+        using Kernel = SPHKernel<Tscal>;
+
+        /// Riemann solver instance
+        RiemannSolverType riemann_solver;
+
+        /// Solver configuration
+        RiemannSolverConfig config;
+
+        /// Whether to use MUSCL reconstruction
+        bool use_muscl;
+
+        public:
+        /**
+         * @brief Edge container for type-safe access
+         */
+        struct Edges {
+            const shamrock::solvergraph::Indexes<u32> &part_counts;
+            const shamrock::solvergraph::FieldRefs<Tvec> &positions_with_ghosts;
+            const shamrock::solvergraph::FieldRefs<Tscal> &hpart_with_ghosts;
+            const shamrock::solvergraph::Field<Tscal> &density;
+            const shamrock::solvergraph::Field<Tscal> &pressure;
+            const shamrock::solvergraph::FieldRefs<Tvec> &velocity_with_ghosts;
+            const shamrock::solvergraph::Field<Tscal> &soundspeed;
+            const GradientsEdge<Tvec> *gradients; // nullable for 1st order
+            RiemannResultEdge<Tvec> &riemann_result;
+        };
+
+        /**
+         * @brief Construct Riemann solver node
+         *
+         * @param riemann_solver Riemann solver implementation
+         * @param config Solver configuration
+         * @param use_muscl Whether to use MUSCL reconstruction
+         */
+        RiemannSolverNode(
+            RiemannSolverType riemann_solver,
+            RiemannSolverConfig config = {},
+            bool use_muscl             = true)
+            : riemann_solver(std::move(riemann_solver)), config(config), use_muscl(use_muscl) {}
+
+        /**
+         * @brief Set input/output edges (with MUSCL gradients)
+         */
+        void set_edges(
+            std::shared_ptr<shamrock::solvergraph::Indexes<u32>> part_counts,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tvec>> positions_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tscal>> hpart_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> density,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> pressure,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tvec>> velocity_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> soundspeed,
+            std::shared_ptr<GradientsEdge<Tvec>> gradients,
+            std::shared_ptr<RiemannResultEdge<Tvec>> riemann_result) {
+            __internal_set_ro_edges(
+                {part_counts,
+                 positions_with_ghosts,
+                 hpart_with_ghosts,
+                 density,
+                 pressure,
+                 velocity_with_ghosts,
+                 soundspeed,
+                 gradients});
+            __internal_set_rw_edges({riemann_result});
+        }
+
+        /**
+         * @brief Set input/output edges (without MUSCL - 1st order)
+         */
+        void set_edges_first_order(
+            std::shared_ptr<shamrock::solvergraph::Indexes<u32>> part_counts,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tvec>> positions_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tscal>> hpart_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> density,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> pressure,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tvec>> velocity_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> soundspeed,
+            std::shared_ptr<RiemannResultEdge<Tvec>> riemann_result) {
+            use_muscl = false;
+            __internal_set_ro_edges(
+                {part_counts,
+                 positions_with_ghosts,
+                 hpart_with_ghosts,
+                 density,
+                 pressure,
+                 velocity_with_ghosts,
+                 soundspeed});
+            __internal_set_rw_edges({riemann_result});
+        }
+
+        std::string _impl_get_label() const override { return "RiemannSolver"; }
+
+        std::string _impl_get_tex() const override {
+            return "p^*, v^* \\leftarrow \\text{Riemann}";
+        }
+
+        protected:
+        /**
+         * @brief Execute the computation
+         *
+         * Solves Riemann problems for all particle pairs.
+         */
+        void _impl_evaluate_internal() override;
+    };
+
+    // =========================================================================
+    // Approximate Riemann Solvers (STUBS)
+    // =========================================================================
+
+    /**
+     * @brief HLL Riemann solver (STUB)
+     *
+     * Simple two-wave approximation. Fast but diffusive.
+     */
+    template<class Tscal>
+    struct HLLSolver {
+        static RiemannResult<Tscal> solve(
+            Tscal rho_L,
+            Tscal P_L,
+            Tscal v_L,
+            Tscal cs_L,
+            Tscal rho_R,
+            Tscal P_R,
+            Tscal v_R,
+            Tscal cs_R) {
+            // STUB: HLL solver not yet implemented
+            return {(P_L + P_R) / Tscal{2}, (v_L + v_R) / Tscal{2}};
+        }
+    };
+
+    /**
+     * @brief HLLC Riemann solver (STUB)
+     *
+     * Three-wave approximation with contact discontinuity.
+     */
+    template<class Tscal>
+    struct HLLCSolver {
+        static RiemannResult<Tscal> solve(
+            Tscal rho_L,
+            Tscal P_L,
+            Tscal v_L,
+            Tscal cs_L,
+            Tscal rho_R,
+            Tscal P_R,
+            Tscal v_R,
+            Tscal cs_R) {
+            // STUB: HLLC solver not yet implemented
+            return {(P_L + P_R) / Tscal{2}, (v_L + v_R) / Tscal{2}};
+        }
+    };
+
+    /**
+     * @brief HLLD Riemann solver for MHD (STUB)
+     *
+     * Five-wave approximation for ideal MHD.
+     */
+    template<class Tvec>
+    struct HLLDSolver {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        static MHDRiemannResult<Tvec> solve(
+            Tscal rho_L,
+            Tscal P_L,
+            Tscal v_L,
+            Tscal cs_L,
+            Tvec B_L,
+            Tscal rho_R,
+            Tscal P_R,
+            Tscal v_R,
+            Tscal cs_R,
+            Tvec B_R) {
+            // STUB: HLLD solver not yet implemented
+            MHDRiemannResult<Tvec> result;
+            result.p_star = (P_L + P_R) / Tscal{2};
+            result.v_star = (v_L + v_R) / Tscal{2};
+            result.B_star = (B_L + B_R) / Tscal{2};
+            return result;
+        }
+    };
+
+    /**
+     * @brief Relativistic HLLC solver for SR (STUB)
+     */
+    template<class Tvec>
+    struct SRHLLCSolver {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        static SRRiemannResult<Tvec> solve(
+            Tscal rho_L,
+            Tscal P_L,
+            Tscal v_L,
+            Tscal cs_L,
+            Tscal W_L,
+            Tscal rho_R,
+            Tscal P_R,
+            Tscal v_R,
+            Tscal cs_R,
+            Tscal W_R) {
+            // STUB: SR HLLC solver not yet implemented
+            SRRiemannResult<Tvec> result;
+            result.p_star = (P_L + P_R) / Tscal{2};
+            result.v_star = (v_L + v_R) / Tscal{2};
+            result.W_star = Tscal{1}; // Non-relativistic limit
+            return result;
+        }
+    };
+
+} // namespace shammodels::gsph::solvergraph

--- a/src/shammodels/gsph/include/shammodels/gsph/solvergraph/nodes/UpdateDerivsNode.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/solvergraph/nodes/UpdateDerivsNode.hpp
@@ -1,0 +1,251 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2025 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file UpdateDerivsNode.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Solvergraph node for computing GSPH derivatives
+ *
+ * Computes acceleration and energy rate from Riemann solver results.
+ * This is the core GSPH force computation.
+ *
+ * For Newtonian hydro:
+ *   dv_a/dt = -\sum_b m_b [A_a p*_{ab} \nabla W_a + A_b p*_{ab} \nabla W_b]
+ *   du_a/dt = \sum_b m_b A_a p*_{ab} (v*_{ab} - v_a) \cdot \nabla W_a
+ *
+ * where A_a = 1/(\Omega_a \rho_a^2)
+ */
+
+#include "shambackends/vec.hpp"
+#include "shammodels/gsph/solvergraph/edges/RiemannResultEdge.hpp"
+#include "shamrock/solvergraph/Field.hpp"
+#include "shamrock/solvergraph/FieldRefs.hpp"
+#include "shamrock/solvergraph/INode.hpp"
+#include "shamrock/solvergraph/Indexes.hpp"
+
+namespace shammodels::gsph::solvergraph {
+
+    /**
+     * @brief Compute GSPH derivatives from Riemann solutions
+     *
+     * This node accumulates forces and energy rates over all particle pairs
+     * using the Riemann solver interface states.
+     *
+     * The computation follows the Godunov SPH formulation where forces
+     * are computed from the Riemann problem solution at particle interfaces.
+     *
+     * Inputs:
+     * - positions_with_ghosts: Particle positions
+     * - hpart_with_ghosts: Smoothing lengths
+     * - omega: Grad-h correction factor
+     * - density: SPH density
+     * - velocity: Particle velocities
+     * - riemann_result: Interface states from Riemann solver
+     * - part_counts: Particle counts per patch
+     *
+     * Outputs:
+     * - acceleration: dv/dt for each particle
+     * - energy_rate: du/dt for each particle
+     *
+     * @tparam Tvec Vector type
+     * @tparam SPHKernel SPH kernel template
+     */
+    template<class Tvec, template<class> class SPHKernel>
+    class UpdateDerivsNode : public shamrock::solvergraph::INode {
+        using Tscal  = shambase::VecComponent<Tvec>;
+        using Kernel = SPHKernel<Tscal>;
+
+        /// Particle mass (uniform for now)
+        Tscal particle_mass;
+
+        public:
+        /**
+         * @brief Edge container for type-safe access
+         */
+        struct Edges {
+            const shamrock::solvergraph::Indexes<u32> &part_counts;
+            const shamrock::solvergraph::FieldRefs<Tvec> &positions_with_ghosts;
+            const shamrock::solvergraph::FieldRefs<Tscal> &hpart_with_ghosts;
+            const shamrock::solvergraph::Field<Tscal> &omega;
+            const shamrock::solvergraph::Field<Tscal> &density;
+            const shamrock::solvergraph::FieldRefs<Tvec> &velocity_with_ghosts;
+            shamrock::solvergraph::Field<Tvec> &acceleration;
+            shamrock::solvergraph::Field<Tscal> &energy_rate;
+        };
+
+        /**
+         * @brief Construct derivative computation node
+         *
+         * @param particle_mass Uniform particle mass
+         */
+        explicit UpdateDerivsNode(Tscal particle_mass) : particle_mass(particle_mass) {}
+
+        /**
+         * @brief Set input/output edges
+         */
+        void set_edges(
+            std::shared_ptr<shamrock::solvergraph::Indexes<u32>> part_counts,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tvec>> positions_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tscal>> hpart_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> omega,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> density,
+            std::shared_ptr<shamrock::solvergraph::FieldRefs<Tvec>> velocity_with_ghosts,
+            std::shared_ptr<shamrock::solvergraph::Field<Tvec>> acceleration,
+            std::shared_ptr<shamrock::solvergraph::Field<Tscal>> energy_rate) {
+            __internal_set_ro_edges(
+                {part_counts,
+                 positions_with_ghosts,
+                 hpart_with_ghosts,
+                 omega,
+                 density,
+                 velocity_with_ghosts});
+            __internal_set_rw_edges({acceleration, energy_rate});
+        }
+
+        /**
+         * @brief Get typed edge references
+         */
+        Edges get_edges() {
+            return Edges{
+                get_ro_edge<shamrock::solvergraph::Indexes<u32>>(0),
+                get_ro_edge<shamrock::solvergraph::FieldRefs<Tvec>>(1),
+                get_ro_edge<shamrock::solvergraph::FieldRefs<Tscal>>(2),
+                get_ro_edge<shamrock::solvergraph::Field<Tscal>>(3),
+                get_ro_edge<shamrock::solvergraph::Field<Tscal>>(4),
+                get_ro_edge<shamrock::solvergraph::FieldRefs<Tvec>>(5),
+                get_rw_edge<shamrock::solvergraph::Field<Tvec>>(0),
+                get_rw_edge<shamrock::solvergraph::Field<Tscal>>(1)};
+        }
+
+        std::string _impl_get_label() const override { return "UpdateDerivs"; }
+
+        std::string _impl_get_tex() const override {
+            return "\\dot{v}, \\dot{u} \\leftarrow p^*, v^*";
+        }
+
+        protected:
+        /**
+         * @brief Execute the computation
+         *
+         * Accumulates forces and energy rates from Riemann solutions.
+         */
+        void _impl_evaluate_internal() override;
+    };
+
+    // =========================================================================
+    // Extended UpdateDerivs nodes for different physics (STUBS)
+    // =========================================================================
+
+    /**
+     * @brief UpdateDerivs for MHD (STUB)
+     *
+     * Adds magnetic force contribution:
+     *   dv_a/dt += magnetic pressure + tension terms
+     *   dB_a/dt = induction equation terms
+     *
+     * @tparam Tvec Vector type
+     * @tparam SPHKernel SPH kernel template
+     */
+    template<class Tvec, template<class> class SPHKernel>
+    class UpdateDerivsMHDNode : public shamrock::solvergraph::INode {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        public:
+        struct Edges {
+            const shamrock::solvergraph::Indexes<u32> &part_counts;
+            // Additional inputs for MHD: magnetic field, div B, etc.
+            shamrock::solvergraph::Field<Tvec> &acceleration;
+            shamrock::solvergraph::Field<Tscal> &energy_rate;
+            shamrock::solvergraph::Field<Tvec> &dBdt; // Induction equation
+        };
+
+        UpdateDerivsMHDNode() = default;
+
+        std::string _impl_get_label() const override { return "UpdateDerivs_MHD"; }
+
+        std::string _impl_get_tex() const override {
+            return "\\dot{v}, \\dot{u}, \\dot{B} \\leftarrow \\text{MHD}";
+        }
+
+        protected:
+        void _impl_evaluate_internal() override {
+            // STUB: MHD force computation not yet implemented
+        }
+    };
+
+    /**
+     * @brief UpdateDerivs for SR (STUB)
+     *
+     * Uses relativistic momentum and energy equations:
+     *   d(W v)/dt = relativistic force
+     *   d(W - 1 + W u)/dt = relativistic energy rate
+     *
+     * @tparam Tvec Vector type
+     * @tparam SPHKernel SPH kernel template
+     */
+    template<class Tvec, template<class> class SPHKernel>
+    class UpdateDerivsSRNode : public shamrock::solvergraph::INode {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        public:
+        struct Edges {
+            const shamrock::solvergraph::Indexes<u32> &part_counts;
+            // SR-specific: Lorentz factor, enthalpy, etc.
+            shamrock::solvergraph::Field<Tvec> &d_momentum_dt;
+            shamrock::solvergraph::Field<Tscal> &d_energy_dt;
+        };
+
+        UpdateDerivsSRNode() = default;
+
+        std::string _impl_get_label() const override { return "UpdateDerivs_SR"; }
+
+        std::string _impl_get_tex() const override {
+            return "\\dot{S}, \\dot{E} \\leftarrow \\text{SR-GSPH}";
+        }
+
+        protected:
+        void _impl_evaluate_internal() override {
+            // STUB: SR force computation not yet implemented
+        }
+    };
+
+    /**
+     * @brief UpdateDerivs for GR (STUB)
+     *
+     * Adds geometric source terms from curved spacetime:
+     *   d(W v)/dt = ... + Christoffel terms
+     *
+     * @tparam Tvec Vector type
+     * @tparam SPHKernel SPH kernel template
+     * @tparam SpacetimeType Spacetime metric type
+     */
+    template<class Tvec, template<class> class SPHKernel, class SpacetimeType>
+    class UpdateDerivsGRNode : public shamrock::solvergraph::INode {
+        using Tscal = shambase::VecComponent<Tvec>;
+
+        SpacetimeType spacetime;
+
+        public:
+        explicit UpdateDerivsGRNode(SpacetimeType spacetime) : spacetime(std::move(spacetime)) {}
+
+        std::string _impl_get_label() const override { return "UpdateDerivs_GR"; }
+
+        std::string _impl_get_tex() const override {
+            return "\\dot{S}, \\dot{E} \\leftarrow \\text{GR-GSPH}";
+        }
+
+        protected:
+        void _impl_evaluate_internal() override {
+            // STUB: GR force computation not yet implemented
+        }
+    };
+
+} // namespace shammodels::gsph::solvergraph


### PR DESCRIPTION
## Summary

This PR adds an orthogonal physics composition system for GSPH that enables clean extension to Special Relativity, MHD, radiation hydrodynamics, and General Relativity without code branching.

**Key additions:**

- **Physics traits** (`physics/`):
  - `MatterTraits.hpp`: HydroMatter with field definitions + stubs for MHD, RadHydro
  - `SpacetimeTraits.hpp`: Minkowski spacetime + stubs for Schwarzschild, Kerr, numerical spacetimes
  - `RelativityTraits.hpp`: Newtonian physics + stubs for SR, GR with primitive recovery
  - `PhysicsComposition.hpp`: Template composition combining matter, relativity, spacetime, and solver modes

- **Solver modes** (`modes/`):
  - `SolverModes.hpp`: NormalEvolution, RelaxationMode (Lane-Emden), DustMode (pressureless)

- **Solvergraph edges** (`solvergraph/edges/`):
  - `GradientsEdge.hpp`: Bundle of MUSCL gradient fields
  - `RiemannResultEdge.hpp`: Riemann solver results + stubs for MHD/SR extensions

- **Solvergraph nodes** (`solvergraph/nodes/`):
  - `ComputeOmegaNode.hpp`: Grad-h correction factor computation
  - `ComputeEOSNode.hpp`: Equation of state evaluation
  - `ComputeGradientsNode.hpp`: MUSCL reconstruction gradients
  - `RiemannSolverNode.hpp`: Riemann problem solving with HLL/HLLC/HLLD stubs
  - `UpdateDerivsNode.hpp`: Force and energy rate accumulation

**Design principles:**
- Compile-time physics selection via template composition
- Feature flags control which nodes are instantiated
- Stubs provide clear extension points for future physics

## Test plan

- [x] Pre-commit style check passes
- [x] Build succeeds
- [x] GSPH Sod shock tube test passes (`sod_tube_gsph.py`)