### PR TITLE
[Base] remove __COUNTER__ from unique_name macro (clang-22 c2y extensions)

### DIFF
--- a/src/shambase/include/shambase/unique_name_macro.hpp
+++ b/src/shambase/include/shambase/unique_name_macro.hpp
@@ -25,12 +25,8 @@
  * @fn __shamrock_unique_name
  * @brief Macro to create a unique name.
  *
- * This macro creates a unique identifier from `base_name` using `__COUNTER__` or `__LINE__`.
+ * This macro creates a unique identifier from `base_name` using `__LINE__`.
  * @note The `__LINE__` fallback is not unique for multiple uses on the same line.
  */
 
-#ifdef __COUNTER__
-    #define __shamrock_unique_name(base_name) internal_macro_sham_EXPAND2(base_name, __COUNTER__)
-#else
-    #define __shamrock_unique_name(base_name) internal_macro_sham_EXPAND2(base_name, __LINE__)
-#endif
+#define __shamrock_unique_name(base_name) internal_macro_sham_EXPAND2(base_name, __LINE__)


### PR DESCRIPTION


see https://github.com/catchorg/Catch2/issues/3076