### PR TITLE
[SPH] move get_ideal_hcp_box to math module

### DIFF
--- a/examples/TO_MIGRATE/benchmarks/sedov_scale_test_updated.py
+++ b/examples/TO_MIGRATE/benchmarks/sedov_scale_test_updated.py
@@ -46,7 +46,7 @@ model.set_solver_config(cfg)
 model.init_scheduler(scheduler_split_val, scheduler_merge_val)
 
 
-bmin, bmax = model.get_ideal_hcp_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/examples/TO_MIGRATE/sph/sph_sedov.py
+++ b/examples/TO_MIGRATE/sph/sph_sedov.py
@@ -35,7 +35,7 @@ model.set_solver_config(cfg)
 model.init_scheduler(int(1e5), 1)
 
 
-bmin, bmax = model.get_ideal_hcp_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/examples/TO_MIGRATE/sph/sph_soundwave.py
+++ b/examples/TO_MIGRATE/sph/sph_soundwave.py
@@ -34,7 +34,7 @@ model.set_solver_config(cfg)
 model.init_scheduler(int(1e6), 1)
 
 
-bmin, bmax = model.get_ideal_fcc_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_fcc_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/examples/TO_MIGRATE/sph/sph_soundwave.py
+++ b/examples/TO_MIGRATE/sph/sph_soundwave.py
@@ -34,7 +34,7 @@ model.set_solver_config(cfg)
 model.init_scheduler(int(1e6), 1)
 
 
-bmin, bmax = shamrock.math.get_ideal_fcc_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/examples/benchmarks/sph_homogeneous_benchmark.py
+++ b/examples/benchmarks/sph_homogeneous_benchmark.py
@@ -87,7 +87,7 @@ cfg.print_status()
 model.set_solver_config(cfg)
 model.init_scheduler(scheduler_split_val, scheduler_merge_val)
 
-bmin, bmax = model.get_ideal_hcp_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/examples/benchmarks/sph_weak_scale_test.py
+++ b/examples/benchmarks/sph_weak_scale_test.py
@@ -67,7 +67,7 @@ for N_target_base in [32e6]:
     model.set_solver_config(cfg)
     model.init_scheduler(scheduler_split_val, scheduler_merge_val)
 
-    bmin, bmax = model.get_ideal_hcp_box(dr, bmin, bmax)
+    bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
     xm, ym, zm = bmin
     xM, yM, zM = bmax
 

--- a/examples/sph/run_dustydiffuse_tvi.py
+++ b/examples/sph/run_dustydiffuse_tvi.py
@@ -156,7 +156,7 @@ scheduler_merge_val = int(1)
 model.init_scheduler(scheduler_split_val, scheduler_merge_val)
 
 
-bmin, bmax = model.get_ideal_hcp_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/examples/sph/run_dustysettle_tvi.py
+++ b/examples/sph/run_dustysettle_tvi.py
@@ -219,7 +219,7 @@ def setup_model():
 
     model.init_scheduler(int(1e8), 1)
 
-    bmin, bmax = model.get_ideal_hcp_box(dr, bmin, bmax)
+    bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
     xm, ym, zm = bmin
     xM, yM, zM = bmax
 

--- a/examples/sph/run_dustywave_tvi.py
+++ b/examples/sph/run_dustywave_tvi.py
@@ -96,7 +96,7 @@ def do_setup(model, cs, delta_v_0):
 
         pmass = -1
 
-        bmin, bmax = model.get_ideal_hcp_box(dr, bmin, bmax)
+        bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
         xm, ym, zm = bmin
         xM, yM, zM = bmax
 

--- a/examples/sph/run_init_sim_from_other.py.py
+++ b/examples/sph/run_init_sim_from_other.py.py
@@ -62,7 +62,7 @@ cfg.print_status()
 model.set_solver_config(cfg)
 model.init_scheduler(scheduler_split_val, scheduler_merge_val)
 
-bmin, bmax = model.get_ideal_hcp_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/examples/sph/run_pairing_instab.py
+++ b/examples/sph/run_pairing_instab.py
@@ -80,7 +80,7 @@ model.set_solver_config(cfg)
 model.init_scheduler(scheduler_split_val, scheduler_merge_val)
 
 
-bmin, bmax = model.get_ideal_hcp_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/examples/sph/run_sph_shear_test.py
+++ b/examples/sph/run_sph_shear_test.py
@@ -35,7 +35,7 @@ bmin = (-0.6, -0.6, -0.1)
 bmax = (0.6, 0.6, 0.1)
 pmass = -1
 
