### PR TITLE
[CI] fix docker-run-action by using a fork of it

### DIFF
--- a/.github/workflows/shamrock-acpp-phys-test.yml
+++ b/.github/workflows/shamrock-acpp-phys-test.yml
@@ -113,7 +113,8 @@ jobs:
           sudo apt install -y gfortran
 
       - name: run test
-        uses: addnab/docker-run-action@v3
+        # see https://github.com/NomicFoundation/edr/pull/1293
+        uses: NomicFoundation/docker-run-action@63f044457cfb71a5c63fa589218c89a418565d9c # Fork of v3 with updated Docker (https://github.com/addnab/docker-run-action/issues/62)
         with:
           image: ci-phys-test-image
           run: |


### PR DESCRIPTION
Temporary fix by using the same as https://github.com/NomicFoundation/edr/pull/1293, see https://github.com/addnab/docker-run-action/issues/62

A long term better option would be to switch to https://github.com/maus007/docker-run-action-fork maybe ?