### PR TITLE
[Pylib][COALA] add direct source term for coagulation

### DIFF
--- a/src/pylib/shamrock/external/coala/interface_coala_shamrock.py
+++ b/src/pylib/shamrock/external/coala/interface_coala_shamrock.py
@@ -37,7 +37,7 @@ def coala_source_term_k0(nbins,massgrid, rhodust, tensor_tabflux_coag, dv):
     flux = compute_flux_coag_k0_kdv(gij, tensor_tabflux_coag, dv)
 
     S_coag = np.zeros(len(rhodust))
-    S_coag[0] = flux[0]
-    S_coag[1:] = -(flux[1:] - flux[0 : nbins - 1])
+    S_coag[0] = -flux[0]
+    S_coag[1:] = flux[:-1] - flux[1:]
 
     return S_coag

--- a/src/pylib/shamrock/external/coala/interface_coala_shamrock.py
+++ b/src/pylib/shamrock/external/coala/interface_coala_shamrock.py
@@ -1,0 +1,43 @@
+from .solver_DG import *
+
+def coala_source_term_k0(nbins,massgrid, rhodust, tensor_tabflux_coag, dv):
+    """
+    Function to compute the source for coagulation and fragmentation in continuity equation for piecewise constant approximation (see Lombart et al., 2021)
+    Function for ballistic kernel with differential velocities dv
+    Used to evaluate the source term, then hydro code applies time solver
+ 
+    /!\ Only coagulation so far
+
+    Parameters
+    ----------
+    nbins : scalar, type -> integer
+       number of dust bins
+    massgrid : 1D array (dim = nbins+1), type -> float
+       grid of masses given borders value of mass bins
+    rhodust : 1D array (dim = nbins), type -> float
+       dust density for each grain size
+    tensor_tabflux_coag : 3D array (dim = (nbins,nbins,nbins)), type -> float
+       array to evaluate coagulation flux
+    dv : 2D array (dim = (nbins,nbins)), type -> float
+       array of the differential velocity between grains
+
+
+    Returns
+    -------
+    S_coag : 1D array (dim = nbins), type -> float
+        Source term for dust coagulation in continuity equation
+        DG operator for piecewise constant approximation in each binls       
+
+    """
+
+    #compute gij from rhodust for coala k=0
+    gij = rhodust/(massgrid[1:] - massgrid[0:nbins])
+
+    #copmute flux for all dust bins
+    flux = compute_flux_coag_k0_kdv(gij, tensor_tabflux_coag, dv)
+
+    S_coag = np.zeros(len(rhodust))
+    S_coag[0] = flux[0]
+    S_coag[1:] = -(flux[1:] - flux[0 : nbins - 1])
+
+    return S_coag

--- a/src/pylib/shamrock/external/coala/interface_coala_shamrock.py
+++ b/src/pylib/shamrock/external/coala/interface_coala_shamrock.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from .generate_flux_intflux import compute_flux_coag_k0_kdv
 
 

--- a/src/pylib/shamrock/external/coala/interface_coala_shamrock.py
+++ b/src/pylib/shamrock/external/coala/interface_coala_shamrock.py
@@ -1,3 +1,4 @@
+import numpy as np
 from .generate_flux_intflux import compute_flux_coag_k0_kdv
 
 

--- a/src/pylib/shamrock/external/coala/interface_coala_shamrock.py
+++ b/src/pylib/shamrock/external/coala/interface_coala_shamrock.py
@@ -1,6 +1,6 @@
-from .solver_DG import *
+from .generate_flux_intflux import compute_flux_coag_k0_kdv
 
-def coala_source_term_k0(nbins,massgrid, rhodust, tensor_tabflux_coag, dv):
+def coala_source_term_k0(nbins,massgrid, rhodust, rhodust_eps, tensor_tabflux_coag, dv):
     """
     Function to compute the source for coagulation and fragmentation in continuity equation for piecewise constant approximation (see Lombart et al., 2021)
     Function for ballistic kernel with differential velocities dv
@@ -16,6 +16,8 @@ def coala_source_term_k0(nbins,massgrid, rhodust, tensor_tabflux_coag, dv):
        grid of masses given borders value of mass bins
     rhodust : 1D array (dim = nbins), type -> float
        dust density for each grain size
+    rhodust_eps : scalar, type -> float
+       threshold value for rhodust
     tensor_tabflux_coag : 3D array (dim = (nbins,nbins,nbins)), type -> float
        array to evaluate coagulation flux
     dv : 2D array (dim = (nbins,nbins)), type -> float
@@ -30,13 +32,18 @@ def coala_source_term_k0(nbins,massgrid, rhodust, tensor_tabflux_coag, dv):
 
     """
 
+
+
     #compute gij from rhodust for coala k=0
-    gij = rhodust/(massgrid[1:] - massgrid[0:nbins])
+    gij = 0.
+    for j in range(nbins):
+        if (rhodust[j] > rhodust_eps):
+            gij[j] = rhodust[j]/(massgrid[j+1] - massgrid[j])
 
     #copmute flux for all dust bins
     flux = compute_flux_coag_k0_kdv(gij, tensor_tabflux_coag, dv)
 
-    S_coag = np.zeros(len(rhodust))
+    S_coag = np.zeros(nbins)
     S_coag[0] = -flux[0]
     S_coag[1:] = flux[:-1] - flux[1:]
 

--- a/src/pylib/shamrock/external/coala/interface_coala_shamrock.py
+++ b/src/pylib/shamrock/external/coala/interface_coala_shamrock.py
@@ -1,11 +1,12 @@
 from .generate_flux_intflux import compute_flux_coag_k0_kdv
 
-def coala_source_term_k0(nbins,massgrid, rhodust, rhodust_eps, tensor_tabflux_coag, dv):
+
+def coala_source_term_k0(nbins, massgrid, rhodust, rhodust_eps, tensor_tabflux_coag, dv):
     """
     Function to compute the source for coagulation and fragmentation in continuity equation for piecewise constant approximation (see Lombart et al., 2021)
     Function for ballistic kernel with differential velocities dv
     Used to evaluate the source term, then hydro code applies time solver
- 
+
     /!\ Only coagulation so far
 
     Parameters
@@ -28,19 +29,17 @@ def coala_source_term_k0(nbins,massgrid, rhodust, rhodust_eps, tensor_tabflux_co
     -------
     S_coag : 1D array (dim = nbins), type -> float
         Source term for dust coagulation in continuity equation
-        DG operator for piecewise constant approximation in each binls       
+        DG operator for piecewise constant approximation in each binls
 
     """
 
-
-
-    #compute gij from rhodust for coala k=0
-    gij = 0.
+    # compute gij from rhodust for coala k=0
+    gij = 0.0
     for j in range(nbins):
-        if (rhodust[j] > rhodust_eps):
-            gij[j] = rhodust[j]/(massgrid[j+1] - massgrid[j])
+        if rhodust[j] > rhodust_eps:
+            gij[j] = rhodust[j] / (massgrid[j + 1] - massgrid[j])
 
-    #copmute flux for all dust bins
+    # copmute flux for all dust bins
     flux = compute_flux_coag_k0_kdv(gij, tensor_tabflux_coag, dv)
 
     S_coag = np.zeros(nbins)


### PR DESCRIPTION
File to interface coala and shamrock in which dust coag term is treated as source term of continuity equation. 
So far only coala with piecewise constant approximation, and only coagulation.