### PR TITLE
[GSPH] migrate solver storage to solvergraph architecture

### DIFF
--- a/src/shammodels/gsph/include/shammodels/gsph/Solver.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/Solver.hpp
@@ -89,14 +89,18 @@ namespace shammodels::gsph {
 
         // Serial patch tree control
         void gen_serial_patch_tree();
-        inline void reset_serial_patch_tree() { storage.serial_patch_tree.reset(); }
+        inline void reset_serial_patch_tree() {
+            shambase::get_check_ref(storage.serial_patch_tree).free_alloc();
+        }
 
         // Ghost handling - use GSPH ghost handler with Newtonian field names
         using GhostHandle      = GSPHGhostHandler<Tvec>;
         using GhostHandleCache = typename GhostHandle::CacheMap;
 
         void gen_ghost_handler(Tscal time_val);
-        inline void reset_ghost_handler() { storage.ghost_handler.reset(); }
+        inline void reset_ghost_handler() {
+            shambase::get_check_ref(storage.ghost_handler).free_alloc();
+        }
 
         void build_ghost_cache();
         void clear_ghost_cache();

--- a/src/shammodels/gsph/include/shammodels/gsph/modules/SolverStorage.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/modules/SolverStorage.hpp
@@ -14,10 +14,15 @@
  * @author Guo Yansong (guo.yansong.ngy@gmail.com)
  * @author Timothée David--Cléris (tim.shamrock@proton.me)
  * @author Yona Lapeyre (yona.lapeyre@ens-lyon.fr)
- * @brief Storage for GSPH solver runtime data
+ * @brief Storage for GSPH solver runtime data with SolverGraph integration
  *
  * This file contains the storage structure for GSPH solver runtime data,
  * including neighbor caches, ghost data, and field storage.
+ *
+ * The storage uses the SolverGraph architecture for:
+ * - Explicit data dependency tracking
+ * - Automatic memory management via free_alloc()
+ * - Graph-based operation sequencing
  *
  * The GSPH solver originated from:
  * - Inutsuka, S. (2002) "Reformulation of Smoothed Particle Hydrodynamics
@@ -27,14 +32,31 @@
 #include "shambase/StorageComponent.hpp"
 #include "shambase/stacktrace.hpp"
 #include "shambackends/vec.hpp"
+
+// GSPH-specific includes
 #include "shammodels/gsph/modules/GSPHGhostHandler.hpp"
-#include "shammodels/sph/solvergraph/NeighCache.hpp"
-#include "shamrock/scheduler/SerialPatchTree.hpp"
-#include "shamrock/scheduler/ShamrockCtx.hpp"
+
+// SolverGraph core includes
 #include "shamrock/solvergraph/Field.hpp"
 #include "shamrock/solvergraph/FieldRefs.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
+#include "shamrock/solvergraph/OperationSequence.hpp"
 #include "shamrock/solvergraph/ScalarsEdge.hpp"
+#include "shamrock/solvergraph/SolverGraph.hpp"
+
+// GSPH SolverGraph edge types
+#include "shammodels/gsph/solvergraph/GhostCacheEdge.hpp"
+#include "shammodels/gsph/solvergraph/GhostHandlerEdge.hpp"
+#include "shammodels/gsph/solvergraph/MergedPatchDataEdge.hpp"
+#include "shammodels/gsph/solvergraph/SerialPatchTreeEdge.hpp"
+
+// Reuse SPH NeighCache (same implementation)
+#include "shammodels/sph/solvergraph/NeighCache.hpp"
+
+// Scheduler and tree includes
+#include "shamrock/scheduler/ComputeField.hpp"
+#include "shamrock/scheduler/SerialPatchTree.hpp"
+#include "shamrock/scheduler/ShamrockCtx.hpp"
 #include "shamsys/legacy/log.hpp"
 #include "shamtree/CompressedLeafBVH.hpp"
 #include "shamtree/KarrasRadixTreeField.hpp"
@@ -48,9 +70,10 @@ namespace shammodels::gsph {
     using Component = shambase::StorageComponent<T>;
 
     /**
-     * @brief Runtime storage for GSPH solver
+     * @brief Runtime storage for GSPH solver with SolverGraph integration
      *
      * Stores all temporary data needed during GSPH simulation steps:
+     * - SolverGraph for data dependency management
      * - Neighbor caches for particle interactions
      * - Ghost particle data for boundary handling
      * - Computed fields (pressure, sound speed, omega)
@@ -70,49 +93,88 @@ namespace shammodels::gsph {
 
         using RTree = shamtree::CompressedLeafBVH<Tmorton, Tvec, 3>;
 
-        /// Particle counts per patch
+        // =====================================================================
+        // SolverGraph infrastructure
+        // =====================================================================
+
+        /// Central graph for managing edges (data) and nodes (operations)
+        shamrock::solvergraph::SolverGraph solver_graph;
+
+        /// Main operation sequence executed each timestep
+        std::shared_ptr<shamrock::solvergraph::OperationSequence> solver_sequence;
+
+        // =====================================================================
+        // SolverGraph edges - Particle counts and indices
+        // =====================================================================
+
+        /// Particle counts per patch (real particles only)
         std::shared_ptr<shamrock::solvergraph::Indexes<u32>> part_counts;
+
+        /// Particle counts including ghost particles
         std::shared_ptr<shamrock::solvergraph::Indexes<u32>> part_counts_with_ghost;
 
-        /// Position and smoothing length fields with ghosts
+        /// Patch rank ownership mapping
+        std::shared_ptr<shamrock::solvergraph::ScalarsEdge<u32>> patch_rank_owner;
+
+        // =====================================================================
+        // SolverGraph edges - Field references
+        // =====================================================================
+
+        /// Position field references with ghost particles
         std::shared_ptr<shamrock::solvergraph::FieldRefs<Tvec>> positions_with_ghosts;
+
+        /// Smoothing length field references with ghost particles
         std::shared_ptr<shamrock::solvergraph::FieldRefs<Tscal>> hpart_with_ghosts;
+
+        // =====================================================================
+        // SolverGraph edges - Neighbor cache (reuse from SPH)
+        // =====================================================================
 
         /// Neighbor cache - uses shamrock's tree-based neighbor search
         std::shared_ptr<shammodels::sph::solvergraph::NeighCache> neigh_cache;
 
-        /// Patch rank ownership
-        std::shared_ptr<shamrock::solvergraph::ScalarsEdge<u32>> patch_rank_owner;
+        // =====================================================================
+        // SolverGraph edges - Infrastructure (GSPH-specific)
+        // =====================================================================
 
-        /// Serial patch tree for load balancing
-        Component<SerialPatchTree<Tvec>> serial_patch_tree;
+        /// Serial patch tree for load balancing and interface detection
+        std::shared_ptr<solvergraph::SerialPatchTreeEdge<Tvec>> serial_patch_tree;
 
-        /// Ghost handler for boundary particles
-        Component<GhostHandle> ghost_handler;
-        Component<GhostHandleCache> ghost_patch_cache;
+        /// Ghost handler for boundary particle communication
+        std::shared_ptr<solvergraph::GhostHandlerEdge<Tvec>> ghost_handler;
 
-        /// Merged position-h data for neighbor search
-        Component<shambase::DistributedData<shamrock::patch::PatchDataLayer>> merged_xyzh;
+        /// Ghost interface cache for communication optimization
+        std::shared_ptr<solvergraph::GhostCacheEdge<Tvec>> ghost_patch_cache;
+
+        /// Merged position-h data for neighbor search (local + ghost)
+        std::shared_ptr<solvergraph::MergedPatchDataEdge> merged_xyzh;
+
+        /// Merged patchdata including all ghost fields
+        std::shared_ptr<solvergraph::MergedPatchDataEdge> merged_patchdata_ghost;
+
+        // =====================================================================
+        // Legacy Component storage (trees - complex lifecycle, migrate later)
+        // =====================================================================
 
         /// Radix trees for neighbor search
         Component<shambase::DistributedData<RTree>> merged_pos_trees;
         Component<shambase::DistributedData<shamtree::KarrasRadixTreeField<Tscal>>>
             rtree_rint_field;
 
+        // =====================================================================
+        // SolverGraph edges - Computed fields
+        // =====================================================================
+
         /// Grad-h correction factor (Omega)
         std::shared_ptr<shamrock::solvergraph::Field<Tscal>> omega;
-
-        /// Ghost data layout and merged data
-        std::shared_ptr<shamrock::patch::PatchDataLayerLayout> xyzh_ghost_layout;
-        std::shared_ptr<shamrock::patch::PatchDataLayerLayout> ghost_layout;
-        Component<shambase::DistributedData<shamrock::patch::PatchDataLayer>>
-            merged_patchdata_ghost;
 
         /// Density field computed via SPH summation
         std::shared_ptr<shamrock::solvergraph::Field<Tscal>> density;
 
-        /// Thermodynamic fields computed from EOS
+        /// Pressure from EOS
         std::shared_ptr<shamrock::solvergraph::Field<Tscal>> pressure;
+
+        /// Sound speed from EOS
         std::shared_ptr<shamrock::solvergraph::Field<Tscal>> soundspeed;
 
         /// Gradient fields for MUSCL reconstruction (2nd order)
@@ -123,13 +185,21 @@ namespace shammodels::gsph {
         std::shared_ptr<shamrock::solvergraph::Field<Tvec>> grad_vy;       ///< \nabla v_y
         std::shared_ptr<shamrock::solvergraph::Field<Tvec>> grad_vz;       ///< \nabla v_z
 
-        /// Minimum h/c_s for CFL timestep calculation
-        /// For pure GSPH hydrodynamics: dt_CFL = C_cour * h / c_s
-        Tscal h_per_cs_min = std::numeric_limits<Tscal>::max();
-
         /// Old derivatives for predictor-corrector integration
         Component<shamrock::ComputeField<Tvec>> old_axyz;
         Component<shamrock::ComputeField<Tscal>> old_duint;
+
+        // =====================================================================
+        // Non-graph storage
+        // =====================================================================
+
+        /// Ghost data layout pointers
+        std::shared_ptr<shamrock::patch::PatchDataLayerLayout> xyzh_ghost_layout;
+        std::shared_ptr<shamrock::patch::PatchDataLayerLayout> ghost_layout;
+
+        /// Minimum h/c_s for CFL timestep calculation
+        /// For pure GSPH hydrodynamics: dt_CFL = C_cour * h / c_s
+        Tscal h_per_cs_min = std::numeric_limits<Tscal>::max();
 
         /// Timing statistics
         struct Timings {

--- a/src/shammodels/gsph/include/shammodels/gsph/solvergraph/GhostCacheEdge.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/solvergraph/GhostCacheEdge.hpp
@@ -1,0 +1,82 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2026 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file GhostCacheEdge.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief SolverGraph edge for GSPH ghost cache
+ */
+
+#include "shambase/memory.hpp"
+#include "shammodels/gsph/modules/GSPHGhostHandler.hpp"
+#include "shamrock/solvergraph/IEdgeNamed.hpp"
+#include <optional>
+
+namespace shammodels::gsph::solvergraph {
+
+    /**
+     * @brief SolverGraph edge wrapping the ghost interface cache
+     *
+     * This edge stores the cache map used for ghost particle communication.
+     * The cache is built per timestep based on the current particle distribution
+     * and freed after the force computation.
+     *
+     * @tparam Tvec Vector type (e.g., f64_3)
+     */
+    template<class Tvec>
+    class GhostCacheEdge : public shamrock::solvergraph::IEdgeNamed {
+        public:
+        using IEdgeNamed::IEdgeNamed;
+        using GhostHandle = GSPHGhostHandler<Tvec>;
+        using CacheMap    = typename GhostHandle::CacheMap;
+
+        std::optional<CacheMap> cache;
+
+        /**
+         * @brief Get the ghost cache
+         * @throws std::runtime_error if cache is not set
+         */
+        CacheMap &get() {
+            if (!cache.has_value()) {
+                shambase::throw_with_loc<std::runtime_error>("GhostCache not set");
+            }
+            return cache.value();
+        }
+
+        /**
+         * @brief Get the ghost cache (const)
+         * @throws std::runtime_error if cache is not set
+         */
+        const CacheMap &get() const {
+            if (!cache.has_value()) {
+                shambase::throw_with_loc<std::runtime_error>("GhostCache not set");
+            }
+            return cache.value();
+        }
+
+        /**
+         * @brief Check if the cache is set
+         */
+        bool has_value() const { return cache.has_value(); }
+
+        /**
+         * @brief Set the ghost cache
+         * @param c The cache map to store
+         */
+        void set(CacheMap &&c) { cache = std::move(c); }
+
+        /**
+         * @brief Free the allocated cache
+         */
+        inline virtual void free_alloc() override { cache.reset(); }
+    };
+
+} // namespace shammodels::gsph::solvergraph

--- a/src/shammodels/gsph/include/shammodels/gsph/solvergraph/GhostHandlerEdge.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/solvergraph/GhostHandlerEdge.hpp
@@ -1,0 +1,84 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2026 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file GhostHandlerEdge.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief SolverGraph edge for GSPH ghost handler
+ */
+
+#include "shambase/memory.hpp"
+#include "shammodels/gsph/modules/GSPHGhostHandler.hpp"
+#include "shamrock/solvergraph/IEdgeNamed.hpp"
+#include <optional>
+
+namespace shammodels::gsph::solvergraph {
+
+    /**
+     * @brief SolverGraph edge wrapping the GSPHGhostHandler
+     *
+     * This edge provides storage for the ghost handler used in GSPH
+     * boundary condition processing. The handler is created per timestep
+     * and freed after use.
+     *
+     * @tparam Tvec Vector type (e.g., f64_3)
+     */
+    template<class Tvec>
+    class GhostHandlerEdge : public shamrock::solvergraph::IEdgeNamed {
+        public:
+        using IEdgeNamed::IEdgeNamed;
+        using GhostHandle = GSPHGhostHandler<Tvec>;
+
+        std::optional<GhostHandle> handler;
+
+        /**
+         * @brief Get the ghost handler
+         * @throws std::runtime_error if handler is not set
+         */
+        GhostHandle &get() {
+            if (!handler.has_value()) {
+                shambase::throw_with_loc<std::runtime_error>("GhostHandler not set");
+            }
+            return handler.value();
+        }
+
+        /**
+         * @brief Get the ghost handler (const)
+         * @throws std::runtime_error if handler is not set
+         */
+        const GhostHandle &get() const {
+            if (!handler.has_value()) {
+                shambase::throw_with_loc<std::runtime_error>("GhostHandler not set");
+            }
+            return handler.value();
+        }
+
+        /**
+         * @brief Check if the handler is set
+         */
+        bool has_value() const { return handler.has_value(); }
+
+        /**
+         * @brief Set the ghost handler
+         * @param h The ghost handler to store
+         */
+        void set(GhostHandle &&h) {
+            handler.reset();
+            handler.emplace(std::move(h));
+        }
+
+        /**
+         * @brief Free the allocated handler
+         */
+        inline virtual void free_alloc() override { handler.reset(); }
+    };
+
+} // namespace shammodels::gsph::solvergraph

--- a/src/shammodels/gsph/include/shammodels/gsph/solvergraph/MergedPatchDataEdge.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/solvergraph/MergedPatchDataEdge.hpp
@@ -1,0 +1,69 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2026 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file MergedPatchDataEdge.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief SolverGraph edge for merged PatchDataLayer
+ */
+
+#include "shambase/DistributedData.hpp"
+#include "shambase/memory.hpp"
+#include "shamrock/patch/PatchDataLayer.hpp"
+#include "shamrock/solvergraph/IEdgeNamed.hpp"
+
+namespace shammodels::gsph::solvergraph {
+
+    /**
+     * @brief SolverGraph edge for merged PatchDataLayer storage
+     *
+     * This edge stores distributed PatchDataLayer data that contains
+     * merged local and ghost particle information. Used for:
+     * - merged_xyzh: Position and smoothing length data for tree building
+     * - merged_patchdata_ghost: Full field data including ghosts for force computation
+     */
+    class MergedPatchDataEdge : public shamrock::solvergraph::IEdgeNamed {
+        public:
+        using IEdgeNamed::IEdgeNamed;
+
+        shambase::DistributedData<shamrock::patch::PatchDataLayer> data;
+
+        /**
+         * @brief Get PatchDataLayer for a specific patch
+         * @param id Patch ID
+         */
+        shamrock::patch::PatchDataLayer &get(u64 id) { return data.get(id); }
+
+        /**
+         * @brief Get PatchDataLayer for a specific patch (const)
+         * @param id Patch ID
+         */
+        const shamrock::patch::PatchDataLayer &get(u64 id) const { return data.get(id); }
+
+        /**
+         * @brief Get the underlying distributed data
+         */
+        shambase::DistributedData<shamrock::patch::PatchDataLayer> &get_data() { return data; }
+
+        /**
+         * @brief Get the underlying distributed data (const)
+         */
+        const shambase::DistributedData<shamrock::patch::PatchDataLayer> &get_data() const {
+            return data;
+        }
+
+        /**
+         * @brief Free the allocated data
+         */
+        inline virtual void free_alloc() override { data = {}; }
+    };
+
+} // namespace shammodels::gsph::solvergraph

--- a/src/shammodels/gsph/include/shammodels/gsph/solvergraph/SerialPatchTreeEdge.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/solvergraph/SerialPatchTreeEdge.hpp
@@ -1,0 +1,80 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2026 Timothee David--Cleris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file SerialPatchTreeEdge.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief SolverGraph edge for SerialPatchTree
+ */
+
+#include "shambase/memory.hpp"
+#include "shamrock/scheduler/SerialPatchTree.hpp"
+#include "shamrock/solvergraph/IEdgeNamed.hpp"
+#include <optional>
+
+namespace shammodels::gsph::solvergraph {
+
+    /**
+     * @brief SolverGraph edge wrapping the SerialPatchTree
+     *
+     * This edge stores the serial patch tree used for load balancing
+     * and ghost particle interface detection. The tree is rebuilt
+     * each timestep based on the current particle distribution.
+     *
+     * @tparam Tvec Vector type (e.g., f64_3)
+     */
+    template<class Tvec>
+    class SerialPatchTreeEdge : public shamrock::solvergraph::IEdgeNamed {
+        public:
+        using IEdgeNamed::IEdgeNamed;
+
+        std::optional<SerialPatchTree<Tvec>> tree;
+
+        /**
+         * @brief Get the serial patch tree
+         * @throws std::runtime_error if tree is not set
+         */
+        SerialPatchTree<Tvec> &get() {
+            if (!tree.has_value()) {
+                shambase::throw_with_loc<std::runtime_error>("SerialPatchTree not set");
+            }
+            return tree.value();
+        }
+
+        /**
+         * @brief Get the serial patch tree (const)
+         * @throws std::runtime_error if tree is not set
+         */
+        const SerialPatchTree<Tvec> &get() const {
+            if (!tree.has_value()) {
+                shambase::throw_with_loc<std::runtime_error>("SerialPatchTree not set");
+            }
+            return tree.value();
+        }
+
+        /**
+         * @brief Check if the tree is set
+         */
+        bool has_value() const { return tree.has_value(); }
+
+        /**
+         * @brief Set the serial patch tree
+         * @param t The tree to store
+         */
+        void set(SerialPatchTree<Tvec> &&t) { tree = std::move(t); }
+
+        /**
+         * @brief Free the allocated tree
+         */
+        inline virtual void free_alloc() override { tree.reset(); }
+    };
+
+} // namespace shammodels::gsph::solvergraph

--- a/src/shammodels/gsph/src/Solver.cpp
+++ b/src/shammodels/gsph/src/Solver.cpp
@@ -69,42 +69,84 @@
 template<class Tvec, template<class> class Kern>
 void shammodels::gsph::Solver<Tvec, Kern>::init_solver_graph() {
 
-    storage.part_counts = std::make_shared<shamrock::solvergraph::Indexes<u32>>(
-        edges::part_counts, "N_{\\rm part}");
+    using namespace shamrock::solvergraph;
 
-    storage.part_counts_with_ghost = std::make_shared<shamrock::solvergraph::Indexes<u32>>(
-        edges::part_counts_with_ghost, "N_{\\rm part, with ghost}");
+    SolverGraph &solver_graph = storage.solver_graph;
 
-    storage.patch_rank_owner = std::make_shared<shamrock::solvergraph::ScalarsEdge<u32>>(
-        edges::patch_rank_owner, "rank");
+    // =========================================================================
+    // Register particle count and index edges
+    // =========================================================================
+    storage.part_counts = solver_graph.register_edge(
+        edges::part_counts, Indexes<u32>(edges::part_counts, "N_{\\rm part}"));
 
-    // Merged ghost spans
-    storage.positions_with_ghosts = std::make_shared<shamrock::solvergraph::FieldRefs<Tvec>>(
-        edges::positions_with_ghosts, "\\mathbf{r}");
-    storage.hpart_with_ghosts
-        = std::make_shared<shamrock::solvergraph::FieldRefs<Tscal>>(edges::hpart_with_ghosts, "h");
+    storage.part_counts_with_ghost = solver_graph.register_edge(
+        edges::part_counts_with_ghost,
+        Indexes<u32>(edges::part_counts_with_ghost, "N_{\\rm part, ghost}"));
 
-    storage.neigh_cache
-        = std::make_shared<shammodels::sph::solvergraph::NeighCache>(edges::neigh_cache, "neigh");
+    storage.patch_rank_owner = solver_graph.register_edge(
+        edges::patch_rank_owner, ScalarsEdge<u32>(edges::patch_rank_owner, "rank"));
 
-    storage.omega    = std::make_shared<shamrock::solvergraph::Field<Tscal>>(1, "omega", "\\Omega");
-    storage.density  = std::make_shared<shamrock::solvergraph::Field<Tscal>>(1, "density", "\\rho");
-    storage.pressure = std::make_shared<shamrock::solvergraph::Field<Tscal>>(1, "pressure", "P");
+    // =========================================================================
+    // Register field reference edges (with ghosts)
+    // =========================================================================
+    storage.positions_with_ghosts = solver_graph.register_edge(
+        edges::positions_with_ghosts, FieldRefs<Tvec>(edges::positions_with_ghosts, "\\mathbf{r}"));
+
+    storage.hpart_with_ghosts = solver_graph.register_edge(
+        edges::hpart_with_ghosts, FieldRefs<Tscal>(edges::hpart_with_ghosts, "h"));
+
+    // =========================================================================
+    // Register neighbor cache edge (reuse SPH implementation)
+    // =========================================================================
+    storage.neigh_cache = solver_graph.register_edge(
+        edges::neigh_cache, shammodels::sph::solvergraph::NeighCache(edges::neigh_cache, "neigh"));
+
+    // =========================================================================
+    // Register GSPH infrastructure edges
+    // =========================================================================
+    storage.serial_patch_tree = solver_graph.register_edge(
+        "serial_patch_tree",
+        solvergraph::SerialPatchTreeEdge<Tvec>("serial_patch_tree", "\\mathcal{T}_{\\rm patch}"));
+
+    storage.ghost_handler = solver_graph.register_edge(
+        "ghost_handler", solvergraph::GhostHandlerEdge<Tvec>("ghost_handler", "\\mathcal{G}"));
+
+    storage.ghost_patch_cache = solver_graph.register_edge(
+        "ghost_patch_cache",
+        solvergraph::GhostCacheEdge<Tvec>("ghost_patch_cache", "\\mathcal{C}_{\\rm ghost}"));
+
+    storage.merged_xyzh = solver_graph.register_edge(
+        "merged_xyzh", solvergraph::MergedPatchDataEdge("merged_xyzh", "\\mathbf{xyzh}_{\\rm m}"));
+
+    storage.merged_patchdata_ghost = solver_graph.register_edge(
+        "merged_patchdata_ghost",
+        solvergraph::MergedPatchDataEdge("merged_patchdata_ghost", "\\mathbb{U}_{\\rm ghost}"));
+
+    // =========================================================================
+    // Register computed field edges
+    // =========================================================================
+    storage.omega    = solver_graph.register_edge("omega", Field<Tscal>(1, "omega", "\\Omega"));
+    storage.density  = solver_graph.register_edge("density", Field<Tscal>(1, "density", "\\rho"));
+    storage.pressure = solver_graph.register_edge("pressure", Field<Tscal>(1, "pressure", "P"));
     storage.soundspeed
-        = std::make_shared<shamrock::solvergraph::Field<Tscal>>(1, "soundspeed", "c_s");
+        = solver_graph.register_edge("soundspeed", Field<Tscal>(1, "soundspeed", "c_s"));
 
-    // Initialize gradient fields for MUSCL reconstruction
+    // Gradient fields for MUSCL reconstruction (2nd order)
     // These are only used when reconstruct_config.is_muscl() == true
-    storage.grad_density
-        = std::make_shared<shamrock::solvergraph::Field<Tvec>>(1, "grad_density", "\\nabla\\rho");
+    storage.grad_density = solver_graph.register_edge(
+        "grad_density", Field<Tvec>(1, "grad_density", "\\nabla\\rho"));
     storage.grad_pressure
-        = std::make_shared<shamrock::solvergraph::Field<Tvec>>(1, "grad_pressure", "\\nabla P");
+        = solver_graph.register_edge("grad_pressure", Field<Tvec>(1, "grad_pressure", "\\nabla P"));
     storage.grad_vx
-        = std::make_shared<shamrock::solvergraph::Field<Tvec>>(1, "grad_vx", "\\nabla v_x");
+        = solver_graph.register_edge("grad_vx", Field<Tvec>(1, "grad_vx", "\\nabla v_x"));
     storage.grad_vy
-        = std::make_shared<shamrock::solvergraph::Field<Tvec>>(1, "grad_vy", "\\nabla v_y");
+        = solver_graph.register_edge("grad_vy", Field<Tvec>(1, "grad_vy", "\\nabla v_y"));
     storage.grad_vz
-        = std::make_shared<shamrock::solvergraph::Field<Tvec>>(1, "grad_vz", "\\nabla v_z");
+        = solver_graph.register_edge("grad_vz", Field<Tvec>(1, "grad_vz", "\\nabla v_z"));
+
+    // Note: old_axyz and old_duint are managed as Component<ComputeField<...>>
+    // for predictor-corrector integration, not as solvergraph Field edges.
+    // They are set/reset in prepare_corrector() and apply_corrector().
 }
 
 template<class Tvec, template<class> class Kern>
@@ -120,7 +162,7 @@ void shammodels::gsph::Solver<Tvec, Kern>::gen_serial_patch_tree() {
 
     SerialPatchTree<Tvec> _sptree = SerialPatchTree<Tvec>::build(scheduler());
     _sptree.attach_buf();
-    storage.serial_patch_tree.set(std::move(_sptree));
+    shambase::get_check_ref(storage.serial_patch_tree).set(std::move(_sptree));
 }
 
 template<class Tvec, template<class> class Kern>
@@ -142,26 +184,32 @@ void shammodels::gsph::Solver<Tvec, Kern>::gen_ghost_handler(Tscal time_val) {
     // Boundary condition selection - similar to SPH solver
     // Note: Wall boundaries use Periodic with dynamic wall particles
     if (SolverBCFree *c = std::get_if<SolverBCFree>(&solver_config.boundary_config.config)) {
-        storage.ghost_handler.set(
-            GhostHandle{
-                scheduler(), BCFree{}, storage.patch_rank_owner, storage.xyzh_ghost_layout});
+        shambase::get_check_ref(storage.ghost_handler)
+            .set(
+                GhostHandle{
+                    scheduler(), BCFree{}, storage.patch_rank_owner, storage.xyzh_ghost_layout});
     } else if (
         SolverBCPeriodic *c
         = std::get_if<SolverBCPeriodic>(&solver_config.boundary_config.config)) {
-        storage.ghost_handler.set(
-            GhostHandle{
-                scheduler(), BCPeriodic{}, storage.patch_rank_owner, storage.xyzh_ghost_layout});
+        shambase::get_check_ref(storage.ghost_handler)
+            .set(
+                GhostHandle{
+                    scheduler(),
+                    BCPeriodic{},
+                    storage.patch_rank_owner,
+                    storage.xyzh_ghost_layout});
     } else if (
         SolverBCShearingPeriodic *c
         = std::get_if<SolverBCShearingPeriodic>(&solver_config.boundary_config.config)) {
         // Shearing periodic boundaries (Stone 2010) - reuse SPH implementation
-        storage.ghost_handler.set(
-            GhostHandle{
-                scheduler(),
-                BCShearingPeriodic{
-                    c->shear_base, c->shear_dir, c->shear_speed * time_val, c->shear_speed},
-                storage.patch_rank_owner,
-                storage.xyzh_ghost_layout});
+        shambase::get_check_ref(storage.ghost_handler)
+            .set(
+                GhostHandle{
+                    scheduler(),
+                    BCShearingPeriodic{
+                        c->shear_base, c->shear_dir, c->shear_speed * time_val, c->shear_speed},
+                    storage.patch_rank_owner,
+                    storage.xyzh_ghost_layout});
     } else {
         shambase::throw_with_loc<std::runtime_error>("GSPH: Unsupported boundary condition type.");
     }
@@ -174,24 +222,27 @@ void shammodels::gsph::Solver<Tvec, Kern>::build_ghost_cache() {
     using GSPHUtils = GSPHUtilities<Tvec, Kernel>;
     GSPHUtils gsph_utils(scheduler());
 
-    storage.ghost_patch_cache.set(gsph_utils.build_interf_cache(
-        storage.ghost_handler.get(),
-        storage.serial_patch_tree.get(),
-        solver_config.htol_up_coarse_cycle));
+    shambase::get_check_ref(storage.ghost_patch_cache)
+        .set(gsph_utils.build_interf_cache(
+            shambase::get_check_ref(storage.ghost_handler).get(),
+            shambase::get_check_ref(storage.serial_patch_tree).get(),
+            solver_config.htol_up_coarse_cycle));
 }
 
 template<class Tvec, template<class> class Kern>
 void shammodels::gsph::Solver<Tvec, Kern>::clear_ghost_cache() {
     StackEntry stack_loc{};
-    storage.ghost_patch_cache.reset();
+    shambase::get_check_ref(storage.ghost_patch_cache).free_alloc();
 }
 
 template<class Tvec, template<class> class Kern>
 void shammodels::gsph::Solver<Tvec, Kern>::merge_position_ghost() {
     StackEntry stack_loc{};
 
-    storage.merged_xyzh.set(
-        storage.ghost_handler.get().build_comm_merge_positions(storage.ghost_patch_cache.get()));
+    shambase::get_check_ref(storage.merged_xyzh).data
+        = shambase::get_check_ref(storage.ghost_handler)
+              .get()
+              .build_comm_merge_positions(shambase::get_check_ref(storage.ghost_patch_cache).get());
 
     // Get field indices from xyzh_ghost_layout
     const u32 ixyz_ghost
@@ -199,31 +250,31 @@ void shammodels::gsph::Solver<Tvec, Kern>::merge_position_ghost() {
     const u32 ihpart_ghost
         = storage.xyzh_ghost_layout->template get_field_idx<Tscal>(gsph::names::common::hpart);
 
+    auto &merged_xyzh = shambase::get_check_ref(storage.merged_xyzh);
+
     // Set element counts
-    shambase::get_check_ref(storage.part_counts).indexes
-        = storage.merged_xyzh.get().template map<u32>(
-            [&](u64 id, shamrock::patch::PatchDataLayer &mpdat) {
-                return scheduler().patch_data.get_pdat(id).get_obj_cnt();
-            });
+    shambase::get_check_ref(storage.part_counts).indexes = merged_xyzh.get_data().template map<u32>(
+        [&](u64 id, shamrock::patch::PatchDataLayer &mpdat) {
+            return scheduler().patch_data.get_pdat(id).get_obj_cnt();
+        });
 
     // Set element counts with ghost
     shambase::get_check_ref(storage.part_counts_with_ghost).indexes
-        = storage.merged_xyzh.get().template map<u32>(
+        = merged_xyzh.get_data().template map<u32>(
             [&](u64 id, shamrock::patch::PatchDataLayer &mpdat) {
                 return mpdat.get_obj_cnt();
             });
 
     // Attach spans to block coords
     shambase::get_check_ref(storage.positions_with_ghosts)
-        .set_refs(
-            storage.merged_xyzh.get().template map<std::reference_wrapper<PatchDataField<Tvec>>>(
-                [&, ixyz_ghost](u64 id, shamrock::patch::PatchDataLayer &mpdat) {
-                    return std::ref(mpdat.get_field<Tvec>(ixyz_ghost));
-                }));
+        .set_refs(merged_xyzh.get_data().template map<std::reference_wrapper<PatchDataField<Tvec>>>(
+            [&, ixyz_ghost](u64 id, shamrock::patch::PatchDataLayer &mpdat) {
+                return std::ref(mpdat.get_field<Tvec>(ixyz_ghost));
+            }));
 
     shambase::get_check_ref(storage.hpart_with_ghosts)
         .set_refs(
-            storage.merged_xyzh.get().template map<std::reference_wrapper<PatchDataField<Tscal>>>(
+            merged_xyzh.get_data().template map<std::reference_wrapper<PatchDataField<Tscal>>>(
                 [&, ihpart_ghost](u64 id, shamrock::patch::PatchDataLayer &mpdat) {
                     return std::ref(mpdat.get_field<Tscal>(ihpart_ghost));
                 }));
@@ -233,7 +284,7 @@ template<class Tvec, template<class> class Kern>
 void shammodels::gsph::Solver<Tvec, Kern>::build_merged_pos_trees() {
     StackEntry stack_loc{};
 
-    auto &merged_xyzh = storage.merged_xyzh.get();
+    auto &merged_xyzh = shambase::get_check_ref(storage.merged_xyzh).get_data();
     auto dev_sched    = shamsys::instance::get_compute_scheduler_ptr();
 
     // Get field index from xyzh_ghost_layout
@@ -278,7 +329,7 @@ template<class Tvec, template<class> class Kern>
 void shammodels::gsph::Solver<Tvec, Kern>::compute_presteps_rint() {
     StackEntry stack_loc{};
 
-    auto &xyzh_merged = storage.merged_xyzh.get();
+    auto &xyzh_merged = shambase::get_check_ref(storage.merged_xyzh).get_data();
     auto dev_sched    = shamsys::instance::get_compute_scheduler_ptr();
 
     storage.rtree_rint_field.set(
@@ -324,7 +375,7 @@ void shammodels::gsph::Solver<Tvec, Kern>::start_neighbors_cache() {
 
     // Build neighbor cache using tree traversal - same approach as SPH module
     auto build_neigh_cache = [&](u64 patch_id) -> shamrock::tree::ObjectCache {
-        auto &mfield = storage.merged_xyzh.get().get(patch_id);
+        auto &mfield = shambase::get_check_ref(storage.merged_xyzh).get(patch_id);
 
         sham::DeviceBuffer<Tvec> &buf_xyz    = mfield.template get_field_buf_ref<Tvec>(0);
         sham::DeviceBuffer<Tscal> &buf_hpart = mfield.template get_field_buf_ref<Tscal>(1);
@@ -540,7 +591,8 @@ void shammodels::gsph::Solver<Tvec, Kern>::apply_position_boundary(Tscal time_va
         shambase::throw_with_loc<std::runtime_error>("GSPH: Unsupported boundary condition type.");
     }
 
-    reatrib.reatribute_patch_objects(storage.serial_patch_tree.get(), gsph::names::common::xyz);
+    reatrib.reatribute_patch_objects(
+        shambase::get_check_ref(storage.serial_patch_tree).get(), gsph::names::common::xyz);
 }
 
 template<class Tvec, template<class> class Kern>
@@ -665,7 +717,8 @@ void shammodels::gsph::Solver<Tvec, Kern>::communicate_merge_ghosts_fields() {
 
     using InterfaceBuildInfos = typename gsph::GSPHGhostHandler<Tvec>::InterfaceBuildInfos;
 
-    gsph::GSPHGhostHandler<Tvec> &ghost_handle   = storage.ghost_handler.get();
+    gsph::GSPHGhostHandler<Tvec> &ghost_handle
+        = shambase::get_check_ref(storage.ghost_handler).get();
     shamrock::solvergraph::Field<Tscal> &omega   = shambase::get_check_ref(storage.omega);
     shamrock::solvergraph::Field<Tscal> &density = shambase::get_check_ref(storage.density);
 
@@ -683,7 +736,7 @@ void shammodels::gsph::Solver<Tvec, Kern>::communicate_merge_ghosts_fields() {
 
     // Build interface data from ghost cache
     auto pdat_interf = ghost_handle.template build_interface_native<PatchDataLayer>(
-        storage.ghost_patch_cache.get(),
+        shambase::get_check_ref(storage.ghost_patch_cache).get(),
         [&](u64 sender, u64, InterfaceBuildInfos binfo, sham::DeviceBuffer<u32> &buf_idx, u32 cnt) {
             PatchDataLayer pdat(ghost_layout_ptr);
             pdat.reserve(cnt);
@@ -692,7 +745,7 @@ void shammodels::gsph::Solver<Tvec, Kern>::communicate_merge_ghosts_fields() {
 
     // Populate interface data with field values
     ghost_handle.template modify_interface_native<PatchDataLayer>(
-        storage.ghost_patch_cache.get(),
+        shambase::get_check_ref(storage.ghost_patch_cache).get(),
         pdat_interf,
         [&](u64 sender,
             u64,
@@ -733,7 +786,7 @@ void shammodels::gsph::Solver<Tvec, Kern>::communicate_merge_ghosts_fields() {
 
     // Apply velocity offset for periodic boundaries
     ghost_handle.template modify_interface_native<PatchDataLayer>(
-        storage.ghost_patch_cache.get(),
+        shambase::get_check_ref(storage.ghost_patch_cache).get(),
         pdat_interf,
         [&](u64 sender,
             u64,
@@ -757,8 +810,8 @@ void shammodels::gsph::Solver<Tvec, Kern>::communicate_merge_ghosts_fields() {
     });
 
     // Merge local and ghost data
-    storage.merged_patchdata_ghost.set(
-        ghost_handle.template merge_native<PatchDataLayer, PatchDataLayer>(
+    shambase::get_check_ref(storage.merged_patchdata_ghost).data
+        = ghost_handle.template merge_native<PatchDataLayer, PatchDataLayer>(
             std::move(interf_pdat),
             [&](const shamrock::patch::Patch p, shamrock::patch::PatchDataLayer &pdat) {
                 PatchDataLayer pdat_new(ghost_layout_ptr);
@@ -795,7 +848,7 @@ void shammodels::gsph::Solver<Tvec, Kern>::communicate_merge_ghosts_fields() {
             },
             [](PatchDataLayer &pdat, PatchDataLayer &pdat_interf) {
                 pdat.insert_elements(pdat_interf);
-            }));
+            });
 
     timer_interf.end();
     storage.timings_details.interface += timer_interf.elasped_sec();
@@ -803,7 +856,7 @@ void shammodels::gsph::Solver<Tvec, Kern>::communicate_merge_ghosts_fields() {
 
 template<class Tvec, template<class> class Kern>
 void shammodels::gsph::Solver<Tvec, Kern>::reset_merge_ghosts_fields() {
-    storage.merged_patchdata_ghost.reset();
+    shambase::get_check_ref(storage.merged_patchdata_ghost).free_alloc();
 }
 
 template<class Tvec, template<class> class Kern>
@@ -856,7 +909,7 @@ void shammodels::gsph::Solver<Tvec, Kern>::compute_omega() {
     // 3. If h grows beyond tolerance, signal for cache rebuild
     // =========================================================================
 
-    auto &merged_xyzh = storage.merged_xyzh.get();
+    auto &merged_xyzh = shambase::get_check_ref(storage.merged_xyzh).get_data();
 
     // Create field references for the iteration module
     // Position spans (from merged xyzh)
@@ -1129,73 +1182,77 @@ void shammodels::gsph::Solver<Tvec, Kern>::compute_eos_fields() {
     soundspeed_field.ensure_sizes(counts_with_ghosts);
 
     // Iterate over merged_patchdata_ghost (includes local + ghost particles)
-    storage.merged_patchdata_ghost.get().for_each([&](u64 id, PatchDataLayer &mpdat) {
-        u32 total_elements
-            = shambase::get_check_ref(storage.part_counts_with_ghost).indexes.get(id);
-        if (total_elements == 0)
-            return;
+    shambase::get_check_ref(storage.merged_patchdata_ghost)
+        .get_data()
+        .for_each([&](u64 id, PatchDataLayer &mpdat) {
+            u32 total_elements
+                = shambase::get_check_ref(storage.part_counts_with_ghost).indexes.get(id);
+            if (total_elements == 0)
+                return;
 
-        // Use SPH-summation density from communicated ghost data
-        sham::DeviceBuffer<Tscal> &buf_density = mpdat.get_field_buf_ref<Tscal>(idensity_interf);
-        auto &pressure_buf                     = pressure_field.get_field(id).get_buf();
-        auto &soundspeed_buf                   = soundspeed_field.get_field(id).get_buf();
+            // Use SPH-summation density from communicated ghost data
+            sham::DeviceBuffer<Tscal> &buf_density
+                = mpdat.get_field_buf_ref<Tscal>(idensity_interf);
+            auto &pressure_buf   = pressure_field.get_field(id).get_buf();
+            auto &soundspeed_buf = soundspeed_field.get_field(id).get_buf();
 
-        sham::DeviceQueue &q = dev_sched->get_queue();
-        sham::EventList depends_list;
+            sham::DeviceQueue &q = dev_sched->get_queue();
+            sham::EventList depends_list;
 
-        auto density    = buf_density.get_read_access(depends_list);
-        auto pressure   = pressure_buf.get_write_access(depends_list);
-        auto soundspeed = soundspeed_buf.get_write_access(depends_list);
+            auto density    = buf_density.get_read_access(depends_list);
+            auto pressure   = pressure_buf.get_write_access(depends_list);
+            auto soundspeed = soundspeed_buf.get_write_access(depends_list);
 
-        const Tscal *uint_ptr = nullptr;
-        if (has_uint) {
-            uint_ptr = mpdat.get_field_buf_ref<Tscal>(iuint_interf).get_read_access(depends_list);
-        }
+            const Tscal *uint_ptr = nullptr;
+            if (has_uint) {
+                uint_ptr
+                    = mpdat.get_field_buf_ref<Tscal>(iuint_interf).get_read_access(depends_list);
+            }
 
-        auto e = q.submit(depends_list, [&](sycl::handler &cgh) {
-            shambase::parallel_for(cgh, total_elements, "compute_eos_gsph", [=](u64 gid) {
-                u32 i = (u32) gid;
+            auto e = q.submit(depends_list, [&](sycl::handler &cgh) {
+                shambase::parallel_for(cgh, total_elements, "compute_eos_gsph", [=](u64 gid) {
+                    u32 i = (u32) gid;
 
-                // Use SPH-summation density (from compute_omega, communicated to ghosts)
-                Tscal rho = density[i];
-                rho       = sycl::max(rho, Tscal(1e-30));
+                    // Use SPH-summation density (from compute_omega, communicated to ghosts)
+                    Tscal rho = density[i];
+                    rho       = sycl::max(rho, Tscal(1e-30));
 
-                if (has_uint && uint_ptr != nullptr) {
-                    // Adiabatic EOS (reference: g_pre_interaction.cpp line 107)
-                    // P = (\gamma - 1) * \rho * u
-                    Tscal u = uint_ptr[i];
-                    u       = sycl::max(u, Tscal(1e-30));
-                    Tscal P = (gamma - Tscal(1.0)) * rho * u;
+                    if (has_uint && uint_ptr != nullptr) {
+                        // Adiabatic EOS (reference: g_pre_interaction.cpp line 107)
+                        // P = (\gamma - 1) * \rho * u
+                        Tscal u = uint_ptr[i];
+                        u       = sycl::max(u, Tscal(1e-30));
+                        Tscal P = (gamma - Tscal(1.0)) * rho * u;
 
-                    // Sound speed from internal energy (reference: solver.cpp line 2661)
-                    // c = sqrt(\gamma * (\gamma - 1) * u)
-                    Tscal cs = sycl::sqrt(gamma * (gamma - Tscal(1.0)) * u);
+                        // Sound speed from internal energy (reference: solver.cpp line 2661)
+                        // c = sqrt(\gamma * (\gamma - 1) * u)
+                        Tscal cs = sycl::sqrt(gamma * (gamma - Tscal(1.0)) * u);
 
-                    // Clamp to reasonable values
-                    P  = sycl::clamp(P, Tscal(1e-30), Tscal(1e30));
-                    cs = sycl::clamp(cs, Tscal(1e-10), Tscal(1e10));
+                        // Clamp to reasonable values
+                        P  = sycl::clamp(P, Tscal(1e-30), Tscal(1e30));
+                        cs = sycl::clamp(cs, Tscal(1e-10), Tscal(1e10));
 
-                    pressure[i]   = P;
-                    soundspeed[i] = cs;
-                } else {
-                    // Isothermal case
-                    Tscal cs = Tscal(1.0);
-                    Tscal P  = cs * cs * rho;
+                        pressure[i]   = P;
+                        soundspeed[i] = cs;
+                    } else {
+                        // Isothermal case
+                        Tscal cs = Tscal(1.0);
+                        Tscal P  = cs * cs * rho;
 
-                    pressure[i]   = P;
-                    soundspeed[i] = cs;
-                }
+                        pressure[i]   = P;
+                        soundspeed[i] = cs;
+                    }
+                });
             });
-        });
 
-        // Complete all buffer event states
-        buf_density.complete_event_state(e);
-        if (has_uint) {
-            mpdat.get_field_buf_ref<Tscal>(iuint_interf).complete_event_state(e);
-        }
-        pressure_buf.complete_event_state(e);
-        soundspeed_buf.complete_event_state(e);
-    });
+            // Complete all buffer event states
+            buf_density.complete_event_state(e);
+            if (has_uint) {
+                mpdat.get_field_buf_ref<Tscal>(iuint_interf).complete_event_state(e);
+            }
+            pressure_buf.complete_event_state(e);
+            soundspeed_buf.complete_event_state(e);
+        });
 }
 
 template<class Tvec, template<class> class Kern>
@@ -1309,7 +1366,7 @@ void shammodels::gsph::Solver<Tvec, Kern>::compute_gradients() {
     grad_vy_field.ensure_sizes(counts);
     grad_vz_field.ensure_sizes(counts);
 
-    auto &merged_xyzh = storage.merged_xyzh.get();
+    auto &merged_xyzh = shambase::get_check_ref(storage.merged_xyzh).get_data();
     auto &neigh_cache = storage.neigh_cache->neigh_cache;
 
     static constexpr Tscal Rkern = Kernel::Rkern;
@@ -1824,7 +1881,7 @@ shammodels::gsph::TimestepLog shammodels::gsph::Solver<Tvec, Kern>::evolve_once(
     reset_presteps_rint();
     clear_merged_pos_trees();
     reset_merge_ghosts_fields();
-    storage.merged_xyzh.reset();
+    shambase::get_check_ref(storage.merged_xyzh).free_alloc();
     clear_ghost_cache();
     reset_serial_patch_tree();
     reset_ghost_handler();

--- a/src/shammodels/gsph/src/modules/UpdateDerivs.cpp
+++ b/src/shammodels/gsph/src/modules/UpdateDerivs.cpp
@@ -84,9 +84,10 @@ void shammodels::gsph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_ite
         = has_uint ? ghost_layout.get_field_idx<Tscal>(gsph::names::newtonian::uint) : 0;
 
     // Get merged data and caches from storage
-    auto &merged_xyzh                                 = storage.merged_xyzh.get();
-    shamrock::solvergraph::Field<Tscal> &omega_field  = shambase::get_check_ref(storage.omega);
-    shambase::DistributedData<PatchDataLayer> &mpdats = storage.merged_patchdata_ghost.get();
+    auto &merged_xyzh = shambase::get_check_ref(storage.merged_xyzh).get_data();
+    shamrock::solvergraph::Field<Tscal> &omega_field = shambase::get_check_ref(storage.omega);
+    shambase::DistributedData<PatchDataLayer> &mpdats
+        = shambase::get_check_ref(storage.merged_patchdata_ghost).get_data();
 
     // Get pressure and soundspeed from storage (includes ghosts)
     shamrock::solvergraph::Field<Tscal> &pressure_field = shambase::get_check_ref(storage.pressure);
@@ -300,9 +301,10 @@ void shammodels::gsph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_hll
     u32 iuint_interf
         = has_uint ? ghost_layout.get_field_idx<Tscal>(gsph::names::newtonian::uint) : 0;
 
-    auto &merged_xyzh                                 = storage.merged_xyzh.get();
-    shamrock::solvergraph::Field<Tscal> &omega_field  = shambase::get_check_ref(storage.omega);
-    shambase::DistributedData<PatchDataLayer> &mpdats = storage.merged_patchdata_ghost.get();
+    auto &merged_xyzh = shambase::get_check_ref(storage.merged_xyzh).get_data();
+    shamrock::solvergraph::Field<Tscal> &omega_field = shambase::get_check_ref(storage.omega);
+    shambase::DistributedData<PatchDataLayer> &mpdats
+        = shambase::get_check_ref(storage.merged_patchdata_ghost).get_data();
 
     // Get pressure and soundspeed from storage (includes ghosts)
     shamrock::solvergraph::Field<Tscal> &pressure_field = shambase::get_check_ref(storage.pressure);


### PR DESCRIPTION
## Summary

Integrate GSPH module with the solvergraph framework for explicit data dependency management.

**Changes:**
- Add custom edge types for GSPH-specific data structures (GhostHandlerEdge, GhostCacheEdge, SerialPatchTreeEdge, MergedPatchDataEdge)
- Update SolverStorage to use solvergraph edges
- Update Solver methods to use solvergraph access pattern
- Keep old_axyz/old_duint as Component for predictor-corrector (matches SPH)

## Test plan

- [x] Build passes
- [x] GSPH Sod shock tube test passes