### PR TITLE
[Backends] test allocations (small & large) during startup

### DIFF
--- a/src/shambackends/include/shambackends/Device.hpp
+++ b/src/shambackends/include/shambackends/Device.hpp
@@ -107,7 +107,10 @@ namespace sham {
         uint32_t max_compute_units;
 
         /// The maximum size of memory that can be allocated on the device in bytes
-        uint64_t max_mem_alloc_size;
+        uint64_t max_mem_alloc_size_dev;
+
+        /// The maximum size of memory that can be allocated on the host in bytes
+        uint64_t max_mem_alloc_size_host;
 
         /// The maximum alignment of memory that can be allocated on the device in bytes
         uint32_t mem_base_addr_align;
@@ -117,12 +120,6 @@ namespace sham {
 
         /// Default work group size
         uint32_t default_work_group_size;
-
-        /// Whether the device can allocate large host memory (>2GB)
-        bool large_host_alloc;
-
-        /// Whether the device can allocate large device memory (>2GB)
-        bool large_device_alloc;
     };
 
     struct DeviceMPIProperties {

--- a/src/shambackends/include/shambackends/Device.hpp
+++ b/src/shambackends/include/shambackends/Device.hpp
@@ -117,6 +117,12 @@ namespace sham {
 
         /// Default work group size
         uint32_t default_work_group_size;
+
+        /// Whether the device can allocate large host memory (>2GB)
+        bool large_host_alloc;
+
+        /// Whether the device can allocate large device memory (>2GB)
+        bool large_device_alloc;
     };
 
     struct DeviceMPIProperties {

--- a/src/shambackends/src/Device.cpp
+++ b/src/shambackends/src/Device.cpp
@@ -207,12 +207,13 @@ namespace sham {
         FETCH_PROP(partition_type_property, sycl::info::partition_property)
         FETCH_PROP(partition_type_affinity_domain, sycl::info::partition_affinity_domain)
 
+        auto physmem = sham::getPhysicalMemory();
+
 // On acpp 2^64-1 is returned, so we need to correct it
 // see : https://github.com/AdaptiveCpp/AdaptiveCpp/issues/1573
 #ifdef SYCL_COMP_ACPP
         if (get_device_backend(dev) == Backend::OPENMP) {
             // Correct memory size
-            auto physmem = sham::getPhysicalMemory();
             if (physmem) {
                 global_mem_size = {*physmem};
             }
@@ -260,7 +261,7 @@ namespace sham {
             shambase::get_check_ref(local_mem_size),
             shambase::get_check_ref(max_compute_units),
             shambase::get_check_ref(max_mem_alloc_size),
-            i64_max,
+            ((physmem) ? *physmem : i64_max),
             shambase::get_check_ref(mem_base_addr_align),
             shambase::get_check_ref(sub_group_sizes),
             default_work_group_size};

--- a/src/shambackends/src/Device.cpp
+++ b/src/shambackends/src/Device.cpp
@@ -260,11 +260,10 @@ namespace sham {
             shambase::get_check_ref(local_mem_size),
             shambase::get_check_ref(max_compute_units),
             shambase::get_check_ref(max_mem_alloc_size),
+            i64_max,
             shambase::get_check_ref(mem_base_addr_align),
             shambase::get_check_ref(sub_group_sizes),
-            default_work_group_size,
-            false,
-            false};
+            default_work_group_size};
     }
 
     /**

--- a/src/shambackends/src/Device.cpp
+++ b/src/shambackends/src/Device.cpp
@@ -262,7 +262,9 @@ namespace sham {
             shambase::get_check_ref(max_mem_alloc_size),
             shambase::get_check_ref(mem_base_addr_align),
             shambase::get_check_ref(sub_group_sizes),
-            default_work_group_size};
+            default_work_group_size,
+            false,
+            false};
     }
 
     /**

--- a/src/shambackends/src/Device.cpp
+++ b/src/shambackends/src/Device.cpp
@@ -258,8 +258,19 @@ namespace sham {
         size_t max_alloc_dev  = shambase::get_check_ref(max_mem_alloc_size);
         size_t max_alloc_host = ((physmem) ? *physmem : i64_max);
         if (SHAM_MAX_ALLOC_SIZE) {
-            max_alloc_dev  = std::stoull(SHAM_MAX_ALLOC_SIZE.value());
-            max_alloc_host = std::stoull(SHAM_MAX_ALLOC_SIZE.value());
+            try {
+                const auto max_alloc = std::stoull(SHAM_MAX_ALLOC_SIZE.value());
+                max_alloc_dev        = max_alloc;
+                max_alloc_host       = max_alloc;
+            } catch (const std::exception &e) {
+                logger::warn_ln(
+                    "Backends",
+                    shambase::format(
+                        "Could not parse SHAM_MAX_ALLOC_SIZE value '{}'. Error: {}. "
+                        "Ignoring override.",
+                        SHAM_MAX_ALLOC_SIZE.value(),
+                        e.what()));
+            }
         }
 
         return DeviceProperties{

--- a/src/shambackends/src/DeviceScheduler.cpp
+++ b/src/shambackends/src/DeviceScheduler.cpp
@@ -119,9 +119,9 @@ namespace sham {
             } catch (std::runtime_error &e) {
                 logger::warn_ln(
                     "Backends",
-                    "[Alloc testing] name = ",
+                    " name = ",
                     dev.dev.get_info<sycl::info::device::name>(),
-                    " -> large device allocation not working !");
+                    " -> large device allocation (>2GB) not working !");
                 dev.prop.max_mem_alloc_size_dev = i32_max;
             }
 
@@ -132,9 +132,9 @@ namespace sham {
             } catch (std::runtime_error &e) {
                 logger::warn_ln(
                     "Backends",
-                    "[Alloc testing] name = ",
+                    " name = ",
                     dev.dev.get_info<sycl::info::device::name>(),
-                    " -> large host allocation not working !");
+                    " -> large host allocation (>2GB) not working !");
                 dev.prop.max_mem_alloc_size_host = i32_max;
             }
         }

--- a/src/shambackends/src/DeviceScheduler.cpp
+++ b/src/shambackends/src/DeviceScheduler.cpp
@@ -107,15 +107,20 @@ namespace sham {
             = USMPtrHolder<sham::host>::create(1024, dev_sched, 8);
         ptr1024_host.free_ptr();
 
+        auto &dev = shambase::get_check_ref(ctxref.device);
+
         size_t GBval = 1024 * 1024 * 1024;
         // avoid <8GB card, they won't run at that scale anyway
-        if (ctxref.device->prop.global_mem_size > usize(8 * GBval * 1.1)) {
+        if (dev.prop.global_mem_size > usize(3 * GBval)) {
             USMPtrHolder<sham::device> ptr2G_dev
                 = USMPtrHolder<sham::device>::create(2 * GBval + 1024, dev_sched, 8);
             ptr2G_dev.free_ptr();
             USMPtrHolder<sham::host> ptr2G_host
                 = USMPtrHolder<sham::host>::create(2 * GBval + 1024, dev_sched, 8);
             ptr2G_host.free_ptr();
+
+            dev.prop.large_device_alloc = true;
+            dev.prop.large_host_alloc   = true;
         }
 
         logger::debug_ln("Backends", "[Alloc testing] done !");

--- a/src/shambackends/src/DeviceScheduler.cpp
+++ b/src/shambackends/src/DeviceScheduler.cpp
@@ -112,30 +112,35 @@ namespace sham {
         size_t GBval = 1024 * 1024 * 1024;
         // avoid <8GB card, they won't run at that scale anyway
         if (dev.prop.global_mem_size > usize(3 * GBval)) {
-            try {
-                USMPtrHolder<sham::device> ptr2G_dev
-                    = USMPtrHolder<sham::device>::create(2 * GBval + 1024, dev_sched, 8);
-                ptr2G_dev.free_ptr();
-            } catch (std::runtime_error &e) {
-                logger::warn_ln(
-                    "Backends",
-                    " name = ",
-                    dev.dev.get_info<sycl::info::device::name>(),
-                    " -> large device allocation (>2GB) not working !");
-                dev.prop.max_mem_alloc_size_dev = i32_max;
+
+            if (dev.prop.max_mem_alloc_size_dev > 2 * GBval) {
+                try {
+                    USMPtrHolder<sham::device> ptr2G_dev
+                        = USMPtrHolder<sham::device>::create(2 * GBval + 1024, dev_sched, 8);
+                    ptr2G_dev.free_ptr();
+                } catch (std::runtime_error &e) {
+                    logger::warn_ln(
+                        "Backends",
+                        " name = ",
+                        dev.dev.get_info<sycl::info::device::name>(),
+                        " -> large device allocation (>2GB) not working !");
+                    dev.prop.max_mem_alloc_size_dev = i32_max;
+                }
             }
 
-            try {
-                USMPtrHolder<sham::host> ptr2G_host
-                    = USMPtrHolder<sham::host>::create(2 * GBval + 1024, dev_sched, 8);
-                ptr2G_host.free_ptr();
-            } catch (std::runtime_error &e) {
-                logger::warn_ln(
-                    "Backends",
-                    " name = ",
-                    dev.dev.get_info<sycl::info::device::name>(),
-                    " -> large host allocation (>2GB) not working !");
-                dev.prop.max_mem_alloc_size_host = i32_max;
+            if (dev.prop.max_mem_alloc_size_host > 2 * GBval) {
+                try {
+                    USMPtrHolder<sham::host> ptr2G_host
+                        = USMPtrHolder<sham::host>::create(2 * GBval + 1024, dev_sched, 8);
+                    ptr2G_host.free_ptr();
+                } catch (std::runtime_error &e) {
+                    logger::warn_ln(
+                        "Backends",
+                        " name = ",
+                        dev.dev.get_info<sycl::info::device::name>(),
+                        " -> large host allocation (>2GB) not working !");
+                    dev.prop.max_mem_alloc_size_host = i32_max;
+                }
             }
         }
 

--- a/src/shambackends/src/DeviceScheduler.cpp
+++ b/src/shambackends/src/DeviceScheduler.cpp
@@ -112,15 +112,25 @@ namespace sham {
         size_t GBval = 1024 * 1024 * 1024;
         // avoid <8GB card, they won't run at that scale anyway
         if (dev.prop.global_mem_size > usize(3 * GBval)) {
-            USMPtrHolder<sham::device> ptr2G_dev
-                = USMPtrHolder<sham::device>::create(2 * GBval + 1024, dev_sched, 8);
-            ptr2G_dev.free_ptr();
-            USMPtrHolder<sham::host> ptr2G_host
-                = USMPtrHolder<sham::host>::create(2 * GBval + 1024, dev_sched, 8);
-            ptr2G_host.free_ptr();
+            try {
+                USMPtrHolder<sham::device> ptr2G_dev
+                    = USMPtrHolder<sham::device>::create(2 * GBval + 1024, dev_sched, 8);
+                ptr2G_dev.free_ptr();
+                USMPtrHolder<sham::host> ptr2G_host
+                    = USMPtrHolder<sham::host>::create(2 * GBval + 1024, dev_sched, 8);
+                ptr2G_host.free_ptr();
 
-            dev.prop.large_device_alloc = true;
-            dev.prop.large_host_alloc   = true;
+                dev.prop.large_device_alloc = true;
+                dev.prop.large_host_alloc   = true;
+            } catch (std::runtime_error &e) {
+                logger::debug_ln(
+                    "Backends",
+                    "[Alloc testing] name = ",
+                    dev.dev.get_info<sycl::info::device::name>(),
+                    " -> large allocation not working !");
+                dev.prop.large_device_alloc = false;
+                dev.prop.large_host_alloc   = false;
+            }
         }
 
         logger::debug_ln("Backends", "[Alloc testing] done !");

--- a/src/shambackends/src/DeviceScheduler.cpp
+++ b/src/shambackends/src/DeviceScheduler.cpp
@@ -116,20 +116,26 @@ namespace sham {
                 USMPtrHolder<sham::device> ptr2G_dev
                     = USMPtrHolder<sham::device>::create(2 * GBval + 1024, dev_sched, 8);
                 ptr2G_dev.free_ptr();
-                USMPtrHolder<sham::host> ptr2G_host
-                    = USMPtrHolder<sham::host>::create(2 * GBval + 1024, dev_sched, 8);
-                ptr2G_host.free_ptr();
-
-                dev.prop.large_device_alloc = true;
-                dev.prop.large_host_alloc   = true;
             } catch (std::runtime_error &e) {
                 logger::debug_ln(
                     "Backends",
                     "[Alloc testing] name = ",
                     dev.dev.get_info<sycl::info::device::name>(),
-                    " -> large allocation not working !");
-                dev.prop.large_device_alloc = false;
-                dev.prop.large_host_alloc   = false;
+                    " -> large device allocation not working !");
+                dev.prop.max_mem_alloc_size_dev = i32_max;
+            }
+
+            try {
+                USMPtrHolder<sham::host> ptr2G_host
+                    = USMPtrHolder<sham::host>::create(2 * GBval + 1024, dev_sched, 8);
+                ptr2G_host.free_ptr();
+            } catch (std::runtime_error &e) {
+                logger::debug_ln(
+                    "Backends",
+                    "[Alloc testing] name = ",
+                    dev.dev.get_info<sycl::info::device::name>(),
+                    " -> large host allocation not working !");
+                dev.prop.max_mem_alloc_size_host = i32_max;
             }
         }
 

--- a/src/shambackends/src/DeviceScheduler.cpp
+++ b/src/shambackends/src/DeviceScheduler.cpp
@@ -117,7 +117,7 @@ namespace sham {
                     = USMPtrHolder<sham::device>::create(2 * GBval + 1024, dev_sched, 8);
                 ptr2G_dev.free_ptr();
             } catch (std::runtime_error &e) {
-                logger::debug_ln(
+                logger::warn_ln(
                     "Backends",
                     "[Alloc testing] name = ",
                     dev.dev.get_info<sycl::info::device::name>(),
@@ -130,7 +130,7 @@ namespace sham {
                     = USMPtrHolder<sham::host>::create(2 * GBval + 1024, dev_sched, 8);
                 ptr2G_host.free_ptr();
             } catch (std::runtime_error &e) {
-                logger::debug_ln(
+                logger::warn_ln(
                     "Backends",
                     "[Alloc testing] name = ",
                     dev.dev.get_info<sycl::info::device::name>(),

--- a/src/shamsys/src/shamrock_smi.cpp
+++ b/src/shamsys/src/shamrock_smi.cpp
@@ -179,16 +179,16 @@ namespace shamsys {
           - global_mem_size = {}
           - local_mem_size = {}
           - mem_base_addr_align = {},
-          - large_device_alloc = {},
-          - large_host_alloc = {})",
+          - max_mem_alloc_size_dev = {},
+          - max_mem_alloc_size_host = {})",
                 DeviceName,
                 dev.device_id,
                 dev.prop.default_work_group_size,
                 shambase::readable_sizeof(dev.prop.global_mem_size),
                 nolimit_if_too_large(dev.prop.local_mem_size),
                 dev.prop.mem_base_addr_align,
-                dev.prop.large_device_alloc,
-                dev.prop.large_host_alloc);
+                dev.prop.max_mem_alloc_size_dev,
+                dev.prop.max_mem_alloc_size_host);
 
             std::unordered_map<std::string, int> devicename_histogram
                 = shamcomm::string_histogram({dev_with_id}, "xxx\nxxx");

--- a/src/shamsys/src/shamrock_smi.cpp
+++ b/src/shamsys/src/shamrock_smi.cpp
@@ -187,8 +187,8 @@ namespace shamsys {
                 shambase::readable_sizeof(dev.prop.global_mem_size),
                 nolimit_if_too_large(dev.prop.local_mem_size),
                 dev.prop.mem_base_addr_align,
-                dev.prop.max_mem_alloc_size_dev,
-                dev.prop.max_mem_alloc_size_host);
+                shambase::readable_sizeof(dev.prop.max_mem_alloc_size_dev),
+                shambase::readable_sizeof(dev.prop.max_mem_alloc_size_host));
 
             std::unordered_map<std::string, int> devicename_histogram
                 = shamcomm::string_histogram({dev_with_id}, "xxx\nxxx");

--- a/src/shamsys/src/shamrock_smi.cpp
+++ b/src/shamsys/src/shamrock_smi.cpp
@@ -178,13 +178,17 @@ namespace shamsys {
           - default_work_group_size = {}
           - global_mem_size = {}
           - local_mem_size = {}
-          - mem_base_addr_align = {})",
+          - mem_base_addr_align = {},
+          - large_device_alloc = {},
+          - large_host_alloc = {})",
                 DeviceName,
                 dev.device_id,
                 dev.prop.default_work_group_size,
                 shambase::readable_sizeof(dev.prop.global_mem_size),
                 nolimit_if_too_large(dev.prop.local_mem_size),
-                dev.prop.mem_base_addr_align);
+                dev.prop.mem_base_addr_align,
+                dev.prop.large_device_alloc,
+                dev.prop.large_host_alloc);
 
             std::unordered_map<std::string, int> devicename_histogram
                 = shamcomm::string_histogram({dev_with_id}, "xxx\nxxx");


### PR DESCRIPTION
End goal:
add also a property in the device to state if host allocs > 2GB are supported. If not the comms should use splitter buffers ... (freakin CUDA)