-bmin, bmax = shamrock.math.get_ideal_fcc_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/examples/sph/run_sph_shear_test.py
+++ b/examples/sph/run_sph_shear_test.py
@@ -35,7 +35,7 @@ bmin = (-0.6, -0.6, -0.1)
 bmax = (0.6, 0.6, 0.1)
 pmass = -1
 
-bmin, bmax = model.get_ideal_fcc_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_fcc_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/examples/sph/run_sphsetup_logs.py
+++ b/examples/sph/run_sphsetup_logs.py
@@ -84,7 +84,7 @@ model.set_solver_config(cfg)
 model.init_scheduler(scheduler_split_val, scheduler_merge_val)
 
 
-bmin, bmax = model.get_ideal_hcp_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/examples/sph/run_uniform_box.py
+++ b/examples/sph/run_uniform_box.py
@@ -66,7 +66,7 @@ model.set_solver_config(cfg)
 model.init_scheduler(scheduler_split_val, scheduler_merge_val)
 
 
-bmin, bmax = model.get_ideal_hcp_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/examples/sph/run_upscale_simulation_restart.py
+++ b/examples/sph/run_upscale_simulation_restart.py
@@ -62,7 +62,7 @@ cfg.print_status()
 model.set_solver_config(cfg)
 model.init_scheduler(scheduler_split_val, scheduler_merge_val)
 
-bmin, bmax = model.get_ideal_hcp_box(dr, bmin, bmax)
+bmin, bmax = shamrock.math.get_ideal_hcp_box(dr, bmin, bmax)
 xm, ym, zm = bmin
 xM, yM, zM = bmax
 

--- a/src/shammath/include/shammath/crystalLattice.hpp
+++ b/src/shammath/include/shammath/crystalLattice.hpp
@@ -389,8 +389,6 @@ namespace shammath {
 
             auto [bmin, bmax] = box;
 
-            StackEntry stack_loc{};
-
             auto [idxs_min, idxs_max] = LatticeHCP::get_box_index_bounds(dr, bmin, bmax);
 
             auto [idxs_min_per, idxs_max_per]

--- a/src/shammath/include/shammath/crystalLattice.hpp
+++ b/src/shammath/include/shammath/crystalLattice.hpp
@@ -383,6 +383,24 @@ namespace shammath {
                 shamlog_debug_ln("Discontinuous iterator", "skip final idx", current_idx);
             }
         };
