### PR TITLE
[All] ensure that structs are initialized using designated initializers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >
   performance-unnecessary-copy-initialization,
   performance-for-range-copy,
   performance-no-automatic-move,
+  modernize-use-designated-initializers,
 
 # Future options that are likely to be added:
 #

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,7 @@ int main(int argc, char *argv[]) {
         shamsys::instance::init(argc, argv);
     } else {
         using namespace shamsys::instance;
-        start_mpi(MPIInitInfo{opts::get_argc(), opts::get_argv()});
+        start_mpi(MPIInitInfo{.argc = opts::get_argc(), .argv = opts::get_argv()});
         if (shamcomm::world_rank() == 0) {
             logger::warn_ln(
                 "Init", "No kernel can be run without a sycl configuration (--sycl-cfg x:x)");

--- a/src/main_test.cpp
+++ b/src/main_test.cpp
@@ -125,7 +125,7 @@ int main(int argc, char *argv[]) {
         shamsys::instance::init(argc, argv);
     } else {
         using namespace shamsys::instance;
-        start_mpi(MPIInitInfo{opts::get_argc(), opts::get_argv()});
+        start_mpi(MPIInitInfo{.argc = opts::get_argc(), .argv = opts::get_argv()});
         if (shamcomm::world_rank() == 0) {
             logger::warn_ln(
                 "Init", "No kernel can be run without a sycl configuration (--sycl-cfg x:x)");

--- a/src/shamalgs/include/shamalgs/collective/indexing.hpp
+++ b/src/shamalgs/include/shamalgs/collective/indexing.hpp
@@ -46,7 +46,7 @@ namespace shamalgs::collective {
 
         shamlog_debug_mpi_ln("fetch view", byte_count, "->", scan_val, "sum:", sum_val);
 
-        return {sum_val, scan_val};
+        return {.total_byte_count = sum_val, .head_offset = scan_val};
     }
 
     inline ViewInfo fetch_view_known_total(u64 byte_count, u64 total_byte) {
@@ -61,7 +61,7 @@ namespace shamalgs::collective {
 
         shamlog_debug_mpi_ln("fetch view", byte_count, "->", scan_val, "sum:", total_byte);
 
-        return {total_byte, scan_val};
+        return {.total_byte_count = total_byte, .head_offset = scan_val};
     }
 
 } // namespace shamalgs::collective

--- a/src/shamalgs/include/shamalgs/serialize.hpp
+++ b/src/shamalgs/include/shamalgs/serialize.hpp
@@ -91,8 +91,8 @@ namespace shamalgs {
             return lhs; // return the result by value (uses move constructor)
         }
 
-        static SerializeSize Header(u64 sz) { return {sz, 0}; }
-        static SerializeSize Content(u64 sz) { return {0, sz}; }
+        static SerializeSize Header(u64 sz) { return {.head_size = sz, .content_size = 0}; }
+        static SerializeSize Content(u64 sz) { return {.head_size = 0, .content_size = sz}; }
 
         inline u64 get_total_size() { return head_size + content_size; }
     };

--- a/src/shamalgs/src/collective/distributedDataComm.cpp
+++ b/src/shamalgs/src/collective/distributedDataComm.cpp
@@ -147,7 +147,11 @@ namespace shamalgs::collective {
                 auto [sender_rank, receiver_rank] = key;
 
                 if (sources.size() > 0) {
-                    PrepareCommUtil next{sender_rank, receiver_rank, byte_sz, sources};
+                    PrepareCommUtil next{
+                        .sender_rank   = sender_rank,
+                        .receiver_rank = receiver_rank,
+                        .sz            = byte_sz,
+                        .sources       = sources};
                     ret.push_back(std::move(next));
                 }
 
@@ -215,7 +219,9 @@ namespace shamalgs::collective {
         send_distrib_data.for_each([&](u64 sender, u64 receiver, sham::DeviceBuffer<u8> &buf) {
             std::pair<i32, i32> key = {rank_getter(sender), rank_getter(receiver)};
 
-            send_data[key].push_back(DataTmp{sender, receiver, buf.get_size(), buf});
+            send_data[key].push_back(
+                DataTmp{
+                    .sender = sender, .receiver = receiver, .length = buf.get_size(), .data = buf});
         });
 
         // serialize together similar communications
@@ -237,8 +243,8 @@ namespace shamalgs::collective {
             NamedStackEntry stack_loc2{"prepare payload"};
             for (auto &[key, buf] : send_bufs) {
                 send_payoad.push_back(
-                    {key.second,
-                     std::make_unique<shamcomm::CommunicationBuffer>(
+                    {.receiver_rank = key.second,
+                     .payload       = std::make_unique<shamcomm::CommunicationBuffer>(
                          shambase::extract_pointer(buf), dev_sched)});
             }
         }
@@ -271,7 +277,8 @@ namespace shamalgs::collective {
 
                 recv_payload_bufs.push_back(
                     RecvPayloadSer{
-                        payload.sender_ranks, SerializeHelper(dev_sched, std::move(buf))});
+                        .sender_ranks = payload.sender_ranks,
+                        .ser          = SerializeHelper(dev_sched, std::move(buf))});
             }
         }
 
@@ -346,7 +353,9 @@ namespace shamalgs::collective {
         send_distrib_data.for_each([&](u64 sender, u64 receiver, sham::DeviceBuffer<u8> &buf) {
             std::pair<i32, i32> key = {rank_getter(sender), rank_getter(receiver)};
 
-            send_data[key].push_back(DataTmp{sender, receiver, buf.get_size(), buf});
+            send_data[key].push_back(
+                DataTmp{
+                    .sender = sender, .receiver = receiver, .length = buf.get_size(), .data = buf});
         });
 
         std::vector<details::PrepareCommUtil> prepared_comms
@@ -363,12 +372,12 @@ namespace shamalgs::collective {
 
             messages_send.push_back(
                 shamalgs::collective::CommMessageInfo{
-                    size,
-                    sender,
-                    receiver,
-                    std::nullopt,
-                    std::nullopt,
-                    std::nullopt,
+                    .message_size                = size,
+                    .rank_sender                 = sender,
+                    .rank_receiver               = receiver,
+                    .message_tag                 = std::nullopt,
+                    .message_bytebuf_offset_send = std::nullopt,
+                    .message_bytebuf_offset_recv = std::nullopt,
                 });
 
             data_send.push_back(std::move(cms.send_buf));
@@ -458,7 +467,8 @@ namespace shamalgs::collective {
             cache.recv_cache_read_buf_at(offset_info.buf_id, offset_info.data_offset, size, recov);
 
             recv_payload_bufs.push_back(
-                RecvPayloadSer{sender, SerializeHelper(dev_sched, std::move(recov))});
+                RecvPayloadSer{
+                    .sender_ranks = sender, .ser = SerializeHelper(dev_sched, std::move(recov))});
         }
 
         {

--- a/src/shamalgs/src/collective/sparseXchg.cpp
+++ b/src/shamalgs/src/collective/sparseXchg.cpp
@@ -466,7 +466,13 @@ namespace shamalgs::collective {
 
                 auto &rq = rqs.new_request();
 
-                rqs_infos.push_back({sender, receiver, payload->get_size(), tag, true, false});
+                rqs_infos.push_back(
+                    {.sender   = sender,
+                     .receiver = receiver,
+                     .size     = payload->get_size(),
+                     .tag      = tag,
+                     .is_send  = true,
+                     .is_recv  = false});
 
                 SHAM_ASSERT(payload->get_size() == comm_sizes_loc[send_idx]);
 
@@ -496,7 +502,13 @@ namespace shamalgs::collective {
 
                 auto &rq = rqs.new_request();
 
-                rqs_infos.push_back({sender, receiver, u64(comm_sizes[i]), tag, false, true});
+                rqs_infos.push_back(
+                    {.sender   = sender,
+                     .receiver = receiver,
+                     .size     = u64(comm_sizes[i]),
+                     .tag      = tag,
+                     .is_send  = false,
+                     .is_recv  = true});
 
                 // logger::raw_ln(shambase::format(
                 //     "[{}] recv {} bytes from rank {}, tag {}",

--- a/src/shamalgs/src/collective/sparse_exchange.cpp
+++ b/src/shamalgs/src/collective/sparse_exchange.cpp
@@ -45,12 +45,12 @@ namespace shamalgs::collective {
         }
 
         return CommMessageInfo{
-            message_size,
-            static_cast<i32>(sender),
-            static_cast<i32>(receiver),
-            std::nullopt,
-            std::nullopt,
-            std::nullopt};
+            .message_size                = message_size,
+            .rank_sender                 = static_cast<i32>(sender),
+            .rank_receiver               = static_cast<i32>(receiver),
+            .message_tag                 = std::nullopt,
+            .message_bytebuf_offset_send = std::nullopt,
+            .message_bytebuf_offset_recv = std::nullopt};
     };
 
     /// fetch u64_2 from global message data
@@ -162,7 +162,8 @@ namespace shamalgs::collective {
                         // logger::info_ln("sparse comm", "is using multiple buffers (send) !");
                     }
 
-                    message_info.message_bytebuf_offset_send = {send_buf_id, tmp_send_offset};
+                    message_info.message_bytebuf_offset_send
+                        = {.buf_id = send_buf_id, .data_offset = tmp_send_offset};
                     tmp_send_offset += message_info.message_size;
                     send_buf_sizes.at(send_buf_id) += message_info.message_size;
 
@@ -191,7 +192,8 @@ namespace shamalgs::collective {
                         // logger::info_ln("sparse comm", "is using multiple buffers (recv) !");
                     }
 
-                    message_info.message_bytebuf_offset_recv = {recv_buf_id, tmp_recv_offset};
+                    message_info.message_bytebuf_offset_recv
+                        = {.buf_id = recv_buf_id, .data_offset = tmp_recv_offset};
                     tmp_recv_offset += message_info.message_size;
                     recv_buf_sizes.at(recv_buf_id) += message_info.message_size;
 
@@ -235,13 +237,13 @@ namespace shamalgs::collective {
         }
 
         return CommTable{
-            ret_message_send,
-            message_all,
-            ret_message_recv,
-            send_message_global_ids,
-            recv_message_global_ids,
-            send_buf_sizes,
-            recv_buf_sizes};
+            .messages_send           = ret_message_send,
+            .message_all             = message_all,
+            .messages_recv           = ret_message_recv,
+            .send_message_global_ids = send_message_global_ids,
+            .recv_message_global_ids = recv_message_global_ids,
+            .send_total_sizes        = send_buf_sizes,
+            .recv_total_sizes        = recv_buf_sizes};
     }
 
     void sparse_exchange(

--- a/src/shamalgs/src/collective/string_histogram.cpp
+++ b/src/shamalgs/src/collective/string_histogram.cpp
@@ -84,7 +84,7 @@ namespace {
             auto rank = data[i].y();
 
             if (hash_case_info.find(hash) == hash_case_info.end()) {
-                hash_case_info[hash] = {rank, 1};
+                hash_case_info[hash] = {.min_rank_id = rank, .count = 1};
             } else {
                 hash_case_info[hash].count += 1;
                 hash_case_info[hash].min_rank_id = std::min(hash_case_info[hash].min_rank_id, rank);

--- a/src/shamalgs/src/primitives/is_all_true.cpp
+++ b/src/shamalgs/src/primitives/is_all_true.cpp
@@ -83,16 +83,17 @@ namespace shamalgs::primitives {
 
     inline shamalgs::impl_param is_all_true_impl_to_params(const IS_ALL_TRUE_IMPL &impl) {
         if (impl == IS_ALL_TRUE_IMPL::HOST) {
-            return {"host", ""};
+            return {.impl_name = "host", .params = ""};
         } else if (impl == IS_ALL_TRUE_IMPL::SUM_REDUCTION) {
-            return {"sum_reduction", ""};
+            return {.impl_name = "sum_reduction", .params = ""};
         }
         throw shambase::make_except_with_loc<std::invalid_argument>(
             shambase::format("unknown is_all_true implementation : {}", u32(impl)));
     }
 
     std::vector<shamalgs::impl_param> impl::get_default_impl_list_is_all_true() {
-        std::vector<shamalgs::impl_param> impl_list{{"host", ""}, {"sum_reduction", ""}};
+        std::vector<shamalgs::impl_param> impl_list{
+            {.impl_name = "host", .params = ""}, {.impl_name = "sum_reduction", .params = ""}};
         return impl_list;
     }
 

--- a/src/shamalgs/src/primitives/reduction.cpp
+++ b/src/shamalgs/src/primitives/reduction.cpp
@@ -67,14 +67,14 @@ namespace shamalgs::primitives {
 
     inline shamalgs::impl_param reduction_impl_to_params(const REDUCTION_IMPL &impl) {
         if (impl == REDUCTION_IMPL::FALLBACK) {
-            return {"fallback", ""};
+            return {.impl_name = "fallback", .params = ""};
 #ifdef SYCL2020_FEATURE_GROUP_REDUCTION
         } else if (impl == REDUCTION_IMPL::GROUP_REDUCTION16) {
-            return {"group_reduction16", ""};
+            return {.impl_name = "group_reduction16", .params = ""};
         } else if (impl == REDUCTION_IMPL::GROUP_REDUCTION128) {
-            return {"group_reduction128", ""};
+            return {.impl_name = "group_reduction128", .params = ""};
         } else if (impl == REDUCTION_IMPL::GROUP_REDUCTION256) {
-            return {"group_reduction256", ""};
+            return {.impl_name = "group_reduction256", .params = ""};
 #endif
         }
         throw shambase::make_except_with_loc<std::invalid_argument>(
@@ -83,11 +83,11 @@ namespace shamalgs::primitives {
 
     std::vector<shamalgs::impl_param> impl::get_default_impl_list_reduction() {
         return {
-            {"fallback", ""},
+            {.impl_name = "fallback", .params = ""},
 #ifdef SYCL2020_FEATURE_GROUP_REDUCTION
-            {"group_reduction16", ""},
-            {"group_reduction128", ""},
-            {"group_reduction256", ""}
+            {.impl_name = "group_reduction16", .params = ""},
+            {.impl_name = "group_reduction128", .params = ""},
+            {.impl_name = "group_reduction256", .params = ""}
 #endif
         };
     }

--- a/src/shamalgs/src/primitives/scan_exclusive_sum_in_place.cpp
+++ b/src/shamalgs/src/primitives/scan_exclusive_sum_in_place.cpp
@@ -163,18 +163,18 @@ namespace shamalgs::primitives {
     inline shamalgs::impl_param scan_exclusive_sum_in_place_impl_to_params(
         const EXSCAN_IN_PLACE_IMPL &impl) {
         if (impl == EXSCAN_IN_PLACE_IMPL::STD_SCAN) {
-            return {"std_scan", ""};
+            return {.impl_name = "std_scan", .params = ""};
 #ifdef __ACPP__
         } else if (impl == EXSCAN_IN_PLACE_IMPL::STD_SCAN_SINGLE_TASK_ACPP) {
-            return {"std_scan_single_task_acpp", ""};
+            return {.impl_name = "std_scan_single_task_acpp", .params = ""};
 #endif
 #ifdef SYCL2020_FEATURE_GROUP_REDUCTION
         } else if (impl == EXSCAN_IN_PLACE_IMPL::DECOUPLED_LOOKBACK_512) {
-            return {"decoupled_lookback_512", ""};
+            return {.impl_name = "decoupled_lookback_512", .params = ""};
 #endif
 #ifdef ACPP_ALG_AVAILABLE
         } else if (impl == EXSCAN_IN_PLACE_IMPL::ADAPTIVECPP_ALG) {
-            return {"acpp_alg", ""};
+            return {.impl_name = "acpp_alg", .params = ""};
 #endif
         }
 
@@ -184,15 +184,15 @@ namespace shamalgs::primitives {
 
     std::vector<shamalgs::impl_param> impl::get_default_impl_list_scan_exclusive_sum_in_place() {
         return {
-            {"std_scan", ""},
+            {.impl_name = "std_scan", .params = ""},
 #ifdef __ACPP__
-            {"std_scan_single_task_acpp", ""},
+            {.impl_name = "std_scan_single_task_acpp", .params = ""},
 #endif
 #ifdef SYCL2020_FEATURE_GROUP_REDUCTION
-            {"decoupled_lookback_512", ""},
+            {.impl_name = "decoupled_lookback_512", .params = ""},
 #endif
 #ifdef ACPP_ALG_AVAILABLE
-            {"acpp_alg", ""},
+            {.impl_name = "acpp_alg", .params = ""},
 #endif
         };
     }

--- a/src/shamalgs/src/primitives/segmented_sort_in_place.cpp
+++ b/src/shamalgs/src/primitives/segmented_sort_in_place.cpp
@@ -134,9 +134,9 @@ namespace shamalgs::primitives {
         inline shamalgs::impl_param segmented_sort_in_place_impl_to_params(
             const SEGMENTED_SORT_IN_PLACE_IMPL &impl) {
             if (impl == SEGMENTED_SORT_IN_PLACE_IMPL::LOCAL_INSERTION_SORT) {
-                return {"local_insertion_sort", ""};
+                return {.impl_name = "local_insertion_sort", .params = ""};
             } else if (impl == SEGMENTED_SORT_IN_PLACE_IMPL::MULTI_STD_SORT) {
-                return {"multi_std_sort", ""};
+                return {.impl_name = "multi_std_sort", .params = ""};
             }
             throw shambase::make_except_with_loc<std::invalid_argument>(
                 shambase::format("unknown segmented sort in place implementation : {}", u32(impl)));
@@ -145,8 +145,8 @@ namespace shamalgs::primitives {
         /// Get list of available segmented sort in place implementations
         std::vector<shamalgs::impl_param> get_default_impl_list_segmented_sort_in_place() {
             return {
-                {"local_insertion_sort", ""},
-                {"multi_std_sort", ""},
+                {.impl_name = "local_insertion_sort", .params = ""},
+                {.impl_name = "multi_std_sort", .params = ""},
             };
         }
 

--- a/src/shambackends/include/shambackends/benchmarks/fma_chains.hpp
+++ b/src/shambackends/include/shambackends/benchmarks/fma_chains.hpp
@@ -147,7 +147,11 @@ namespace sham::benchmarks {
         double flop_count   = double(N) * flop_per_thread;
         double flops        = flop_count / (sec);
 
-        return {SourceLocation{}.loc.function_name(), sec, flops, nrotation};
+        return {
+            .func_name  = SourceLocation{}.loc.function_name(),
+            .seconds    = sec,
+            .flops      = flops,
+            .nrotations = nrotation};
     }
 
 } // namespace sham::benchmarks

--- a/src/shambackends/include/shambackends/benchmarks/saxpy.hpp
+++ b/src/shambackends/include/shambackends/benchmarks/saxpy.hpp
@@ -155,10 +155,10 @@ namespace sham::benchmarks {
         }
 
         return {
-            SourceLocation{}.loc.function_name(),
-            seconds,
-            double(N) * load_size * 3 / seconds / 1e9,
-            u64(N) * u64(load_size) * 2_u64};
+            .func_name = SourceLocation{}.loc.function_name(),
+            .seconds   = seconds,
+            .bandwidth = double(N) * load_size * 3 / seconds / 1e9,
+            .byte_used = u64(N) * u64(load_size) * 2_u64};
     }
 
 } // namespace sham::benchmarks

--- a/src/shambackends/include/shambackends/gpu_core_timeline.hpp
+++ b/src/shambackends/include/shambackends/gpu_core_timeline.hpp
@@ -201,7 +201,12 @@ namespace sham {
 
                     if (acc._valid[0]) {
 #ifdef SHAMROCK_INTRISICS_GET_SMID_AVAILABLE
-                        events[acc._index[0]] = {u64_max, u64_max, 0, sham::get_sm_id(), 0};
+                        events[acc._index[0]]
+                            = {.start     = u64_max,
+                               .first_end = u64_max,
+                               .last_end  = 0,
+                               .lane      = sham::get_sm_id(),
+                               .color     = 0};
 #else
                         events[acc._index[0]] = {u64_max, u64_max, 0, 0, 0};
 #endif
@@ -287,9 +292,9 @@ namespace sham {
          */
         inline acc get_write_access(sham::EventList &deps) {
             return {
-                events.get_write_access(deps),
-                event_count.get_write_access(deps),
-                events.get_size()};
+                .events          = events.get_write_access(deps),
+                .event_count     = event_count.get_write_access(deps),
+                .max_event_count = events.get_size()};
         }
 
         /**

--- a/src/shambackends/src/Device.cpp
+++ b/src/shambackends/src/Device.cpp
@@ -351,24 +351,24 @@ namespace sham {
         }
 
         DeviceProperties ret = {
-            Vendor::UNKNOWN,         // We cannot determine the vendor
-            get_device_backend(dev), // Query the backend based on the platform name
-            get_device_type(dev),
-            name,
-            dev.get_platform().get_info<sycl::info::platform::name>(),
-            shambase::get_check_ref(global_mem_size),
-            shambase::get_check_ref(global_mem_cache_line_size),
-            shambase::get_check_ref(global_mem_cache_size),
-            shambase::get_check_ref(local_mem_size),
-            shambase::get_check_ref(max_compute_units),
-            max_alloc_dev,
-            max_alloc_host,
+            .vendor   = Vendor::UNKNOWN,         // We cannot determine the vendor
+            .backend  = get_device_backend(dev), // Query the backend based on the platform name
+            .type     = get_device_type(dev),
+            .name     = name,
+            .platform = dev.get_platform().get_info<sycl::info::platform::name>(),
+            .global_mem_size            = shambase::get_check_ref(global_mem_size),
+            .global_mem_cache_line_size = shambase::get_check_ref(global_mem_cache_line_size),
+            .global_mem_cache_size      = shambase::get_check_ref(global_mem_cache_size),
+            .local_mem_size             = shambase::get_check_ref(local_mem_size),
+            .max_compute_units          = shambase::get_check_ref(max_compute_units),
+            .max_mem_alloc_size_dev     = max_alloc_dev,
+            .max_mem_alloc_size_host    = max_alloc_host,
             // the SYCL standard returns the alignment in bits, we convert to bytes for convenience
-            shambase::get_check_ref(mem_base_addr_align) / CHAR_BIT,
-            shambase::get_check_ref(sub_group_sizes),
-            default_work_group_size,
-            std::nullopt,
-            warnings};
+            .mem_base_addr_align     = shambase::get_check_ref(mem_base_addr_align) / CHAR_BIT,
+            .sub_group_sizes         = shambase::get_check_ref(sub_group_sizes),
+            .default_work_group_size = default_work_group_size,
+            .pci_address             = std::nullopt,
+            .warnings                = warnings};
 
         { // PCI id infos
 #if defined(SYCL_EXT_INTEL_DEVICE_INFO) && SYCL_EXT_INTEL_DEVICE_INFO >= 5
@@ -454,10 +454,10 @@ namespace sham {
         DeviceProperties prop       = fetch_properties(dev); // Get the properties of the device
         DeviceMPIProperties propmpi = {false};               // Get the MPI properties
         return Device{
-            i,      // The index of the device
-            dev,    // The SYCL device
-            prop,   // The properties of the device
-            propmpi // The MPI properties of the device
+            .device_id = i,      // The index of the device
+            .dev       = dev,    // The SYCL device
+            .prop      = prop,   // The properties of the device
+            .mpi_prop  = propmpi // The MPI properties of the device
         };
     }
 

--- a/src/shambase/include/shambase/tabulate.hpp
+++ b/src/shambase/include/shambase/tabulate.hpp
@@ -67,7 +67,7 @@ namespace shambase {
                     cols.size(),
                     cols_count));
             }
-            table_lines.push_back(data{cols, position});
+            table_lines.push_back(data{.cols = cols, .position = position});
         }
 
         std::vector<size_t> compute_widths() {

--- a/src/shambase/src/logs/reformat_message.cpp
+++ b/src/shambase/src/logs/reformat_message.cpp
@@ -59,7 +59,8 @@ namespace shambase::logs {
                    + (name) + shambase::term_colors::reset() + ": " + content;
         }
 
-        return shambase::logs::_reformat_all({color, name, module_name, content});
+        return shambase::logs::_reformat_all(
+            {.color = color, .level_name = name, .module_name = module_name, .content = content});
     }
 
     /**
@@ -82,6 +83,7 @@ namespace shambase::logs {
                    + (name) + shambase::term_colors::reset() + ": " + content;
         }
 
-        return shambase::logs::_reformat_simple({color, name, module_name, content});
+        return shambase::logs::_reformat_simple(
+            {.color = color, .level_name = name, .module_name = module_name, .content = content});
     }
 } // namespace shambase::logs

--- a/src/shambase/src/profiling/chrome.cpp
+++ b/src/shambase/src/profiling/chrome.cpp
@@ -197,12 +197,20 @@ namespace {
 void shambase::profiling::chrome::register_event_start(
     const std::string &name, const std::string &category_name, f64 t_start, u64 pid, u64 tid) {
 
-    event_storage.register_event(ChromeEvent::EventStart{name, category_name, t_start, pid, tid});
+    event_storage.register_event(
+        ChromeEvent::EventStart{
+            .name          = name,
+            .category_name = category_name,
+            .t_start       = t_start,
+            .pid           = pid,
+            .tid           = tid});
 }
 
 void shambase::profiling::chrome::register_event_end(
     const std::string &name, const std::string &category_name, f64 tend, u64 pid, u64 tid) {
-    event_storage.register_event(ChromeEvent::EventEnd{name, category_name, tend, pid, tid});
+    event_storage.register_event(
+        ChromeEvent::EventEnd{
+            .name = name, .category_name = category_name, .tend = tend, .pid = pid, .tid = tid});
 }
 
 void shambase::profiling::chrome::register_event_complete(
@@ -214,7 +222,13 @@ void shambase::profiling::chrome::register_event_complete(
     u64 tid) {
 
     event_storage.register_event(
-        ChromeEvent::EventComplete{name, category_name, t_start, tend, pid, tid});
+        ChromeEvent::EventComplete{
+            .name          = name,
+            .category_name = category_name,
+            .t_start       = t_start,
+            .tend          = tend,
+            .pid           = pid,
+            .tid           = tid});
 }
 
 void shambase::profiling::chrome::register_metadata_thread_name(
@@ -225,5 +239,6 @@ void shambase::profiling::chrome::register_metadata_thread_name(
 void shambase::profiling::chrome::register_counter_val(
     u64 pid, f64 t, const std::string &name, f64 val) {
 
-    event_storage.register_event(ChromeEvent::CounterEvent{name, t, val, pid});
+    event_storage.register_event(
+        ChromeEvent::CounterEvent{.name = name, .t = t, .val = val, .pid = pid});
 }

--- a/src/shambase/src/stacktrace.cpp
+++ b/src/shambase/src/stacktrace.cpp
@@ -92,7 +92,8 @@ namespace shambase::details {
         };
         // Add the entry to the storage
         profile_data_chrome.push_back(
-            ChromeProfileEntry{loc.function_name(), to_prof_time(time), is_start});
+            ChromeProfileEntry{
+                .name = loc.function_name(), .time_val = to_prof_time(time), .is_start = is_start});
     }
 
     /**
@@ -187,7 +188,8 @@ namespace shambase::details {
 
     void register_profile_entry(std::source_location loc, f64 start_time, f64 end_time) {
         // Add the profile entry to the storage
-        profile_data.push_back({start_time, end_time, loc.function_name()});
+        profile_data.push_back(
+            {.time_start = start_time, .time_end = end_time, .entry_name = loc.function_name()});
         // Add a Chrome profiling entry to the storage
         add_entry_chrome(loc, end_time, false);
     };

--- a/src/shamcmdopt/src/cmdopt.cpp
+++ b/src/shamcmdopt/src/cmdopt.cpp
@@ -171,7 +171,8 @@ namespace shamcmdopt {
             }
         }
 
-        registered_opts.push_back({name, std::move(args), std::move(description)});
+        registered_opts.push_back(
+            {.name = name, .args = std::move(args), .description = std::move(description)});
     }
 
     /// supplied argc from main

--- a/src/shammodels/common/include/shammodels/common/amr/AMROverheadtest.hpp
+++ b/src/shammodels/common/include/shammodels/common/amr/AMROverheadtest.hpp
@@ -353,11 +353,12 @@ class AMRTestModel {
                 tree.tree_struct,
                 pdat.get_obj_cnt(),
                 InteractionCrit{
-                    {},
-                    tree,
-                    pdat,
-                    pdat.get_field<u64_3>(0).get_buf().copy_to_sycl_buffer(),
-                    pdat.get_field<u64_3>(1).get_buf().copy_to_sycl_buffer()});
+                    .bounds             = {},
+                    .tree               = tree,
+                    .pdat               = pdat,
+                    .buf_cell_low_bound = pdat.get_field<u64_3>(0).get_buf().copy_to_sycl_buffer(),
+                    .buf_cell_high_bound
+                    = pdat.get_field<u64_3>(1).get_buf().copy_to_sycl_buffer()});
 
             q.submit([&](sycl::handler &cgh) {
                 auto walker        = walk.get_access(cgh);

--- a/src/shammodels/common/include/shammodels/common/amr/NeighGraph.hpp
+++ b/src/shammodels/common/include/shammodels/common/amr/NeighGraph.hpp
@@ -94,7 +94,9 @@ namespace shammodels::basegodunov::modules {
         };
 
         ro_access get_read_access(sham::EventList &e) const {
-            return ro_access{node_link_offset.get_read_access(e), node_links.get_read_access(e)};
+            return ro_access{
+                .node_link_offset = node_link_offset.get_read_access(e),
+                .node_links       = node_links.get_read_access(e)};
         }
 
         void complete_event_state(sycl::event &e) const {

--- a/src/shammodels/ramses/include/shammodels/ramses/modules/ExtractGhostLayer.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/modules/ExtractGhostLayer.hpp
@@ -48,9 +48,9 @@ namespace shammodels::basegodunov::modules {
 
         inline Edges get_edges() {
             return Edges{
-                get_ro_edge<shamrock::solvergraph::IPatchDataLayerRefs>(0),
-                get_ro_edge<shamrock::solvergraph::DDSharedBuffers<u32>>(1),
-                get_rw_edge<shamrock::solvergraph::PatchDataLayerDDShared>(0),
+                .patch_data_layers = get_ro_edge<shamrock::solvergraph::IPatchDataLayerRefs>(0),
+                .idx_in_ghost      = get_ro_edge<shamrock::solvergraph::DDSharedBuffers<u32>>(1),
+                .ghost_layer       = get_rw_edge<shamrock::solvergraph::PatchDataLayerDDShared>(0),
             };
         }
 

--- a/src/shammodels/ramses/include/shammodels/ramses/modules/FuseGhostLayer.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/modules/FuseGhostLayer.hpp
@@ -42,8 +42,8 @@ namespace shammodels::basegodunov::modules {
 
         inline Edges get_edges() {
             return Edges{
-                get_ro_edge<shamrock::solvergraph::PatchDataLayerDDShared>(0),
-                get_rw_edge<shamrock::solvergraph::IPatchDataLayerRefs>(0),
+                .ghost_layer       = get_ro_edge<shamrock::solvergraph::PatchDataLayerDDShared>(0),
+                .patch_data_layers = get_rw_edge<shamrock::solvergraph::IPatchDataLayerRefs>(0),
             };
         }
 

--- a/src/shammodels/ramses/include/shammodels/ramses/modules/details/compute_neigh_graph.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/modules/details/compute_neigh_graph.hpp
@@ -104,7 +104,11 @@ namespace shammodels::basegodunov::modules::details {
 
         using Graph = shammodels::basegodunov::modules::NeighGraph;
         return Graph(
-            Graph{std::move(link_cnt_offsets), std::move(ids_links), link_cnt, graph_nodes});
+            Graph{
+                .node_link_offset = std::move(link_cnt_offsets),
+                .node_links       = std::move(ids_links),
+                .link_count       = link_cnt,
+                .obj_cnt          = graph_nodes});
     };
 
     /**
@@ -183,7 +187,11 @@ namespace shammodels::basegodunov::modules::details {
 
         using Graph = shammodels::basegodunov::modules::NeighGraph;
         return Graph(
-            Graph{std::move(link_cnt_offsets), std::move(ids_links), link_cnt, graph_nodes});
+            Graph{
+                .node_link_offset = std::move(link_cnt_offsets),
+                .node_links       = std::move(ids_links),
+                .link_count       = link_cnt,
+                .obj_cnt          = graph_nodes});
     };
 
 } // namespace shammodels::basegodunov::modules::details

--- a/src/shammodels/ramses/src/modules/FindGhostLayerCandidates.cpp
+++ b/src/shammodels/ramses/src/modules/FindGhostLayerCandidates.cpp
@@ -67,7 +67,9 @@ void shammodels::basegodunov::modules::FindGhostLayerCandidates<
                     // patch `id` and patch `id_found` for this offset
                     // so we store that
                     ghost_layers_candidates.add_obj(
-                        id, id_found, GhostLayerCandidateInfos{xoff, yoff, zoff});
+                        id,
+                        id_found,
+                        GhostLayerCandidateInfos{.xoff = xoff, .yoff = yoff, .zoff = zoff});
                 });
         }
     });

--- a/src/shammodels/sph/include/shammodels/sph/BasicSPHGhosts.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/BasicSPHGhosts.hpp
@@ -202,7 +202,7 @@ namespace shammodels::sph {
                         "their is an empty id table in the interface, it should have been removed");
                 }
 
-                vecarg.push_back({sender,receiver,build_table});
+                vecarg.push_back({.sender = sender, .receiver = receiver, .build_table = build_table});
             });
             // clang-format on
 
@@ -257,7 +257,8 @@ namespace shammodels::sph {
                         "their is an empty id table in the interface, it should have been removed");
                 }
 
-                vecarg.push_back({sender, receiver, build_table});
+                vecarg.push_back(
+                    {.sender = sender, .receiver = receiver, .build_table = build_table});
 
                 return gen_1(
                     sender,

--- a/src/shammodels/sph/include/shammodels/sph/SolverConfig.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/SolverConfig.hpp
@@ -221,13 +221,21 @@ namespace shammodels::sph {
         void set_none() { config = None{}; }
         void set_direct(bool reference_mode = false) { config = Direct{reference_mode}; }
         void set_mm(u32 mm_order, f64 opening_angle, u32 reduction_level) {
-            config = MM{mm_order, opening_angle, reduction_level};
+            config = MM{
+                .order           = mm_order,
+                .opening_angle   = opening_angle,
+                .reduction_level = reduction_level};
         }
         void set_fmm(u32 order, f64 opening_angle, u32 reduction_level) {
-            config = FMM{order, opening_angle, reduction_level};
+            config = FMM{
+                .order = order, .opening_angle = opening_angle, .reduction_level = reduction_level};
         }
         void set_sfmm(u32 order, f64 opening_angle, bool leaf_lowering, u32 reduction_level) {
-            config = SFMM{order, opening_angle, leaf_lowering, reduction_level};
+            config = SFMM{
+                .order           = order,
+                .opening_angle   = opening_angle,
+                .leaf_lowering   = leaf_lowering,
+                .reduction_level = reduction_level};
         }
 
         bool is_none() const { return std::holds_alternative<None>(config); }
@@ -1070,20 +1078,20 @@ namespace shammodels::sph {
     inline void from_json(const nlohmann::json &j, SelfGravConfig &p) {
         if (j.at("type").get<std::string>() == "sfmm") {
             p.config = SelfGravConfig::SFMM{
-                j.at("order").get<u32>(),
-                j.at("opening_angle").get<f64>(),
-                j.at("leaf_lowering").get<bool>(),
-                j.at("reduction_level").get<u32>()};
+                .order           = j.at("order").get<u32>(),
+                .opening_angle   = j.at("opening_angle").get<f64>(),
+                .leaf_lowering   = j.at("leaf_lowering").get<bool>(),
+                .reduction_level = j.at("reduction_level").get<u32>()};
         } else if (j.at("type").get<std::string>() == "fmm") {
             p.config = SelfGravConfig::FMM{
-                j.at("order").get<u32>(),
-                j.at("opening_angle").get<f64>(),
-                j.at("reduction_level").get<u32>()};
+                .order           = j.at("order").get<u32>(),
+                .opening_angle   = j.at("opening_angle").get<f64>(),
+                .reduction_level = j.at("reduction_level").get<u32>()};
         } else if (j.at("type").get<std::string>() == "mm") {
             p.config = SelfGravConfig::MM{
-                j.at("order").get<u32>(),
-                j.at("opening_angle").get<f64>(),
-                j.at("reduction_level").get<u32>()};
+                .order           = j.at("order").get<u32>(),
+                .opening_angle   = j.at("opening_angle").get<f64>(),
+                .reduction_level = j.at("reduction_level").get<u32>()};
         } else if (j.at("type").get<std::string>() == "direct") {
             p.config = SelfGravConfig::Direct{j.at("reference_mode").get<bool>()};
         } else if (j.at("type").get<std::string>() == "none") {

--- a/src/shammodels/sph/include/shammodels/sph/modules/AnalysisBarycenter.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/AnalysisBarycenter.hpp
@@ -104,7 +104,7 @@ namespace shammodels::sph::modules {
                 }
             }
             tot_barycenter /= tot_mass;
-            return result{tot_barycenter, tot_mass_disc};
+            return result{.barycenter = tot_barycenter, .mass_disc = tot_mass_disc};
         }
     };
 } // namespace shammodels::sph::modules

--- a/src/shammodels/sph/include/shammodels/sph/modules/KillParticles.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/KillParticles.hpp
@@ -41,8 +41,8 @@ namespace shammodels::sph::modules {
 
         inline Edges get_edges() {
             return Edges{
-                get_ro_edge<shamrock::solvergraph::DistributedBuffers<u32>>(0),
-                get_rw_edge<shamrock::solvergraph::PatchDataLayerRefs>(0)};
+                .part_to_remove = get_ro_edge<shamrock::solvergraph::DistributedBuffers<u32>>(0),
+                .patchdatas     = get_rw_edge<shamrock::solvergraph::PatchDataLayerRefs>(0)};
         }
 
         void _impl_evaluate_internal();

--- a/src/shammodels/sph/src/modules/setup/GeneratorMCDisc.cpp
+++ b/src/shammodels/sph/src/modules/setup/GeneratorMCDisc.cpp
@@ -62,7 +62,7 @@ auto shammodels::sph::modules::GeneratorMCDisc<Tvec, SPHKernel>::DiscIterator::n
     Tscal fs  = 1;
     Tscal rho = (sigma * fs) * sycl::exp(-z * z / (2 * H * H));
 
-    DiscOutput out{pos, vel, cs, rho};
+    DiscOutput out{.pos = pos, .velocity = vel, .cs = cs, .rho = rho};
 
     // increase counter + check if finished
     current_index++;

--- a/src/shammodels/zeus/src/modules/GhostZones.cpp
+++ b/src/shammodels/zeus/src/modules/GhostZones.cpp
@@ -410,7 +410,11 @@ void shammodels::zeus::modules::GhostZones<Tvec, TgridVec>::exchange_ghost() {
 
                 pdat_new.check_field_obj_cnt_match();
 
-                return MergedPatchData{or_elem, total_elements, std::move(pdat_new), ghost_layout};
+                return MergedPatchData{
+                    .original_elements = or_elem,
+                    .total_elements    = total_elements,
+                    .pdat              = std::move(pdat_new),
+                    .pdl               = ghost_layout};
             },
             [](MergedPatchData &mpdat, PatchDataLayer &pdat_interf) {
                 mpdat.total_elements += pdat_interf.get_obj_cnt();

--- a/src/shamphys/src/HydroSoundwave.cpp
+++ b/src/shamphys/src/HydroSoundwave.cpp
@@ -20,5 +20,5 @@ auto shamphys::HydroSoundwave::get_value(f64 t, f64 x) -> field_val {
 
     std::complex<f64> val = std::exp(i * (get_omega() * t - k * x));
 
-    return {std::real(val * rho_tilde), std::real(val * v_tilde)};
+    return {.rho = std::real(val * rho_tilde), .v = std::real(val * v_tilde)};
 }

--- a/src/shamphys/src/SedovTaylor.cpp
+++ b/src/shamphys/src/SedovTaylor.cpp
@@ -79,5 +79,5 @@ auto shamphys::SedovTaylor::get_value(f64 x) -> field_val {
     f64 vx  = linear_interpolate(r_theo, vr_theo, ntheoval, x);
     f64 P   = linear_interpolate(r_theo, p_theo, ntheoval, x);
 
-    return {rho, vx, P};
+    return {.rho = rho, .vx = vx, .P = P};
 }

--- a/src/shampylib/include/shampylib/pyNodeInstance.hpp
+++ b/src/shampylib/include/shampylib/pyNodeInstance.hpp
@@ -31,7 +31,8 @@ namespace shamsys::instance {
         m.def(
             "init",
             [](std::string sycl_cfg) {
-                init_sycl_mpi(sycl_cfg, MPIInitInfo{opts::get_argc(), opts::get_argv()});
+                init_sycl_mpi(
+                    sycl_cfg, MPIInitInfo{.argc = opts::get_argc(), .argv = opts::get_argv()});
             },
             R"pbdoc(
 

--- a/src/shampylib/src/math/pyshammath.cpp
+++ b/src/shampylib/src/math/pyshammath.cpp
@@ -102,7 +102,11 @@ ON_PYTHON_INIT {
                         bool is_z_periodic) {
                 return std::make_unique<shammath::paving_function_general_3d<f64_3>>(
                     shammath::paving_function_general_3d<f64_3>{
-                        box_size, box_center, is_x_periodic, is_y_periodic, is_z_periodic});
+                        .box_size      = box_size,
+                        .box_center    = box_center,
+                        .is_x_periodic = is_x_periodic,
+                        .is_y_periodic = is_y_periodic,
+                        .is_z_periodic = is_z_periodic});
             }))
         .def("f", &shammath::paving_function_general_3d<f64_3>::f)
         .def("f_inv", &shammath::paving_function_general_3d<f64_3>::f_inv)
@@ -123,12 +127,12 @@ ON_PYTHON_INIT {
                         f64 shear_x) {
                 return std::make_unique<shammath::paving_function_general_3d_shear_x<f64_3>>(
                     shammath::paving_function_general_3d_shear_x<f64_3>{
-                        box_size,
-                        box_center,
-                        is_x_periodic,
-                        is_y_periodic,
-                        is_z_periodic,
-                        shear_x});
+                        .box_size      = box_size,
+                        .box_center    = box_center,
+                        .is_x_periodic = is_x_periodic,
+                        .is_y_periodic = is_y_periodic,
+                        .is_z_periodic = is_z_periodic,
+                        .shear_x       = shear_x});
             }))
         .def("f", &shammath::paving_function_general_3d_shear_x<f64_3>::f)
         .def("f_inv", &shammath::paving_function_general_3d_shear_x<f64_3>::f_inv)

--- a/src/shampylib/src/pyShamalgs.cpp
+++ b/src/shampylib/src/pyShamalgs.cpp
@@ -39,7 +39,7 @@ ON_PYTHON_INIT {
 
     py::class_<shamalgs::impl_param>(shamalgs_module, "impl_param")
         .def(py::init([]() {
-            return shamalgs::impl_param{"", ""};
+            return shamalgs::impl_param{.impl_name = "", .params = ""};
         }))
         .def_readwrite(
             "impl_name",

--- a/src/shampylib/src/pyShamtree.cpp
+++ b/src/shampylib/src/pyShamtree.cpp
@@ -62,8 +62,10 @@ template<class Tmorton, class Tvec, u32 dim>
 inline void register_dtt_alg(py::module &m) {
     py::class_<shamtree::DTTResult>(m, "DTTResult").def(py::init([]() {
         return std::make_unique<shamtree::DTTResult>(shamtree::DTTResult{
-            sham::DeviceBuffer<u32_2>(0, shamsys::instance::get_compute_scheduler_ptr()),
-            sham::DeviceBuffer<u32_2>(0, shamsys::instance::get_compute_scheduler_ptr())});
+            .node_interactions_m2l
+            = sham::DeviceBuffer<u32_2>(0, shamsys::instance::get_compute_scheduler_ptr()),
+            .node_interactions_p2p
+            = sham::DeviceBuffer<u32_2>(0, shamsys::instance::get_compute_scheduler_ptr())});
     }));
 
     m.def(

--- a/src/shamrock/include/shamrock/amr/AMRGrid.hpp
+++ b/src/shamrock/include/shamrock/amr/AMRGrid.hpp
@@ -113,7 +113,7 @@ namespace shamrock::amr {
                 tot_refine += len;
 
                 // add the results to the map
-                ret.add_obj(id_patch, OptIndexList{std::move(buf), len});
+                ret.add_obj(id_patch, OptIndexList{.idx = std::move(buf), .count = len});
             });
 
             logger::info_ln("AMRGrid", "on this process", tot_refine, "cells were refined");
@@ -253,7 +253,7 @@ namespace shamrock::amr {
                 tot_merge += len;
 
                 // add the results to the map
-                ret.add_obj(id_patch, OptIndexList{std::move(opt_buf), len});
+                ret.add_obj(id_patch, OptIndexList{.idx = std::move(opt_buf), .count = len});
             });
 
             logger::info_ln(

--- a/src/shamrock/include/shamrock/scheduler/loadbalance/LoadBalanceStrategy.hpp
+++ b/src/shamrock/include/shamrock/scheduler/loadbalance/LoadBalanceStrategy.hpp
@@ -252,10 +252,10 @@ namespace shamrock::scheduler::details {
         var /= world_size;
 
         return {
-            min * strategy_weight,
-            max * strategy_weight,
-            avg * strategy_weight,
-            sycl::sqrt(var) * strategy_weight};
+            .min    = min * strategy_weight,
+            .max    = max * strategy_weight,
+            .mean   = avg * strategy_weight,
+            .stddev = sycl::sqrt(var) * strategy_weight};
     }
 
 } // namespace shamrock::scheduler::details

--- a/src/shamrock/include/shamrock/solvergraph/CopyPatchDataLayerFields.hpp
+++ b/src/shamrock/include/shamrock/solvergraph/CopyPatchDataLayerFields.hpp
@@ -50,7 +50,9 @@ namespace shamrock::solvergraph {
         }
 
         Edges get_edges() {
-            return Edges{get_ro_edge<IPatchDataLayerRefs>(0), get_rw_edge<PatchDataLayerEdge>(0)};
+            return Edges{
+                .original = get_ro_edge<IPatchDataLayerRefs>(0),
+                .target   = get_rw_edge<PatchDataLayerEdge>(0)};
         }
 
         void _impl_evaluate_internal();

--- a/src/shamrock/include/shamrock/solvergraph/ExchangeGhostLayerDebugDotGraph.hpp
+++ b/src/shamrock/include/shamrock/solvergraph/ExchangeGhostLayerDebugDotGraph.hpp
@@ -47,8 +47,8 @@ namespace shamrock::solvergraph {
 
         inline Edges get_edges() {
             return Edges{
-                get_ro_edge<shamrock::solvergraph::ScalarsEdge<u64>>(0),
-                get_rw_edge<shamrock::solvergraph::PatchDataLayerDDShared>(0),
+                .object_counts = get_ro_edge<shamrock::solvergraph::ScalarsEdge<u64>>(0),
+                .ghost_layer   = get_rw_edge<shamrock::solvergraph::PatchDataLayerDDShared>(0),
             };
         }
 

--- a/src/shamrock/include/shamrock/solvergraph/ExtractCounts.hpp
+++ b/src/shamrock/include/shamrock/solvergraph/ExtractCounts.hpp
@@ -40,7 +40,9 @@ namespace shamrock::solvergraph {
         }
 
         Edges get_edges() {
-            return Edges{get_ro_edge<IPatchDataLayerRefs>(0), get_rw_edge<Indexes<u32>>(0)};
+            return Edges{
+                .refs   = get_ro_edge<IPatchDataLayerRefs>(0),
+                .counts = get_rw_edge<Indexes<u32>>(0)};
         }
 
         void _impl_evaluate_internal() {

--- a/src/shamrock/include/shamrock/solvergraph/GetObjCntFromLayer.hpp
+++ b/src/shamrock/include/shamrock/solvergraph/GetObjCntFromLayer.hpp
@@ -43,8 +43,8 @@ namespace shamrock::solvergraph {
 
         Edges get_edges() {
             return Edges{
-                get_ro_edge<IPatchDataLayerRefs>(0),
-                get_rw_edge<shamrock::solvergraph::Indexes<u32>>(0)};
+                .source  = get_ro_edge<IPatchDataLayerRefs>(0),
+                .out_ref = get_rw_edge<shamrock::solvergraph::Indexes<u32>>(0)};
         }
 
         void _impl_evaluate_internal() {

--- a/src/shamrock/src/io/ShamrockDump.cpp
+++ b/src/shamrock/src/io/ShamrockDump.cpp
@@ -228,7 +228,7 @@ namespace shamrock {
         std::unordered_map<u64, PatchFileOffset> off_table;
 
         for (u32 i = 0; i < all_bytecounts.size(); i++) {
-            off_table[all_pids[i]] = {all_offsets[i], all_bytecounts[i]};
+            off_table[all_pids[i]] = {.offset = all_offsets[i], .bytecount = all_bytecounts[i]};
         }
 
         for (const auto &p : sched.patch_list.local) {

--- a/src/shamrock/src/scheduler/PatchScheduler.cpp
+++ b/src/shamrock/src/scheduler/PatchScheduler.cpp
@@ -974,10 +974,10 @@ std::vector<std::unique_ptr<shamrock::patch::PatchDataLayer>> PatchScheduler::ga
 
             send_payloads.push_back(
                 Message{
-                    std::make_unique<shamcomm::CommunicationBuffer>(
+                    .buf = std::make_unique<shamcomm::CommunicationBuffer>(
                         std::move(tmp), shamsys::instance::get_compute_scheduler_ptr()),
-                    0,
-                    i32(i)});
+                    .rank = 0,
+                    .tag  = i32(i)});
         }
     }
 
@@ -990,9 +990,9 @@ std::vector<std::unique_ptr<shamrock::patch::PatchDataLayer>> PatchScheduler::ga
         for (u32 i = 0; i < plist.size(); i++) {
             recv_payloads.push_back(
                 Message{
-                    std::unique_ptr<shamcomm::CommunicationBuffer>{},
-                    i32(plist[i].node_owner_id),
-                    i32(i)});
+                    .buf  = std::unique_ptr<shamcomm::CommunicationBuffer>{},
+                    .rank = i32(plist[i].node_owner_id),
+                    .tag  = i32(i)});
         }
     }
 

--- a/src/shamrock/src/scheduler/SchedulerPatchData.cpp
+++ b/src/shamrock/src/scheduler/SchedulerPatchData.cpp
@@ -130,10 +130,10 @@ namespace shamrock::scheduler {
 
                 send_payloads.push_back(
                     Message{
-                        std::make_unique<shamcomm::CommunicationBuffer>(
+                        .buf = std::make_unique<shamcomm::CommunicationBuffer>(
                             std::move(tmp), shamsys::instance::get_compute_scheduler_ptr()),
-                        op.rank_owner_new,
-                        op.tag_comm});
+                        .rank = op.rank_owner_new,
+                        .tag  = op.tag_comm});
             }
         }
 
@@ -148,9 +148,9 @@ namespace shamrock::scheduler {
             if (op.rank_owner_new == shamcomm::world_rank()) {
                 recv_payloads.push_back(
                     Message{
-                        std::unique_ptr<shamcomm::CommunicationBuffer>{},
-                        op.rank_owner_old,
-                        op.tag_comm});
+                        .buf  = std::unique_ptr<shamcomm::CommunicationBuffer>{},
+                        .rank = op.rank_owner_old,
+                        .tag  = op.tag_comm});
             }
         }
 

--- a/src/shamrock/src/scheduler/scheduler_patch_list.cpp
+++ b/src/shamrock/src/scheduler/scheduler_patch_list.cpp
@@ -262,16 +262,15 @@ std::vector<shamrock::patch::Patch> make_fake_patch_list(u32 total_dtcnt, u64 di
 
     plist.push_back(
         Patch{
-            0,
-            u64_max,
-            total_dtcnt,
-            0,
-            0,
-            0,
-            HilbertLoadBalance<u64>::max_box_sz,
-            HilbertLoadBalance<u64>::max_box_sz,
-            HilbertLoadBalance<u64>::max_box_sz,
-            0,
+            .id_patch        = 0,
+            .pack_node_index = u64_max,
+            .load_value      = total_dtcnt,
+            .coord_min       = {0, 0, 0},
+            .coord_max
+            = {HilbertLoadBalance<u64>::max_box_sz,
+               HilbertLoadBalance<u64>::max_box_sz,
+               HilbertLoadBalance<u64>::max_box_sz},
+            .node_owner_id = 0,
         });
 
     bool listchanged = true;

--- a/src/shamrock/src/scheduler/scheduler_patch_list.cpp
+++ b/src/shamrock/src/scheduler/scheduler_patch_list.cpp
@@ -326,114 +326,82 @@ std::vector<shamrock::patch::Patch> make_fake_patch_list(u32 total_dtcnt, u64 di
                 u32 qte_ppp = qte_pp - qte_ppm;
 
                 Patch child_mmm = Patch{
-                    id_cnt,
-                    u64_max,
-                    qte_mmm,
-                    min_x,
-                    min_y,
-                    min_z,
-                    split_x,
-                    split_y,
-                    split_z,
-                    0,
+                    .id_patch        = id_cnt,
+                    .pack_node_index = u64_max,
+                    .load_value      = qte_mmm,
+                    .coord_min       = {min_x, min_y, min_z},
+                    .coord_max       = {split_x, split_y, split_z},
+                    .node_owner_id   = 0,
                 };
                 id_cnt++;
 
                 Patch child_mmp = Patch{
-                    id_cnt,
-                    u64_max,
-                    qte_mmp,
-                    min_x,
-                    min_y,
-                    split_z + 1,
-                    split_x,
-                    split_y,
-                    max_z,
-                    0,
+                    .id_patch        = id_cnt,
+                    .pack_node_index = u64_max,
+                    .load_value      = qte_mmp,
+                    .coord_min       = {min_x, min_y, split_z + 1},
+                    .coord_max       = {split_x, split_y, max_z},
+                    .node_owner_id   = 0,
                 };
                 id_cnt++;
 
                 Patch child_mpm = Patch{
-                    id_cnt,
-                    u64_max,
-                    qte_mpm,
-                    min_x,
-                    split_y + 1,
-                    min_z,
-                    split_x,
-                    max_y,
-                    split_z,
-                    0,
+                    .id_patch        = id_cnt,
+                    .pack_node_index = u64_max,
+                    .load_value      = qte_mpm,
+                    .coord_min       = {min_x, split_y + 1, min_z},
+                    .coord_max       = {split_x, max_y, split_z},
+                    .node_owner_id   = 0,
                 };
                 id_cnt++;
 
                 Patch child_mpp = Patch{
-                    id_cnt,
-                    u64_max,
-                    qte_mpp,
-                    min_x,
-                    split_y + 1,
-                    split_z + 1,
-                    split_x,
-                    max_y,
-                    max_z,
-                    0,
+                    .id_patch        = id_cnt,
+                    .pack_node_index = u64_max,
+                    .load_value      = qte_mpp,
+                    .coord_min       = {min_x, split_y + 1, split_z + 1},
+                    .coord_max       = {split_x, max_y, max_z},
+                    .node_owner_id   = 0,
                 };
                 id_cnt++;
 
                 Patch child_pmm = Patch{
-                    id_cnt,
-                    u64_max,
-                    qte_pmm,
-                    split_x + 1,
-                    min_y,
-                    min_z,
-                    max_x,
-                    split_y,
-                    split_z,
-                    0,
+                    .id_patch        = id_cnt,
+                    .pack_node_index = u64_max,
+                    .load_value      = qte_pmm,
+                    .coord_min       = {split_x + 1, min_y, min_z},
+                    .coord_max       = {max_x, split_y, split_z},
+                    .node_owner_id   = 0,
                 };
                 id_cnt++;
 
                 Patch child_pmp = Patch{
-                    id_cnt,
-                    u64_max,
-                    qte_pmp,
-                    split_x + 1,
-                    min_y,
-                    split_z + 1,
-                    max_x,
-                    split_y,
-                    max_z,
-                    0,
+                    .id_patch        = id_cnt,
+                    .pack_node_index = u64_max,
+                    .load_value      = qte_pmp,
+                    .coord_min       = {split_x + 1, min_y, split_z + 1},
+                    .coord_max       = {max_x, split_y, max_z},
+                    .node_owner_id   = 0,
                 };
                 id_cnt++;
 
                 Patch child_ppm = Patch{
-                    id_cnt,
-                    u64_max,
-                    qte_ppm,
-                    split_x + 1,
-                    split_y + 1,
-                    min_z,
-                    max_x,
-                    max_y,
-                    split_z,
-                    0,
+                    .id_patch        = id_cnt,
+                    .pack_node_index = u64_max,
+                    .load_value      = qte_ppm,
+                    .coord_min       = {split_x + 1, split_y + 1, min_z},
+                    .coord_max       = {max_x, max_y, split_z},
+                    .node_owner_id   = 0,
                 };
                 id_cnt++;
 
                 Patch child_ppp = Patch{
-                    id_cnt,
-                    u64_max,
-                    qte_ppp,
-                    split_x + 1,
-                    split_y + 1,
-                    split_z + 1,
-                    max_x,
-                    max_y,
-                    max_z,
-                    0,
+                    .id_patch        = id_cnt,
+                    .pack_node_index = u64_max,
+                    .load_value      = qte_ppp,
+                    .coord_min       = {split_x + 1, split_y + 1, split_z + 1},
+                    .coord_max       = {max_x, max_y, max_z},
+                    .node_owner_id   = 0,
                 };
                 id_cnt++;
 

--- a/src/shamsys/include/shamsys/system_metrics.hpp
+++ b/src/shamsys/include/shamsys/system_metrics.hpp
@@ -112,11 +112,15 @@ namespace shamsys {
                        : std::nullopt;
         };
         return SystemMetrics{
-            lhs.wall_time - rhs.wall_time,
-            optional_sub(lhs.rank_energy_consummed, rhs.rank_energy_consummed),
-            optional_sub(lhs.gpu_energy_consummed, rhs.gpu_energy_consummed),
-            optional_sub(lhs.cpu_energy_consummed, rhs.cpu_energy_consummed),
-            optional_sub(lhs.dram_energy_consummed, rhs.dram_energy_consummed)};
+            .wall_time = lhs.wall_time - rhs.wall_time,
+            .rank_energy_consummed
+            = optional_sub(lhs.rank_energy_consummed, rhs.rank_energy_consummed),
+            .gpu_energy_consummed
+            = optional_sub(lhs.gpu_energy_consummed, rhs.gpu_energy_consummed),
+            .cpu_energy_consummed
+            = optional_sub(lhs.cpu_energy_consummed, rhs.cpu_energy_consummed),
+            .dram_energy_consummed
+            = optional_sub(lhs.dram_energy_consummed, rhs.dram_energy_consummed)};
     }
 
     // Returns true if the current reporter is not a NoopSystemMetricReporter (defined below).

--- a/src/shamsys/src/NodeInstance.cpp
+++ b/src/shamsys/src/NodeInstance.cpp
@@ -331,7 +331,7 @@ namespace shamsys::instance {
 
             // shamlog_debug_ln("NodeInstance", "chosen sycl config :",sycl_cfg);
 
-            init_sycl_mpi(sycl_cfg, {argc, argv, forced_state});
+            init_sycl_mpi(sycl_cfg, {.argc = argc, .argv = argv, .forced_state = forced_state});
 
         } else {
 

--- a/src/shamsys/src/system_metrics.cpp
+++ b/src/shamsys/src/system_metrics.cpp
@@ -206,11 +206,11 @@ namespace shamsys {
         }
         f64 wall_time = shambase::details::get_wtime();
         auto ret      = SystemMetrics{
-            wall_time,
-            get_rank_energy_consummed(),
-            get_gpu_energy_consummed(),
-            get_cpu_energy_consummed(),
-            get_dram_energy_consummed()};
+            .wall_time             = wall_time,
+            .rank_energy_consummed = get_rank_energy_consummed(),
+            .gpu_energy_consummed  = get_gpu_energy_consummed(),
+            .cpu_energy_consummed  = get_cpu_energy_consummed(),
+            .dram_energy_consummed = get_dram_energy_consummed()};
         if (barrier) {
             shamcomm::mpi::Barrier(MPI_COMM_WORLD);
         }
@@ -236,19 +236,21 @@ namespace shamsys {
 
         for (u32 i = 0; i < shamcomm::world_size(); i++) {
             ret[i] = SystemMetrics{
-                metric_time_all_ranks[i],
-                (shamsys::support_rank_energy_consummed())
-                    ? std::optional<f64>{rank_energy_consummed_all_ranks[i]}
-                    : std::nullopt,
-                (shamsys::support_gpu_energy_consummed())
-                    ? std::optional<f64>{gpu_energy_consummed_all_ranks[i]}
-                    : std::nullopt,
-                (shamsys::support_cpu_energy_consummed())
-                    ? std::optional<f64>{cpu_energy_consummed_all_ranks[i]}
-                    : std::nullopt,
-                (shamsys::support_dram_energy_consummed())
-                    ? std::optional<f64>{dram_energy_consummed_all_ranks[i]}
-                    : std::nullopt,
+                .wall_time = metric_time_all_ranks[i],
+                .rank_energy_consummed
+                = (shamsys::support_rank_energy_consummed())
+                      ? std::optional<f64>{rank_energy_consummed_all_ranks[i]}
+                      : std::nullopt,
+                .gpu_energy_consummed = (shamsys::support_gpu_energy_consummed())
+                                            ? std::optional<f64>{gpu_energy_consummed_all_ranks[i]}
+                                            : std::nullopt,
+                .cpu_energy_consummed = (shamsys::support_cpu_energy_consummed())
+                                            ? std::optional<f64>{cpu_energy_consummed_all_ranks[i]}
+                                            : std::nullopt,
+                .dram_energy_consummed
+                = (shamsys::support_dram_energy_consummed())
+                      ? std::optional<f64>{dram_energy_consummed_all_ranks[i]}
+                      : std::nullopt,
             };
         }
 
@@ -311,15 +313,15 @@ namespace shamsys {
         };
 
         FormattedSystemMetrics ret{
-            shambase::format("{:.1f} s", input.wall_time),
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
+            .wall_time             = shambase::format("{:.1f} s", input.wall_time),
+            .rank_energy_consummed = std::nullopt,
+            .gpu_energy_consummed  = std::nullopt,
+            .cpu_energy_consummed  = std::nullopt,
+            .dram_energy_consummed = std::nullopt,
+            .rank_power            = std::nullopt,
+            .gpu_power             = std::nullopt,
+            .cpu_power             = std::nullopt,
+            .dram_power            = std::nullopt,
         };
 
         format_metric(

--- a/src/shamtest/details/TestAssert.cpp
+++ b/src/shamtest/details/TestAssert.cpp
@@ -49,7 +49,7 @@ namespace shamtest::details {
         shambase::stream_read_string(stream, name);
         shambase::stream_read_string(stream, comment);
 
-        return {bool(bl), name, comment};
+        return {.value = bool(bl), .name = name, .comment = comment};
     }
 
 } // namespace shamtest::details

--- a/src/shamtest/details/TestAssertList.hpp
+++ b/src/shamtest/details/TestAssertList.hpp
@@ -67,7 +67,11 @@ namespace shamtest::details {
                 comment = "left=" + std::to_string(a) + " right=" + std::to_string(b);
             }
 
-            asserts.push_back(TestAssert{t, std::move(assert_name), gen_comment(comment, loc)});
+            asserts.push_back(
+                TestAssert{
+                    .value   = t,
+                    .name    = std::move(assert_name),
+                    .comment = gen_comment(comment, loc)});
         }
 
         /// Assert equal on an array of values

--- a/src/shamtest/details/TestAssertList.hpp
+++ b/src/shamtest/details/TestAssertList.hpp
@@ -19,6 +19,7 @@
 #include "shambase/string.hpp"
 #include "TestAssert.hpp"
 #include "shambackends/sycl.hpp"
+#include <utility>
 
 namespace shamtest::details {
 
@@ -32,7 +33,8 @@ namespace shamtest::details {
         // to register asserts
 
         inline void assert_bool_with_log(std::string assert_name, bool v, std::string log) {
-            asserts.push_back(TestAssert{v, std::move(assert_name), std::move(log)});
+            asserts.push_back(
+                TestAssert{.value = v, .name = std::move(assert_name), .comment = std::move(log)});
         }
 
         /// Append the source location to the the supplied string to generate a comment
@@ -47,9 +49,9 @@ namespace shamtest::details {
 
             asserts.push_back(
                 TestAssert{
-                    v,
-                    std::move(assert_name),
-                    "failed assert location : " + loc.format_one_line()});
+                    .value   = v,
+                    .name    = std::move(assert_name),
+                    .comment = "failed assert location : " + loc.format_one_line()});
         }
 
         /// Test for an equality
@@ -92,7 +94,11 @@ namespace shamtest::details {
                 comment += shambase::format_array(acc_b, len, 16, "{} ");
             }
 
-            asserts.push_back(TestAssert{t, std::move(assert_name), gen_comment(comment, loc)});
+            asserts.push_back(
+                TestAssert{
+                    .value   = t,
+                    .name    = std::move(assert_name),
+                    .comment = gen_comment(comment, loc)});
         }
 
         /**
@@ -117,7 +123,11 @@ namespace shamtest::details {
                           + " diff=" + std::to_string(diff);
             }
 
-            asserts.push_back(TestAssert{t, std::move(assert_name), gen_comment(comment, loc)});
+            asserts.push_back(
+                TestAssert{
+                    .value   = t,
+                    .name    = std::move(assert_name),
+                    .comment = gen_comment(comment, loc)});
         }
 
         /// add an assertion with a comment
@@ -126,7 +136,11 @@ namespace shamtest::details {
             bool v,
             std::string comment,
             SourceLocation loc = SourceLocation{}) {
-            asserts.push_back(TestAssert{v, std::move(assert_name), gen_comment(comment, loc)});
+            asserts.push_back(
+                TestAssert{
+                    .value   = v,
+                    .name    = std::move(assert_name),
+                    .comment = gen_comment(std::move(comment), loc)});
         }
 
         /// Serialize the assertion in JSON

--- a/src/shamtest/details/TestData.hpp
+++ b/src/shamtest/details/TestData.hpp
@@ -30,7 +30,7 @@ namespace shamtest::details {
             for (f64 f : v) {
                 new_vec.push_back(f);
             }
-            dataset.push_back(DataNode{std::move(name), std::move(new_vec)});
+            dataset.push_back(DataNode{.name = std::move(name), .data = std::move(new_vec)});
         }
 
         /// Serialize the assertion in JSON

--- a/src/shamtest/details/TestDataList.hpp
+++ b/src/shamtest/details/TestDataList.hpp
@@ -31,7 +31,7 @@ namespace shamtest::details {
 
         /// Create a new TestData in this TestDataList and return a reference to it
         [[nodiscard]] inline TestData &new_dataset(std::string name) {
-            test_data.push_back(TestData{std::move(name), {}});
+            test_data.push_back(TestData{.dataset_name = std::move(name), .dataset = {}});
             return test_data.back();
         }
 

--- a/src/shamtree/include/shamtree/CellIterator.hpp
+++ b/src/shamtree/include/shamtree/CellIterator.hpp
@@ -96,10 +96,10 @@ namespace shamtree {
          */
         inline acc get_read_access(sham::EventList &deps) const {
             return acc{
-                buf_sort_index_map.get_read_access(deps),
-                buf_reduc_index_map.get_read_access(deps),
-                buf_endrange.get_read_access(deps),
-                offset_leaf};
+                .sort_index_map  = buf_sort_index_map.get_read_access(deps),
+                .reduc_index_map = buf_reduc_index_map.get_read_access(deps),
+                .endrange        = buf_endrange.get_read_access(deps),
+                .offset_leaf     = offset_leaf};
         }
 
         /**
@@ -129,7 +129,11 @@ namespace shamtree {
 
         /// get read only accessor
         inline acc get_read_access() const {
-            return acc{sort_index_map.data(), reduc_index_map.data(), endrange.data(), offset_leaf};
+            return acc{
+                .sort_index_map  = sort_index_map.data(),
+                .reduc_index_map = reduc_index_map.data(),
+                .endrange        = endrange.data(),
+                .offset_leaf     = offset_leaf};
         }
     };
 

--- a/src/shamtree/include/shamtree/KarrasRadixTree.hpp
+++ b/src/shamtree/include/shamtree/KarrasRadixTree.hpp
@@ -67,20 +67,20 @@ class shamtree::KarrasRadixTree {
 
     inline KarrasTreeTraverser get_structure_traverser() const {
         return KarrasTreeTraverser{
-            buf_lchild_id,
-            buf_rchild_id,
-            buf_lchild_flag,
-            buf_rchild_flag,
-            get_internal_cell_count()};
+            .buf_lchild_id   = buf_lchild_id,
+            .buf_rchild_id   = buf_rchild_id,
+            .buf_lchild_flag = buf_lchild_flag,
+            .buf_rchild_flag = buf_rchild_flag,
+            .offset_leaf     = get_internal_cell_count()};
     }
 
     inline KarrasTreeTraverserHost get_structure_traverser_host() const {
         return KarrasTreeTraverserHost{
-            buf_lchild_id.copy_to_stdvec(),
-            buf_rchild_id.copy_to_stdvec(),
-            buf_lchild_flag.copy_to_stdvec(),
-            buf_rchild_flag.copy_to_stdvec(),
-            get_internal_cell_count()};
+            .buf_lchild_id   = buf_lchild_id.copy_to_stdvec(),
+            .buf_rchild_id   = buf_rchild_id.copy_to_stdvec(),
+            .buf_lchild_flag = buf_lchild_flag.copy_to_stdvec(),
+            .buf_rchild_flag = buf_rchild_flag.copy_to_stdvec(),
+            .offset_leaf     = get_internal_cell_count()};
     }
 
     static inline KarrasRadixTree make_empty(sham::DeviceScheduler_ptr dev_sched) {

--- a/src/shamtree/include/shamtree/KarrasTreeTraverser.hpp
+++ b/src/shamtree/include/shamtree/KarrasTreeTraverser.hpp
@@ -146,11 +146,11 @@ struct shamtree::KarrasTreeTraverser {
     /// get read only accessor
     inline KarrasTreeTraverserAccessed get_read_access(sham::EventList &deps) const {
         return KarrasTreeTraverserAccessed{
-            buf_lchild_id.get_read_access(deps),
-            buf_rchild_id.get_read_access(deps),
-            buf_lchild_flag.get_read_access(deps),
-            buf_rchild_flag.get_read_access(deps),
-            offset_leaf};
+            .lchild_id   = buf_lchild_id.get_read_access(deps),
+            .rchild_id   = buf_rchild_id.get_read_access(deps),
+            .lchild_flag = buf_lchild_flag.get_read_access(deps),
+            .rchild_flag = buf_rchild_flag.get_read_access(deps),
+            .offset_leaf = offset_leaf};
     }
 
     /// complete the buffer states with the resulting event
@@ -176,10 +176,10 @@ struct shamtree::KarrasTreeTraverserHost {
     /// get read only accessor
     inline KarrasTreeTraverserAccessed get_read_access() const {
         return KarrasTreeTraverserAccessed{
-            buf_lchild_id.data(),
-            buf_rchild_id.data(),
-            buf_lchild_flag.data(),
-            buf_rchild_flag.data(),
-            offset_leaf};
+            .lchild_id   = buf_lchild_id.data(),
+            .rchild_id   = buf_rchild_id.data(),
+            .lchild_flag = buf_lchild_flag.data(),
+            .rchild_flag = buf_rchild_flag.data(),
+            .offset_leaf = offset_leaf};
     }
 };

--- a/src/shamtree/include/shamtree/LeafCellIterator.hpp
+++ b/src/shamtree/include/shamtree/LeafCellIterator.hpp
@@ -76,8 +76,8 @@ namespace shamtree {
          */
         inline acc get_read_access(sham::EventList &deps) const {
             return acc{
-                buf_sort_index_map.get_read_access(deps),
-                buf_reduc_index_map.get_read_access(deps)};
+                .sort_index_map  = buf_sort_index_map.get_read_access(deps),
+                .reduc_index_map = buf_reduc_index_map.get_read_access(deps)};
         }
 
         /**
@@ -104,7 +104,8 @@ namespace shamtree {
 
         /// get read only accessor
         inline acc get_read_access() const {
-            return acc{sort_index_map.data(), reduc_index_map.data()};
+            return acc{
+                .sort_index_map = sort_index_map.data(), .reduc_index_map = reduc_index_map.data()};
         }
     };
 

--- a/src/shamtree/include/shamtree/TreeTraversal.hpp
+++ b/src/shamtree/include/shamtree/TreeTraversal.hpp
@@ -289,9 +289,9 @@ namespace shamrock::tree {
 
         ptrs get_read_access(sham::EventList &depends_list) {
             return ptrs{
-                cnt_neigh.get_read_access(depends_list),
-                scanned_cnt.get_read_access(depends_list),
-                index_neigh_map.get_read_access(depends_list)};
+                .cnt_neigh       = cnt_neigh.get_read_access(depends_list),
+                .scanned_cnt     = scanned_cnt.get_read_access(depends_list),
+                .index_neigh_map = index_neigh_map.get_read_access(depends_list)};
         }
 
         void complete_event_state(sham::EventList &resulting_events) {
@@ -385,10 +385,10 @@ namespace shamrock::tree {
 
         inline HostObjectCache copy_to_host() {
             return HostObjectCache{
-                cnt_neigh.copy_to_stdvec(),
-                scanned_cnt.copy_to_stdvec(),
-                sum_neigh_cnt,
-                index_neigh_map.copy_to_stdvec(),
+                .cnt_neigh       = cnt_neigh.copy_to_stdvec(),
+                .scanned_cnt     = scanned_cnt.copy_to_stdvec(),
+                .sum_neigh_cnt   = sum_neigh_cnt,
+                .index_neigh_map = index_neigh_map.copy_to_stdvec(),
             };
         }
 
@@ -406,10 +406,10 @@ namespace shamrock::tree {
             index_neigh_map.copy_from_stdvec(cache.index_neigh_map);
 
             return ObjectCache{
-                std::move(cnt_neigh),
-                std::move(scanned_cnt),
-                sum_neigh_cnt,
-                std::move(index_neigh_map),
+                .cnt_neigh       = std::move(cnt_neigh),
+                .scanned_cnt     = std::move(scanned_cnt),
+                .sum_neigh_cnt   = sum_neigh_cnt,
+                .index_neigh_map = std::move(index_neigh_map),
             };
         }
 
@@ -427,17 +427,17 @@ namespace shamrock::tree {
 
         ptrs_read get_read_access(sham::EventList &depends_list) const {
             return ptrs_read{
-                cnt_neigh.get_read_access(depends_list),
-                scanned_cnt.get_read_access(depends_list),
-                index_neigh_map.get_read_access(depends_list),
+                .cnt_neigh       = cnt_neigh.get_read_access(depends_list),
+                .scanned_cnt     = scanned_cnt.get_read_access(depends_list),
+                .index_neigh_map = index_neigh_map.get_read_access(depends_list),
             };
         }
 
         ptrs get_write_access(sham::EventList &depends_list) {
             return ptrs{
-                cnt_neigh.get_write_access(depends_list),
-                scanned_cnt.get_write_access(depends_list),
-                index_neigh_map.get_write_access(depends_list),
+                .cnt_neigh       = cnt_neigh.get_write_access(depends_list),
+                .scanned_cnt     = scanned_cnt.get_write_access(depends_list),
+                .index_neigh_map = index_neigh_map.get_write_access(depends_list),
             };
         }
         void complete_event_state(sycl::event &e) const {
@@ -476,10 +476,10 @@ namespace shamrock::tree {
             neigh_sum, shamsys::instance::get_compute_scheduler_ptr());
 
         tree::ObjectCache pcache{
-            std::move(counts),
-            std::move(neigh_scanned_vals),
-            neigh_sum,
-            std::move(particle_neigh_map)};
+            .cnt_neigh       = std::move(counts),
+            .scanned_cnt     = std::move(neigh_scanned_vals),
+            .sum_neigh_cnt   = neigh_sum,
+            .index_neigh_map = std::move(particle_neigh_map)};
 
         return pcache;
     }

--- a/src/shamtree/include/shamtree/details/dtt_parallel_select.hpp
+++ b/src/shamtree/include/shamtree/details/dtt_parallel_select.hpp
@@ -371,10 +371,13 @@ namespace shamtree::details {
                     }
                 });
 
-            DTTResult ret{std::move(idx_m2l), std::move(idx_p2p)};
+            DTTResult ret{
+                .node_interactions_m2l = std::move(idx_m2l),
+                .node_interactions_p2p = std::move(idx_p2p)};
 
             if (ordered_result) {
-                DTTResult::OrderedResult ordering{std::move(scan_m2l), std::move(scan_p2p)};
+                DTTResult::OrderedResult ordering{
+                    .offset_m2l = std::move(scan_m2l), .offset_p2p = std::move(scan_p2p)};
                 ret.ordered_result = std::move(ordering);
             }
 

--- a/src/shamtree/include/shamtree/details/dtt_reference.hpp
+++ b/src/shamtree/include/shamtree/details/dtt_reference.hpp
@@ -175,7 +175,9 @@ namespace shamtree::details {
             // afterward to avoid an issue with clang-tidy complaining when initializing under the
             // hood multiple unique_ptr in a structured binding initialization
             // see : https://github.com/llvm/llvm-project/issues/153300
-            DTTResult result{std::move(interact_m2l_buf), std::move(interact_p2p_buf)};
+            DTTResult result{
+                .node_interactions_m2l = std::move(interact_m2l_buf),
+                .node_interactions_p2p = std::move(interact_p2p_buf)};
 
             if (ordered_result) {
                 auto offset_m2l = sham::DeviceBuffer<u32>(0, dev_sched);
@@ -187,7 +189,8 @@ namespace shamtree::details {
                 shamtree::details::reorder_scan_dtt_result(
                     bvh.structure.get_total_cell_count(), result.node_interactions_p2p, offset_p2p);
 
-                DTTResult::OrderedResult ordering{std::move(offset_m2l), std::move(offset_p2p)};
+                DTTResult::OrderedResult ordering{
+                    .offset_m2l = std::move(offset_m2l), .offset_p2p = std::move(offset_p2p)};
 
                 result.ordered_result = std::move(ordering);
             }

--- a/src/shamtree/include/shamtree/details/dtt_scan_multipass.hpp
+++ b/src/shamtree/include/shamtree/details/dtt_scan_multipass.hpp
@@ -52,7 +52,8 @@ namespace shamtree::details {
             sham::DeviceBuffer<u32_2> node_interactions_p2p(0, dev_sched);
 
             shamtree::DTTResult result{
-                std::move(node_interactions_m2l), std::move(node_interactions_p2p)};
+                .node_interactions_m2l = std::move(node_interactions_m2l),
+                .node_interactions_p2p = std::move(node_interactions_p2p)};
 
             auto add_ordering = [&]() {
                 if (ordered_result) {
@@ -69,7 +70,8 @@ namespace shamtree::details {
                         result.node_interactions_p2p,
                         offset_p2p);
 
-                    DTTResult::OrderedResult ordering{std::move(offset_m2l), std::move(offset_p2p)};
+                    DTTResult::OrderedResult ordering{
+                        .offset_m2l = std::move(offset_m2l), .offset_p2p = std::move(offset_p2p)};
 
                     result.ordered_result = std::move(ordering);
                 }

--- a/src/shamtree/src/CLBVHDualTreeTraversal.cpp
+++ b/src/shamtree/src/CLBVHDualTreeTraversal.cpp
@@ -39,11 +39,11 @@ namespace shamtree {
 
     inline shamalgs::impl_param dtt_impl_to_params(const DTTImpl &impl) {
         if (impl == DTTImpl::REFERENCE) {
-            return {"reference", ""};
+            return {.impl_name = "reference", .params = ""};
         } else if (impl == DTTImpl::PARALLEL_SELECT) {
-            return {"parallel_select", ""};
+            return {.impl_name = "parallel_select", .params = ""};
         } else if (impl == DTTImpl::SCAN_MULTIPASS) {
-            return {"scan_multipass", ""};
+            return {.impl_name = "scan_multipass", .params = ""};
         }
         throw shambase::make_except_with_loc<std::invalid_argument>(
             shambase::format("unknown dtt implementation : {}", u32(impl)));
@@ -51,7 +51,9 @@ namespace shamtree {
 
     std::vector<shamalgs::impl_param> impl::get_default_impl_list_clbvh_dual_tree_traversal() {
         std::vector<shamalgs::impl_param> impl_list{
-            {"reference", ""}, {"parallel_select", ""}, {"scan_multipass", ""}};
+            {.impl_name = "reference", .params = ""},
+            {.impl_name = "parallel_select", .params = ""},
+            {.impl_name = "scan_multipass", .params = ""}};
         return impl_list;
     }
 

--- a/src/tests/fmmTests.cpp
+++ b/src/tests/fmmTests.cpp
@@ -256,18 +256,18 @@ TestStart(ValidationTest, "models/generic/fmm/precision", fmm_prec, 1) {
 
         vec_result.push_back(
             Entry{
-                angle,
-                FMM_prec_eval<f64, 5>::eval_prec_fmm_pot(x_i, x_j, s_a, s_b),
-                FMM_prec_eval<f64, 4>::eval_prec_fmm_pot(x_i, x_j, s_a, s_b),
-                FMM_prec_eval<f64, 3>::eval_prec_fmm_pot(x_i, x_j, s_a, s_b),
-                FMM_prec_eval<f64, 2>::eval_prec_fmm_pot(x_i, x_j, s_a, s_b),
-                FMM_prec_eval<f64, 1>::eval_prec_fmm_pot(x_i, x_j, s_a, s_b),
-                FMM_prec_eval<f64, 0>::eval_prec_fmm_pot(x_i, x_j, s_a, s_b),
-                FMM_prec_eval<f64, 5>::eval_prec_fmm_force(x_i, x_j, s_a, s_b),
-                FMM_prec_eval<f64, 4>::eval_prec_fmm_force(x_i, x_j, s_a, s_b),
-                FMM_prec_eval<f64, 3>::eval_prec_fmm_force(x_i, x_j, s_a, s_b),
-                FMM_prec_eval<f64, 2>::eval_prec_fmm_force(x_i, x_j, s_a, s_b),
-                FMM_prec_eval<f64, 1>::eval_prec_fmm_force(x_i, x_j, s_a, s_b)});
+                .angle          = angle,
+                .result_pot_5   = FMM_prec_eval<f64, 5>::eval_prec_fmm_pot(x_i, x_j, s_a, s_b),
+                .result_pot_4   = FMM_prec_eval<f64, 4>::eval_prec_fmm_pot(x_i, x_j, s_a, s_b),
+                .result_pot_3   = FMM_prec_eval<f64, 3>::eval_prec_fmm_pot(x_i, x_j, s_a, s_b),
+                .result_pot_2   = FMM_prec_eval<f64, 2>::eval_prec_fmm_pot(x_i, x_j, s_a, s_b),
+                .result_pot_1   = FMM_prec_eval<f64, 1>::eval_prec_fmm_pot(x_i, x_j, s_a, s_b),
+                .result_pot_0   = FMM_prec_eval<f64, 0>::eval_prec_fmm_pot(x_i, x_j, s_a, s_b),
+                .result_force_5 = FMM_prec_eval<f64, 5>::eval_prec_fmm_force(x_i, x_j, s_a, s_b),
+                .result_force_4 = FMM_prec_eval<f64, 4>::eval_prec_fmm_force(x_i, x_j, s_a, s_b),
+                .result_force_3 = FMM_prec_eval<f64, 3>::eval_prec_fmm_force(x_i, x_j, s_a, s_b),
+                .result_force_2 = FMM_prec_eval<f64, 2>::eval_prec_fmm_force(x_i, x_j, s_a, s_b),
+                .result_force_1 = FMM_prec_eval<f64, 1>::eval_prec_fmm_force(x_i, x_j, s_a, s_b)});
 
         if (i % 10000 == 0) {
             shamlog_debug_ln("Tests", "i =", i, "\\", 100000);

--- a/src/tests/shamalgs/collective/sparseXchgTests.cpp
+++ b/src/tests/shamalgs/collective/sparseXchgTests.cpp
@@ -55,9 +55,9 @@ void sparse_comm_test(std::string prefix, std::shared_ptr<sham::DeviceScheduler>
             u64 rnd                             = eng();
             elements.push_back(
                 RefBuff{
-                    shamalgs::primitives::mock_value<i32>(eng, 0, wsize - 1),
-                    shamalgs::primitives::mock_value<i32>(eng, 0, wsize - 1),
-                    shamalgs::random::mock_buffer_usm<u8>(
+                    .sender_rank   = shamalgs::primitives::mock_value<i32>(eng, 0, wsize - 1),
+                    .receiver_rank = shamalgs::primitives::mock_value<i32>(eng, 0, wsize - 1),
+                    .payload       = shamalgs::random::mock_buffer_usm<u8>(
                         dev_sched, rnd, shamalgs::primitives::mock_value<i32>(eng, 1, bytes))});
         }
 
@@ -83,8 +83,8 @@ void sparse_comm_test(std::string prefix, std::shared_ptr<sham::DeviceScheduler>
         if (bufinfo.sender_rank == world_rank()) {
             sendop.push_back(
                 SendPayload{
-                    bufinfo.receiver_rank,
-                    std::make_unique<CommunicationBuffer>(bufinfo.payload, qdet)});
+                    .receiver_rank = bufinfo.receiver_rank,
+                    .payload       = std::make_unique<CommunicationBuffer>(bufinfo.payload, qdet)});
 
             REQUIRE_EQUAL(sendop[idx].payload->get_size(), bufinfo.payload.get_size());
 
@@ -99,9 +99,9 @@ void sparse_comm_test(std::string prefix, std::shared_ptr<sham::DeviceScheduler>
     for (RecvPayload &load : recvop) {
         recv_data.push_back(
             RefBuff{
-                load.sender_ranks,
-                wrank,
-                shamcomm::CommunicationBuffer::convert_usm(
+                .sender_rank   = load.sender_ranks,
+                .receiver_rank = wrank,
+                .payload       = shamcomm::CommunicationBuffer::convert_usm(
                     shambase::extract_pointer(load.payload))});
     }
 

--- a/src/tests/shamalgs/collective/sparse_exchange_tests.cpp
+++ b/src/tests/shamalgs/collective/sparse_exchange_tests.cpp
@@ -220,12 +220,12 @@ void test_sparse_exchange(std::vector<TestElement> test_elements, size_t max_all
         if (test_elements[i].sender == shamcomm::world_rank()) {
             messages_send.push_back(
                 shamalgs::collective::CommMessageInfo{
-                    test_elements[i].size,
-                    test_elements[i].sender,
-                    test_elements[i].receiver,
-                    std::nullopt,
-                    std::nullopt,
-                    std::nullopt,
+                    .message_size                = test_elements[i].size,
+                    .rank_sender                 = test_elements[i].sender,
+                    .rank_receiver               = test_elements[i].receiver,
+                    .message_tag                 = std::nullopt,
+                    .message_bytebuf_offset_send = std::nullopt,
+                    .message_bytebuf_offset_recv = std::nullopt,
                 });
         }
     }
@@ -364,7 +364,10 @@ TestStart(Unittest, "shamalgs/collective/test_sparse_exchange", testsparsexchg_2
         std::vector<TestElement> test_elements;
         for (i32 i = 0; i < shamcomm::world_size(); i++) {
             test_elements.push_back(
-                TestElement{i, i, shamalgs::primitives::mock_value<u32>(eng, 1, 10)});
+                TestElement{
+                    .sender   = i,
+                    .receiver = i,
+                    .size     = shamalgs::primitives::mock_value<u32>(eng, 1, 10)});
         }
         test_sparse_exchange(test_elements, i32_max);
     }
@@ -380,9 +383,9 @@ TestStart(Unittest, "shamalgs/collective/test_sparse_exchange", testsparsexchg_2
         for (i32 i = 0; i < shamcomm::world_size(); i++) {
             test_elements.push_back(
                 TestElement{
-                    i,
-                    (i + 1) % shamcomm::world_size(),
-                    shamalgs::primitives::mock_value<u32>(eng, 1, 10)});
+                    .sender   = i,
+                    .receiver = (i + 1) % shamcomm::world_size(),
+                    .size     = shamalgs::primitives::mock_value<u32>(eng, 1, 10)});
         }
         test_sparse_exchange(test_elements, i32_max);
     }
@@ -398,9 +401,11 @@ TestStart(Unittest, "shamalgs/collective/test_sparse_exchange", testsparsexchg_2
         for (u32 i = 0; i < 3 * shamcomm::world_size(); i++) {
             test_elements.push_back(
                 TestElement{
-                    shamalgs::primitives::mock_value<i32>(eng, 0, shamcomm::world_size() - 1),
-                    shamalgs::primitives::mock_value<i32>(eng, 0, shamcomm::world_size() - 1),
-                    shamalgs::primitives::mock_value<u32>(eng, 1, 10)});
+                    .sender
+                    = shamalgs::primitives::mock_value<i32>(eng, 0, shamcomm::world_size() - 1),
+                    .receiver
+                    = shamalgs::primitives::mock_value<i32>(eng, 0, shamcomm::world_size() - 1),
+                    .size = shamalgs::primitives::mock_value<u32>(eng, 1, 10)});
         }
         test_sparse_exchange(test_elements, i32_max);
     }
@@ -416,9 +421,11 @@ TestStart(Unittest, "shamalgs/collective/test_sparse_exchange", testsparsexchg_2
         for (u32 i = 0; i < 3 * shamcomm::world_size(); i++) {
             test_elements.push_back(
                 TestElement{
-                    shamalgs::primitives::mock_value<i32>(eng, 0, shamcomm::world_size() - 1),
-                    shamalgs::primitives::mock_value<i32>(eng, 0, shamcomm::world_size() - 1),
-                    shamalgs::primitives::mock_value<u32>(eng, 1, 10)});
+                    .sender
+                    = shamalgs::primitives::mock_value<i32>(eng, 0, shamcomm::world_size() - 1),
+                    .receiver
+                    = shamalgs::primitives::mock_value<i32>(eng, 0, shamcomm::world_size() - 1),
+                    .size = shamalgs::primitives::mock_value<u32>(eng, 1, 10)});
         }
         test_sparse_exchange(test_elements, 20);
     }

--- a/src/tests/shammath/riemannTests.cpp
+++ b/src/tests/shammath/riemannTests.cpp
@@ -17,8 +17,8 @@ TestStart(Unittest, "shammath/flux_symmetry", flux_rotate, 1) {
 
     using Tcons = shammath::ConsState<f64_3>;
 
-    Tcons state1 = {1._f64, 1.2_f64, f64_3{1, 0, 0}};
-    Tcons state2 = {1.5_f64, 1._f64, f64_3{2, 0, 0}};
+    Tcons state1 = {.rho = 1._f64, .rhoe = 1.2_f64, .rhovel = f64_3{1, 0, 0}};
+    Tcons state2 = {.rho = 1.5_f64, .rhoe = 1._f64, .rhovel = f64_3{2, 0, 0}};
 
     {
         Tcons f1 = shammath::rusanov_flux_x(state1, state2, 1.6666);
@@ -44,13 +44,13 @@ TestStart(Unittest, "shammath/flux_symmetry", flux_rotate, 1) {
         REQUIRE_EQUAL_CUSTOM_COMP(f1.rhoe, -f2.rhoe, sham::equals);
     }
 
-    Tcons state_xp = {1.1_f64, 0.8_f64, f64_3{1.1, 0, 0}};
-    Tcons state_yp = {1._f64, 1._f64, f64_3{1, 0, 0}};
-    Tcons state_zp = {1._f64, 1._f64, f64_3{1, 0, 0}};
-    Tcons state_i  = {1._f64, 1._f64, f64_3{1, 0, 0}};
-    Tcons state_xm = {0.7_f64, 1.2_f64, f64_3{1.1, 0, 0}};
-    Tcons state_ym = {1._f64, 1._f64, f64_3{1, 0, 0}};
-    Tcons state_zm = {1._f64, 1._f64, f64_3{1, 0, 0}};
+    Tcons state_xp = {.rho = 1.1_f64, .rhoe = 0.8_f64, .rhovel = f64_3{1.1, 0, 0}};
+    Tcons state_yp = {.rho = 1._f64, .rhoe = 1._f64, .rhovel = f64_3{1, 0, 0}};
+    Tcons state_zp = {.rho = 1._f64, .rhoe = 1._f64, .rhovel = f64_3{1, 0, 0}};
+    Tcons state_i  = {.rho = 1._f64, .rhoe = 1._f64, .rhovel = f64_3{1, 0, 0}};
+    Tcons state_xm = {.rho = 0.7_f64, .rhoe = 1.2_f64, .rhovel = f64_3{1.1, 0, 0}};
+    Tcons state_ym = {.rho = 1._f64, .rhoe = 1._f64, .rhovel = f64_3{1, 0, 0}};
+    Tcons state_zm = {.rho = 1._f64, .rhoe = 1._f64, .rhovel = f64_3{1, 0, 0}};
     {
         Tcons fx = shammath::rusanov_flux_x(state_i, state_xp, 1.6666);
         shamlog_debug_ln("Riemann Solver", fx.rho, fx.rhovel, fx.rhoe);

--- a/src/tests/shammodels/gsph/GSPHRiemannTests.cpp
+++ b/src/tests/shammodels/gsph/GSPHRiemannTests.cpp
@@ -48,21 +48,71 @@ namespace {
     // Standard shock tube test cases from Toro (2009)
     const std::vector<RiemannTestCase> standard_tests = {
         // Test 1: Sod shock tube (modified)
-        {"Sod", 1.0, 0.0, 1.0, 0.125, 0.0, 0.1, 1.4, 0.30313, 0.92745, 0.05},
+        {.name         = "Sod",
+         .rho_L        = 1.0,
+         .u_L          = 0.0,
+         .p_L          = 1.0,
+         .rho_R        = 0.125,
+         .u_R          = 0.0,
+         .p_R          = 0.1,
+         .gamma        = 1.4,
+         .p_star_exact = 0.30313,
+         .u_star_exact = 0.92745,
+         .tolerance    = 0.05},
 
         // Test 2: 123 problem (two rarefactions)
-        {"123 problem", 1.0, -2.0, 0.4, 1.0, 2.0, 0.4, 1.4, 0.00189, 0.0, 0.1},
+        {.name         = "123 problem",
+         .rho_L        = 1.0,
+         .u_L          = -2.0,
+         .p_L          = 0.4,
+         .rho_R        = 1.0,
+         .u_R          = 2.0,
+         .p_R          = 0.4,
+         .gamma        = 1.4,
+         .p_star_exact = 0.00189,
+         .u_star_exact = 0.0,
+         .tolerance    = 0.1},
 
         // Test 3: Left half of blast wave
-        {"Left blast", 1.0, 0.0, 1000.0, 1.0, 0.0, 0.01, 1.4, 460.894, 19.5975, 5.0},
+        {.name         = "Left blast",
+         .rho_L        = 1.0,
+         .u_L          = 0.0,
+         .p_L          = 1000.0,
+         .rho_R        = 1.0,
+         .u_R          = 0.0,
+         .p_R          = 0.01,
+         .gamma        = 1.4,
+         .p_star_exact = 460.894,
+         .u_star_exact = 19.5975,
+         .tolerance    = 5.0},
 
         // Test 4: Right half of blast wave
-        {"Right blast", 1.0, 0.0, 0.01, 1.0, 0.0, 100.0, 1.4, 46.0950, -6.19633, 1.0},
+        {.name         = "Right blast",
+         .rho_L        = 1.0,
+         .u_L          = 0.0,
+         .p_L          = 0.01,
+         .rho_R        = 1.0,
+         .u_R          = 0.0,
+         .p_R          = 100.0,
+         .gamma        = 1.4,
+         .p_star_exact = 46.0950,
+         .u_star_exact = -6.19633,
+         .tolerance    = 1.0},
 
         // Test 5: Lax shock tube (challenging: left rarefaction + right shock)
         // The iterative solver may struggle with this case due to the non-zero left velocity
         // and the complex wave pattern. Using a more relaxed tolerance.
-        {"Lax", 0.445, 0.698, 3.528, 0.5, 0.0, 0.571, 1.4, 1.12838, 0.92840, 0.8},
+        {.name         = "Lax",
+         .rho_L        = 0.445,
+         .u_L          = 0.698,
+         .p_L          = 3.528,
+         .rho_R        = 0.5,
+         .u_R          = 0.0,
+         .p_R          = 0.571,
+         .gamma        = 1.4,
+         .p_star_exact = 1.12838,
+         .u_star_exact = 0.92840,
+         .tolerance    = 0.8},
     };
 
     //==========================================================================

--- a/src/tests/shamrock/scheduler/LoadBalanceTests.cpp
+++ b/src/tests/shamrock/scheduler/LoadBalanceTests.cpp
@@ -110,8 +110,8 @@ TestStart(TestType::ValidationTest, "shamrock/scheduler/loadbalance", testloadba
         for (u32 i = 0; i < count; i++) {
             res.push_back(
                 LBTile{
-                    shamalgs::primitives::mock_value(eng, 0_u64, u64_max),
-                    shamalgs::primitives::mock_value(eng, min_load, max_load),
+                    .ordering_val = shamalgs::primitives::mock_value(eng, 0_u64, u64_max),
+                    .load_value   = shamalgs::primitives::mock_value(eng, min_load, max_load),
                 });
         }
 


### PR DESCRIPTION
This is a fairly large change but now that we are in c++20 we can finally use designated initializers which are less bug prone.

This PR was done by applying [clang-tidy modernize check](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize/use-designated-initializers.html) using the following command

```bash
find src/ \( -name "*.cpp" -o -name "*.hpp" \) -print0 | \
xargs -0 -n1 -P"$(nproc)" \
clang-tidy \
  -p build/clang-tidy.mod \
  --checks="-*,modernize-use-designated-initializers" \
  --system-headers=false \
  -header-filter='^(?!.*nvtx3).*' \
  --config='{CheckOptions: [{key: modernize-use-designated-initializers.StrictCppStandardCompliance, value: true}]}' \
  --fix
```