### PR TITLE
[Dumps] fix shamrock dumps with large physical domains

### DIFF
--- a/src/shamalgs/include/shamalgs/collective/io.hpp
+++ b/src/shamalgs/include/shamalgs/collective/io.hpp
@@ -16,6 +16,7 @@
  *
  */
 
+#include "shambase/narrowing.hpp"
 #include "shamalgs/collective/indexing.hpp"
 #include "shambackends/SyclMpiTypes.hpp"
 #include "shambackends/typeAliasVec.hpp"
@@ -157,7 +158,23 @@ namespace shamalgs::collective {
     inline void write_at(MPI_File fh, const void *buf, size_t len, u64 file_head_ptr) {
 
         shamcomm::mpi::File_write_at(
-            fh, file_head_ptr, buf, len, get_mpi_type<T>(), MPI_STATUS_IGNORE);
+            fh,
+            file_head_ptr,
+            buf,
+            shambase::narrow_or_throw<int>(len),
+            get_mpi_type<T>(),
+            MPI_STATUS_IGNORE);
+    }
+
+    inline void write_at_large(MPI_File fh, const u8 *buf, size_t len, u64 file_head_ptr) {
+
+        size_t max_message = 1 << 30;
+
+        for (size_t offset = 0; offset < len; offset += max_message) {
+            const u8 *buf_ptr = buf + offset;
+            size_t msg_len    = std::min(max_message, len - offset);
+            write_at<u8>(fh, buf_ptr, msg_len, file_head_ptr + offset);
+        }
     }
 
     /**
@@ -172,7 +189,22 @@ namespace shamalgs::collective {
     inline void read_at(MPI_File fh, void *buf, size_t len, u64 file_head_ptr) {
 
         shamcomm::mpi::File_read_at(
-            fh, file_head_ptr, buf, len, get_mpi_type<T>(), MPI_STATUS_IGNORE);
+            fh,
+            file_head_ptr,
+            buf,
+            shambase::narrow_or_throw<int>(len),
+            get_mpi_type<T>(),
+            MPI_STATUS_IGNORE);
+    }
+
+    inline void read_at_large(MPI_File fh, u8 *buf, size_t len, u64 file_head_ptr) {
+        size_t max_message = 1 << 30;
+
+        for (size_t offset = 0; offset < len; offset += max_message) {
+            u8 *buf_ptr    = buf + offset;
+            size_t msg_len = std::min(max_message, len - offset);
+            read_at<u8>(fh, buf_ptr, msg_len, file_head_ptr + offset);
+        }
     }
 
     /**

--- a/src/shamalgs/include/shamalgs/collective/io.hpp
+++ b/src/shamalgs/include/shamalgs/collective/io.hpp
@@ -166,6 +166,18 @@ namespace shamalgs::collective {
             MPI_STATUS_IGNORE);
     }
 
+    /**
+     * @brief Writes a large byte buffer at a given offset in a file using MPI.
+     *
+     * This function splits the transfer into chunks of at most 1 GiB and delegates
+     * each chunk to write_at<u8>. Use this instead of write_at when len may exceed
+     * the range safely representable as an MPI count (write_at narrows len to int).
+     *
+     * @param fh MPI file handle
+     * @param buf pointer to the bytes to be written
+     * @param len number of bytes to write
+     * @param file_head_ptr offset in the file where the data should be written
+     */
     inline void write_at_large(MPI_File fh, const u8 *buf, size_t len, u64 file_head_ptr) {
 
         size_t max_message = 1 << 30;
@@ -197,6 +209,18 @@ namespace shamalgs::collective {
             MPI_STATUS_IGNORE);
     }
 