+
+        inline static std::tuple<Tvec, Tvec> get_ideal_hcp_box(
+            Tscal dr, std::tuple<Tvec, Tvec> box) {
+
+            auto [bmin, bmax] = box;
+
+            StackEntry stack_loc{};
+
+            auto [idxs_min, idxs_max] = LatticeHCP::get_box_index_bounds(dr, bmin, bmax);
+
+            auto [idxs_min_per, idxs_max_per]
+                = LatticeHCP::nearest_periodic_box_indices(idxs_min, idxs_max);
+
+            shammath::CoordRange<Tvec> ret
+                = LatticeHCP::get_periodic_box(dr, idxs_min_per, idxs_max_per);
+
+            return {ret.lower, ret.upper};
+        }
     };
 
     /**

--- a/src/shammodels/sph/include/shammodels/sph/Model.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/Model.hpp
@@ -125,9 +125,6 @@ namespace shammodels::sph {
 
         f64 total_mass_to_part_mass(f64 totmass);
 
-        std::pair<Tvec, Tvec> get_ideal_fcc_box(Tscal dr, std::pair<Tvec, Tvec> box);
-        std::pair<Tvec, Tvec> get_ideal_hcp_box(Tscal dr, std::pair<Tvec, Tvec> box);
-
         Tscal get_hfact() { return Kernel::hfactd; }
 
         Tscal rho_h(Tscal h) {

--- a/src/shammodels/sph/src/Model.cpp
+++ b/src/shammodels/sph/src/Model.cpp
@@ -143,14 +143,6 @@ auto shammodels::sph::Model<Tvec, SPHKernel>::get_closest_part_to(Tvec pos) -> T
 }
 
 template<class Tvec, template<class> class SPHKernel>
-auto shammodels::sph::Model<Tvec, SPHKernel>::get_ideal_fcc_box(Tscal dr, std::pair<Tvec, Tvec> box)
-    -> std::pair<Tvec, Tvec> {
-    StackEntry stack_loc{};
-    auto [a, b] = generic::setup::generators::get_ideal_fcc_box<Tscal>(dr, box);
-    return {a, b};
-}
-
-template<class Tvec, template<class> class SPHKernel>
 void shammodels::sph::Model<Tvec, SPHKernel>::remap_positions(std::function<Tvec(Tvec)> map) {
     StackEntry stack_loc{};
 
@@ -471,24 +463,6 @@ void shammodels::sph::Model<Tvec, SPHKernel>::push_particle_mhd(
 
         post_insert_data<Tvec>(sched);
     });
-}
-
-template<class Tvec, template<class> class SPHKernel>
-auto shammodels::sph::Model<Tvec, SPHKernel>::get_ideal_hcp_box(
-    Tscal dr, std::pair<Tvec, Tvec> _box) -> std::pair<Tvec, Tvec> {
-    StackEntry stack_loc{};
-
-    using Lattice     = shammath::LatticeHCP<Tvec>;
-    using LatticeIter = typename shammath::LatticeHCP<Tvec>::Iterator;
-
-    shammath::CoordRange<Tvec> box = _box;
-    auto [idxs_min, idxs_max]      = Lattice::get_box_index_bounds(dr, box.lower, box.upper);
-
-    auto [idxs_min_per, idxs_max_per] = Lattice::nearest_periodic_box_indices(idxs_min, idxs_max);
-
-    shammath::CoordRange<Tvec> ret = Lattice::get_periodic_box(dr, idxs_min_per, idxs_max_per);
-
-    return {ret.lower, ret.upper};
 }
 
 template<class Tvec, template<class> class SPHKernel>

--- a/src/shammodels/sph/src/pySPHModel.cpp
+++ b/src/shammodels/sph/src/pySPHModel.cpp
@@ -20,7 +20,9 @@
 #include "shambase/memory.hpp"
 #include "shambindings/pybindaliases.hpp"
 #include "shambindings/pytypealias.hpp"
+#include "shamcomm/logs.hpp"
 #include "shamcomm/worldInfo.hpp"
+#include "shammath/crystalLattice.hpp"
 #include "shammath/sphkernels.hpp"
 #include "shammodels/common/shamrock_json_to_py_json.hpp"
 #include "shammodels/sph/Model.hpp"
@@ -647,12 +649,24 @@ void add_instance(py::module &m, std::string name_config, std::string name_model
         .def(
             "get_ideal_fcc_box",
             [](T &self, f64 dr, f64_3 box_min, f64_3 box_max) {
-                return self.get_ideal_fcc_box(dr, {box_min, box_max});
+                ON_RANK_0(
+                    shamcomm::logs::warn_ln(
+                        "SPH",
+                        "The python function get_ideal_fcc_box is deprecated in the SPH model and "
+                        "will be removed at some point, replace it by "
+                        "shamrock.math.get_ideal_hcp_box"));
+                return shammath::LatticeHCP<f64_3>::get_ideal_hcp_box(dr, {box_min, box_max});
             })
         .def(
             "get_ideal_hcp_box",
             [](T &self, f64 dr, f64_3 box_min, f64_3 box_max) {
-                return self.get_ideal_hcp_box(dr, {box_min, box_max});
+                ON_RANK_0(
+                    shamcomm::logs::warn_ln(
+                        "SPH",
+                        "The python function get_ideal_hcp_box is deprecated in the SPH model and "
+                        "will be removed at some point, replace it by "
+                        "shamrock.math.get_ideal_hcp_box"));
+                return shammath::LatticeHCP<f64_3>::get_ideal_hcp_box(dr, {box_min, box_max});
             })
         .def(
             "resize_simulation_box",

--- a/src/shampylib/src/math/pyshammath.cpp
+++ b/src/shampylib/src/math/pyshammath.cpp
@@ -18,6 +18,7 @@
 #include "shambackends/typeAliasVec.hpp"
 #include "shambindings/pybindaliases.hpp"
 #include "shambindings/pytypealias.hpp"
+#include "shammath/crystalLattice.hpp"
 #include "shammath/derivatives.hpp"
 #include "shammath/matrix.hpp"
 #include "shammath/matrix_op.hpp"
@@ -854,4 +855,8 @@ ON_PYTHON_INIT {
                 "SymTensorCollection_f64_1_1(\n  t1={}\n)",
                 py::str(py::cast(c.t1)).cast<std::string>());
         });
+
+    math_module.def("get_ideal_hcp_box", [](f64 dr, f64_3 box_min, f64_3 box_max) {
+        return shammath::LatticeHCP<f64_3>::get_ideal_hcp_box(dr, {box_min, box_max});
+    });
 }


### PR DESCRIPTION
This PR moves get_ideal_hpc_box from the SPH model into the math global module. 
This allows fetching the box size before starting the SPH model and thus ease the setup. 
On the user side this PR should be a NFC.