### PR TITLE
[Solvergraph] ditch ScalarEdge<T> in favor of IDataEdge<T>

### DIFF
--- a/src/shamrock/include/shamrock/solvergraph/ScalarEdge.hpp
+++ b/src/shamrock/include/shamrock/solvergraph/ScalarEdge.hpp
@@ -16,18 +16,11 @@
  *
  */
 
-#include "shamrock/solvergraph/IEdgeNamed.hpp"
+#include "shamrock/solvergraph/IDataEdge.hpp"
 
 namespace shamrock::solvergraph {
 
     template<class T>
-    class ScalarEdge : public IEdgeNamed {
-        public:
-        using IEdgeNamed::IEdgeNamed;
-
-        T value = {};
-
-        inline void free_alloc() {};
-    };
+    using ScalarEdge = IDataEdge<T>;
 
 } // namespace shamrock::solvergraph


### PR DESCRIPTION
I don't even know why ScalarEdge was created in the first place it is just a duplicate of IDataEdge without a reason.
However this create quite a lot of change in the codebase so i will hold this PR until we unsure that the conflicts are limited.