+    /**
+     * @brief Reads a large byte buffer at a given offset in a file using MPI.
+     *
+     * This function splits the transfer into chunks of at most 1 GiB and delegates
+     * each chunk to read_at<u8>. Use this instead of read_at when len may exceed
+     * the range safely representable as an MPI count (read_at narrows len to int).
+     *
+     * @param fh MPI file handle
+     * @param buf pointer to the buffer that should receive the bytes
+     * @param len number of bytes to read
+     * @param file_head_ptr offset in the file where the data should be read
+     */
     inline void read_at_large(MPI_File fh, u8 *buf, size_t len, u64 file_head_ptr) {
         size_t max_message = 1 << 30;
 

--- a/src/shamalgs/include/shamalgs/serialize.hpp
+++ b/src/shamalgs/include/shamalgs/serialize.hpp
@@ -198,9 +198,11 @@ namespace shamalgs {
         SerializeHelper(std::shared_ptr<sham::DeviceScheduler> dev_sched);
 
         SerializeHelper(
-            std::shared_ptr<sham::DeviceScheduler> dev_sched, sham::DeviceBuffer<u8> &&storage);
+            std::shared_ptr<sham::DeviceScheduler> dev_sched,
+            sham::DeviceBuffer<u8> &&storage,
+            bool allow_large_int_size = false);
 
-        void allocate(SerializeSize szinfo);
+        void allocate(SerializeSize szinfo, bool allow_large_int_size = false);
 
         sham::DeviceBuffer<u8> finalize();
 

--- a/src/shamalgs/src/serialize.cpp
+++ b/src/shamalgs/src/serialize.cpp
@@ -144,11 +144,16 @@ u64 shamalgs::SerializeHelper::pre_head_length() {
         .head_size;
 }
 
-void shamalgs::SerializeHelper::allocate(SerializeSize szinfo) {
+void shamalgs::SerializeHelper::allocate(SerializeSize szinfo, bool allow_large_int_size) {
     StackEntry stack_loc{false};
     u64 bytelen = szinfo.head_size + szinfo.content_size + pre_head_length();
 
-    storage.resize(shambase::narrow_or_throw<u32>(bytelen));
+    if (allow_large_int_size) {
+        storage.resize(bytelen);
+    } else {
+        storage.resize(shambase::narrow_or_throw<u32>(bytelen));
+    }
+
     header_size = szinfo.head_size;
     storage_header.resize(header_size);
 
@@ -174,8 +179,14 @@ shamalgs::SerializeHelper::SerializeHelper(std::shared_ptr<sham::DeviceScheduler
     : dev_sched(std::move(_dev_sched)), storage(0, _dev_sched) {}
 
 shamalgs::SerializeHelper::SerializeHelper(
-    std::shared_ptr<sham::DeviceScheduler> _dev_sched, sham::DeviceBuffer<u8> &&input)
+    std::shared_ptr<sham::DeviceScheduler> _dev_sched,
+    sham::DeviceBuffer<u8> &&input,
+    bool allow_large_int_size)
     : dev_sched(std::move(_dev_sched)), storage(std::forward<sham::DeviceBuffer<u8>>(input)) {
+
+    if (!allow_large_int_size) {
+        shambase::narrow_or_throw<u32>(input.get_size());
+    }
 
     header_size = extract_preahead(dev_sched->get_queue(), storage);
 

--- a/src/shamalgs/src/serialize.cpp
+++ b/src/shamalgs/src/serialize.cpp
@@ -185,7 +185,7 @@ shamalgs::SerializeHelper::SerializeHelper(
     : dev_sched(std::move(_dev_sched)), storage(std::forward<sham::DeviceBuffer<u8>>(input)) {
 
     if (!allow_large_int_size) {
-        shambase::narrow_or_throw<u32>(input.get_size());
+        shambase::narrow_or_throw<u32>(storage.get_size());
     }
 
     header_size = extract_preahead(dev_sched->get_queue(), storage);

--- a/src/shamrock/src/io/ShamrockDump.cpp
+++ b/src/shamrock/src/io/ShamrockDump.cpp
@@ -37,7 +37,7 @@ namespace shamrock {
         sched.patch_data.for_each_patchdata([&](u64 pid, PatchDataLayer &pdat) {
             auto ser_sz = pdat.serialize_buf_byte_size();
             shamalgs::SerializeHelper ser(shamsys::instance::get_compute_scheduler_ptr());
-            ser.allocate(ser_sz);
+            ser.allocate(ser_sz, true);
             pdat.serialize_buf(ser);
 
             auto tmp         = ser.finalize();
@@ -138,7 +138,7 @@ namespace shamrock {
 
             shamcomm::CommunicationBuffer buf(data, shamsys::instance::get_compute_scheduler_ptr());
 
-            shamalgs::collective::write_at<u8>(mfile, buf.get_ptr(), bytecount, head_ptr + off);
+            shamalgs::collective::write_at_large(mfile, buf.get_ptr(), bytecount, head_ptr + off);
         }
 
         // write data to file
@@ -238,13 +238,13 @@ namespace shamrock {
             shamcomm::CommunicationBuffer buf(
                 loc_file_info.bytecount, shamsys::instance::get_compute_scheduler_ptr());
 
-            shamalgs::collective::read_at<u8>(
+            shamalgs::collective::read_at_large(
                 mfile, buf.get_ptr(), loc_file_info.bytecount, head_ptr + loc_file_info.offset);
 
             sham::DeviceBuffer<u8> out = shamcomm::CommunicationBuffer::convert_usm(std::move(buf));
 
             shamalgs::SerializeHelper ser(
-                shamsys::instance::get_compute_scheduler_ptr(), std::move(out));
+                shamsys::instance::get_compute_scheduler_ptr(), std::move(out), true);
 
             patch::PatchDataLayer pdat = patch::PatchDataLayer::deserialize_buf(ser, ctx.pdl);
 

--- a/src/tests/shamalgs/collective/ioTests.cpp
+++ b/src/tests/shamalgs/collective/ioTests.cpp
@@ -8,8 +8,81 @@
 // -------------------------------------------------------//
 
 #include "shamalgs/collective/io.hpp"
+#include "shamalgs/primitives/mock_vector.hpp"
 #include "shamcomm/io.hpp"
+#include "shamcomm/worldInfo.hpp"
 #include "shamtest/shamtest.hpp"
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+namespace {
+
+    std::vector<u8> mock_vector_tiled(u64 seed, size_t len) {
+        constexpr size_t mock_vector_tile_size = 65536;
+        static_assert(mock_vector_tile_size <= std::numeric_limits<u32>::max());
+
+        const size_t tile_len = mock_vector_tile_size;
+        std::vector<u8> tile
+            = shamalgs::primitives::mock_vector<u8>(seed, tile_len, u8{0}, u8{255});
+
+        std::vector<u8> buf(len);
+        for (size_t off = 0; off < len; off += tile_len) {
+            const size_t n = std::min<size_t>(tile_len, len - off);
+            std::memcpy(buf.data() + off, tile.data(), n);
+        }
+        return buf;
+    }
+
+    template<class WriteFn, class ReadFn>
+    void test_read_write_at_chunks(
+        const std::string &fname,
+        size_t chunk0_len,
+        size_t chunk1_len,
+        WriteFn &&write_fn,
+        ReadFn &&read_fn) {
+
+        std::vector<u8> ref0, ref1;
+        if (shamcomm::world_rank() == 0) {
+            try {
+                ref0 = mock_vector_tiled(0x1111, chunk0_len);
+                ref1 = mock_vector_tiled(0x2222, chunk1_len);
+            } catch (const std::bad_alloc &) {
+                REQUIRE(false);
+                return;
+            }
+        }
+
+        { // Write
+            MPI_File mfile{};
+
+            shamcomm::open_reset_file(mfile, fname);
+            if (shamcomm::world_rank() == 0) {
+                write_fn(mfile, ref0.data(), chunk0_len, 0);
+                write_fn(mfile, ref1.data(), chunk1_len, chunk0_len);
+            }
+
+            MPI_File_close(&mfile);
+        }
+
+        { // Read + verify
+            MPI_File mfile{};
+
+            shamcomm::open_read_only_file(mfile, fname);
+            if (shamcomm::world_rank() == 0) {
+                std::vector<u8> out0(chunk0_len), out1(chunk1_len);
+                read_fn(mfile, out0.data(), chunk0_len, 0);
+                read_fn(mfile, out1.data(), chunk1_len, chunk0_len);
+                REQUIRE_EQUAL(ref0, out0);
+                REQUIRE_EQUAL(ref1, out1);
+            }
+
+            MPI_File_close(&mfile);
+        }
+    }
+
+} // namespace
 
 #define TEST_VAL1 0x12345
 #define TEST_VAL2 0x123456
@@ -70,4 +143,30 @@ NEW_TEST(Unittest, "shamalgs/collective/io/header_read_write", -1) {
 
         MPI_File_close(&mfile);
     }
+}
+
+NEW_TEST(Unittest, "shamalgs/collective/io/read_write_at", -1) {
+    test_read_write_at_chunks(
+        "iotest_read_at",
+        12345,
+        98654,
+        [](MPI_File fh, u8 *buf, size_t len, u64 off) {
+            shamalgs::collective::write_at<u8>(fh, buf, len, off);
+        },
+        [](MPI_File fh, u8 *buf, size_t len, u64 off) {
+            shamalgs::collective::read_at<u8>(fh, buf, len, off);
+        });
+}
+
+NEW_TEST(Unittest, "shamalgs/collective/io/read_write_at_large", -1) {
+    test_read_write_at_chunks(
+        "iotest_read_at_large",
+        2'600'000'000ull,
+        600'000'000ull,
+        [](MPI_File fh, u8 *buf, size_t len, u64 off) {
+            shamalgs::collective::write_at_large(fh, buf, len, off);
+        },
+        [](MPI_File fh, u8 *buf, size_t len, u64 off) {
+            shamalgs::collective::read_at_large(fh, buf, len, off);
+        });
 }

--- a/src/tests/shamalgs/memory/serializeTests.cpp
+++ b/src/tests/shamalgs/memory/serializeTests.cpp
@@ -9,6 +9,7 @@
 
 #include "shambase/time.hpp"
 #include "shamalgs/memory.hpp"
+#include "shamalgs/primitives/mock_vector.hpp"
 #include "shamalgs/random.hpp"
 #include "shamalgs/serialize.hpp"
 #include "shambackends/math.hpp"
@@ -16,6 +17,30 @@
 #include "shamtest/PyScriptHandle.hpp"
 #include "shamtest/details/TestResult.hpp"
 #include "shamtest/shamtest.hpp"
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+namespace {
+
+    std::vector<u8> mock_vector_tiled(u64 seed, size_t len) {
+        constexpr size_t mock_vector_tile_size = 65536;
+        static_assert(mock_vector_tile_size <= std::numeric_limits<u32>::max());
+
+        const size_t tile_len = mock_vector_tile_size;
+        std::vector<u8> tile
+            = shamalgs::primitives::mock_vector<u8>(seed, tile_len, u8{0}, u8{255});
+
+        std::vector<u8> buf(len);
+        for (size_t off = 0; off < len; off += tile_len) {
+            const size_t n = std::min<size_t>(tile_len, len - off);
+            std::memcpy(buf.data() + off, tile.data(), n);
+        }
+        return buf;
+    }
+
+} // namespace
 
 template<class T>
 inline void check_buf(std::string prefix, sycl::buffer<T> &b1, sycl::buffer<T> &b2) {
@@ -99,6 +124,55 @@ NEW_TEST(Unittest, "shamalgs/memory/SerializeHelper", 1) {
         check_buf("buf 1", buf_comp1, buf1);
         check_buf("buf 2", buf_comp2, buf2);
     }
+}
+
+NEW_TEST(Unittest, "shamalgs/memory/SerializeHelper/large_buffer", 1) {
+
+    constexpr size_t buf_len = 2'600'000'000ull;
+
+    std::vector<u8> ref;
+    try {
+        ref = mock_vector_tiled(0x1111, buf_len);
+    } catch (const std::bad_alloc &) {
+        REQUIRE(false);
+        return;
+    }
+
+    auto sched = shamsys::instance::get_compute_scheduler_ptr();
+    auto &q    = shambase::get_check_ref(sched).get_queue().q;
+
+    sycl::buffer<u8> buf(ref.data(), buf_len);
+
+    shamalgs::SerializeHelper ser(sched);
+    shamalgs::SerializeSize sz = shamalgs::SerializeHelper::serialize_byte_size<u8>(buf_len);
+    ser.allocate(sz, true);
+    ser.write_buf(buf, buf_len);
+    auto recov = ser.finalize();
+    q.wait();
+
+    sham::DeviceBuffer<u8> buf_out(buf_len, sched);
+    shamalgs::SerializeHelper ser2(sched, std::move(recov), true);
+    ser2.load_buf(buf_out, buf_len);
+    q.wait();
+
+    std::vector<u8> got = buf_out.copy_to_stdvec();
+    REQUIRE_EQUAL(ref, got);
+}
+
+NEW_TEST(Unittest, "shamalgs/memory/SerializeHelper/large_buffer_narrowing", 1) {
+
+    // Total serialized byte length must exceed u32_max for narrow_or_throw<u32> to fail.
+    constexpr size_t buf_len = 4'300'000'000ull;
+
+    auto sched                 = shamsys::instance::get_compute_scheduler_ptr();
+    shamalgs::SerializeSize sz = shamalgs::SerializeHelper::serialize_byte_size<u8>(buf_len);
+
+    shamalgs::SerializeHelper ser(sched);
+    REQUIRE_EXCEPTION_THROW(ser.allocate(sz), std::runtime_error);
+
+    sham::DeviceBuffer<u8> storage(buf_len, sched);
+    REQUIRE_EXCEPTION_THROW(
+        shamalgs::SerializeHelper(sched, std::move(storage), false), std::runtime_error);
 }
 
 NEW_TEST(Benchmark, "shamalgs/memory/SerializeHelper:benchmark", 1) {

--- a/src/tests/shamalgs/memory/serializeTests.cpp
+++ b/src/tests/shamalgs/memory/serializeTests.cpp
@@ -128,7 +128,8 @@ NEW_TEST(Unittest, "shamalgs/memory/SerializeHelper", 1) {
 
 NEW_TEST(Unittest, "shamalgs/memory/SerializeHelper/large_buffer", 1) {
 
-    constexpr size_t buf_len = 2'600'000'000ull;
+    // TODO: find a way to do 4GB but Github CI is too small
+    constexpr size_t buf_len = 600'000'000ull;
 
     std::vector<u8> ref;
     try {


### PR DESCRIPTION
Make Shamrock dumps work with patch larger than 2GB by slicing MPI messages into 1GB chunks. Tested for now on my dusty disc simulations but I need to write a proper test in CI before merge.