### PR TITLE
[GSPH] Add Inutsuka (2002) effective volume/face force formulation

### DIFF
--- a/src/shammodels/gsph/include/shammodels/gsph/SolverConfig.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/SolverConfig.hpp
@@ -35,6 +35,7 @@
 #include "shammath/sphkernels.hpp"
 #include "shammodels/common/EOSConfig.hpp"
 #include "shammodels/common/ExtForceConfig.hpp"
+#include "shammodels/gsph/config/ForceFormulationConfig.hpp"
 #include "shammodels/gsph/config/ReconstructConfig.hpp"
 #include "shammodels/gsph/config/RiemannConfig.hpp"
 #include "shammodels/sph/config/BCConfig.hpp" // Reuse boundary conditions from SPH
@@ -153,6 +154,23 @@ struct shammodels::gsph::SolverConfig {
 
     //////////////////////////////////////////////////////////////////////////////////////////////
     // Reconstruction Config (END)
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // Force Formulation Config
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    using ForceFormulationConfig = ForceFormulationConfig<Tvec>;
+    ForceFormulationConfig force_formulation_config;
+
+    inline void set_force_cha_whitworth() { force_formulation_config.set_cha_whitworth(); }
+
+    inline void set_force_inutsuka_v2() { force_formulation_config.set_inutsuka_v2(); }
+
+    inline bool is_force_inutsuka_v2() const { return force_formulation_config.is_inutsuka_v2(); }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // Force Formulation Config (END)
     //////////////////////////////////////////////////////////////////////////////////////////////
 
     //////////////////////////////////////////////////////////////////////////////////////////////
@@ -277,6 +295,7 @@ struct shammodels::gsph::SolverConfig {
         logger::raw_ln("gpart_mass  =", gpart_mass);
         riemann_config.print_status();
         reconstruct_config.print_status();
+        force_formulation_config.print_status();
         eos_config.print_status();
         logger::raw_ln("--------------------------------------");
     }
@@ -336,6 +355,7 @@ namespace shammodels::gsph {
             {"unit_sys", p.unit_sys},
             {"riemann_config", p.riemann_config},
             {"reconstruct_config", p.reconstruct_config},
+            {"force_formulation_config", p.force_formulation_config},
             {"eos_config", p.eos_config},
             {"boundary_config", p.boundary_config},
             {"tree_reduction_level", p.tree_reduction_level},
@@ -380,6 +400,7 @@ namespace shammodels::gsph {
         _get_to_if_contains("unit_sys", p.unit_sys);
         _get_to_if_contains("riemann_config", p.riemann_config);
         _get_to_if_contains("reconstruct_config", p.reconstruct_config);
+        _get_to_if_contains("force_formulation_config", p.force_formulation_config);
         _get_to_if_contains("eos_config", p.eos_config);
         _get_to_if_contains("boundary_config", p.boundary_config);
         _get_to_if_contains("tree_reduction_level", p.tree_reduction_level);

--- a/src/shammodels/gsph/include/shammodels/gsph/config/ForceFormulationConfig.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/config/ForceFormulationConfig.hpp
@@ -1,0 +1,131 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2026 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file ForceFormulationConfig.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Configuration for the GSPH momentum equation formulation
+ *
+ * GSPH implementations in the literature discretize the momentum equation in more
+ * than one way. This selects between:
+ * - ChaWhitworth: the symmetric SPH form (nabla_W/rho^2/Omega) with p* substituted
+ *   for pressure, following Cha & Whitworth (2003). This is shamrock's default.
+ * - InutsukaV2: the effective volume/face form (V2_ij * grad_W_ij) following
+ *   Inutsuka (2002), reconstructed here with linear (1st order) face interpolation.
+ */
+
+#include "shambackends/type_traits.hpp"
+#include "shambackends/vec.hpp"
+#include "shamsys/legacy/log.hpp"
+#include <nlohmann/json.hpp>
+#include <variant>
+
+namespace shammodels::gsph {
+
+    template<class Tvec>
+    struct ForceFormulationConfig;
+
+} // namespace shammodels::gsph
+
+template<class Tvec>
+struct shammodels::gsph::ForceFormulationConfig {
+
+    using Tscal              = shambase::VecComponent<Tvec>;
+    static constexpr u32 dim = shambase::VectorProperties<Tvec>::dimension;
+
+    /**
+     * @brief Cha & Whitworth (2003) symmetric SPH momentum equation (default)
+     */
+    struct ChaWhitworth {};
+
+    /**
+     * @brief Inutsuka (2002) effective volume/face momentum equation
+     *
+     * Uses linear (1st order) interpolation of the volume element to build the
+     * effective face between each particle pair (see math/reconstruction.hpp).
+     */
+    struct InutsukaV2 {};
+
+    using Variant = std::variant<ChaWhitworth, InutsukaV2>;
+
+    Variant config = ChaWhitworth{};
+
+    void set(Variant v) { config = v; }
+
+    void set_cha_whitworth() { set(ChaWhitworth{}); }
+
+    void set_inutsuka_v2() { set(InutsukaV2{}); }
+
+    inline bool is_cha_whitworth() const { return std::holds_alternative<ChaWhitworth>(config); }
+
+    inline bool is_inutsuka_v2() const { return std::holds_alternative<InutsukaV2>(config); }
+
+    inline void print_status() const {
+        logger::raw_ln("--- Force formulation config");
+
+        if (std::get_if<ChaWhitworth>(&config)) {
+            logger::raw_ln("  Type : ChaWhitworth (2003) - symmetric SPH form");
+        } else if (std::get_if<InutsukaV2>(&config)) {
+            logger::raw_ln(
+                "  Type : InutsukaV2 (2002) - effective volume/face, linear (1st order)");
+        } else {
+            shambase::throw_unimplemented();
+        }
+
+        logger::raw_ln("-------------");
+    }
+};
+
+namespace shammodels::gsph {
+
+    template<class Tvec>
+    inline void to_json(nlohmann::json &j, const ForceFormulationConfig<Tvec> &p) {
+        using T            = ForceFormulationConfig<Tvec>;
+        using ChaWhitworth = typename T::ChaWhitworth;
+        using InutsukaV2   = typename T::InutsukaV2;
+
+        if (std::get_if<ChaWhitworth>(&p.config)) {
+            j = {
+                {"force_formulation", "cha_whitworth"},
+            };
+        } else if (std::get_if<InutsukaV2>(&p.config)) {
+            j = {
+                {"force_formulation", "inutsuka_v2"},
+            };
+        } else {
+            shambase::throw_unimplemented();
+        }
+    }
+
+    template<class Tvec>
+    inline void from_json(const nlohmann::json &j, ForceFormulationConfig<Tvec> &p) {
+        using T            = ForceFormulationConfig<Tvec>;
+        using ChaWhitworth = typename T::ChaWhitworth;
+        using InutsukaV2   = typename T::InutsukaV2;
+
+        if (!j.contains("force_formulation")) {
+            shambase::throw_with_loc<std::runtime_error>(
+                "no field force_formulation is found in this json");
+        }
+
+        std::string force_formulation;
+        j.at("force_formulation").get_to(force_formulation);
+
+        if (force_formulation == "cha_whitworth") {
+            p.set(ChaWhitworth{});
+        } else if (force_formulation == "inutsuka_v2") {
+            p.set(InutsukaV2{});
+        } else {
+            shambase::throw_unimplemented("Unknown force formulation type: " + force_formulation);
+        }
+    }
+
+} // namespace shammodels::gsph

--- a/src/shammodels/gsph/include/shammodels/gsph/math/forces.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/math/forces.hpp
@@ -161,4 +161,42 @@ namespace shammodels::gsph {
     // Note: For velocity projection onto pair axis, use sycl::dot(v, r_ab_unit) directly.
     // For density from smoothing length, use shamrock::sph::rho_h() from density.hpp.
 
+    /**
+     * @brief Add Inutsuka (2002) GSPH force contribution from a single neighbor pair
+     *
+     * Uses the effective volume/face formulation instead of the Cha & Whitworth
+     * symmetric SPH form: acc -= m_b * p* * V2_ij * grad_W_ij, where V2_ij is the
+     * effective squared volume element between the pair (see math/reconstruction.hpp)
+     * and grad_W_ij is the pair-symmetrized kernel gradient.
+     *
+     * @tparam Tvec Vector type
+     * @tparam Tscal Scalar type
+     * @param m_b Mass of neighbor particle
+     * @param p_star Interface pressure from Riemann solver
+     * @param v_star Interface velocity from Riemann solver
+     * @param V2_ij Effective squared volume element for the pair
+     * @param grad_W_ij Pair-symmetrized kernel gradient vector
+     * @param r_ab_unit Unit vector from a to b (points toward b)
+     * @param v_a Velocity of particle a
+     * @param[out] dv_dt Accumulated acceleration
+     * @param[out] du_dt Accumulated energy rate
+     */
+    template<class Tvec, class Tscal>
+    inline void add_gsph_force_contribution_inutsuka(
+        Tscal m_b,
+        Tscal p_star,
+        Tscal v_star,
+        Tscal V2_ij,
+        Tvec grad_W_ij,
+        Tvec r_ab_unit,
+        Tvec v_a,
+        Tvec &dv_dt,
+        Tscal &du_dt) {
+
+        dv_dt -= m_b * p_star * V2_ij * grad_W_ij;
+
+        Tvec v_star_vec = v_star * r_ab_unit;
+        du_dt -= m_b * p_star * V2_ij * sycl::dot(grad_W_ij, v_star_vec - v_a);
+    }
+
 } // namespace shammodels::gsph

--- a/src/shammodels/gsph/include/shammodels/gsph/math/reconstruction.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/math/reconstruction.hpp
@@ -1,0 +1,72 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2026 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file reconstruction.hpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Effective face (volume element) interpolation for the Inutsuka (2002) GSPH formulation
+ *
+ * Inutsuka's GSPH momentum equation replaces the standard SPH kernel-gradient/rho^2
+ * weighting by an effective face between each particle pair, described by an
+ * effective squared volume element V2_ij and an effective face location s*.
+ * These quantities are obtained by interpolating each particle's specific volume
+ * (1/rho for equal-mass particles) along the line joining the pair.
+ *
+ * This file implements the linear (1st order) interpolation, which only needs the
+ * volume at each particle (no gradients).
+ *
+ * Reference:
+ * - Inutsuka, S. (2002) "Reformulation of Smoothed Particle Hydrodynamics with
+ *   Riemann Solver"
+ */
+
+namespace shammodels::gsph {
+
+    /**
+     * @brief Result of the effective face interpolation
+     *
+     * @tparam Tscal Scalar type
+     */
+    template<class Tscal>
+    struct EffectiveFace {
+        Tscal V2;    ///< Effective squared volume element for the pair
+        Tscal s_ast; ///< Effective face location (signed distance from particle a)
+    };
+
+    /**
+     * @brief Linear (1st order) interpolation of the effective face between a pair
+     *
+     * Reconstructs the volume function V(s) linearly between the two particles using
+     * only their volume elements (no gradients needed), following Inutsuka (2002).
+     *
+     * @tparam Tscal Scalar type
+     * @param vol_a Specific volume of particle a (1/rho_a for equal-mass particles)
+     * @param vol_b Specific volume of particle b (1/rho_b for equal-mass particles)
+     * @param h_a Smoothing length of particle a
+     * @param h_b Smoothing length of particle b
+     * @param rab_inv Inverse of the pair separation (1/|r_a - r_b|)
+     * @return EffectiveFace with V2 and s_ast
+     */
+    template<class Tscal>
+    inline EffectiveFace<Tscal> lin_v2_sast_ij(
+        Tscal vol_a, Tscal vol_b, Tscal h_a, Tscal h_b, Tscal rab_inv) {
+
+        const Tscal C  = (vol_a - vol_b) * rab_inv;
+        const Tscal D  = Tscal{0.5} * (vol_a + vol_b);
+        const Tscal h2 = Tscal{0.5} * (h_a * h_a + h_b * h_b);
+
+        const Tscal V2    = Tscal{0.25} * h2 * C * C + D * D;
+        const Tscal s_ast = Tscal{0.5} * h2 * C * D / V2;
+
+        return EffectiveFace<Tscal>{V2, s_ast};
+    }
+
+} // namespace shammodels::gsph

--- a/src/shammodels/gsph/src/modules/UpdateDerivs.cpp
+++ b/src/shammodels/gsph/src/modules/UpdateDerivs.cpp
@@ -31,6 +31,7 @@
 #include "shammath/sphkernels.hpp"
 #include "shammodels/gsph/config/FieldNames.hpp"
 #include "shammodels/gsph/math/forces.hpp"
+#include "shammodels/gsph/math/reconstruction.hpp"
 #include "shammodels/gsph/math/riemann/iterative.hpp"
 #include "shammodels/sph/math/density.hpp"
 #include "shamsys/legacy/log.hpp"
@@ -139,16 +140,18 @@ void shammodels::gsph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_ite
         }
 
         auto e = q.submit(depends_list, [&](sycl::handler &cgh) {
-            const Tscal pmass    = solver_config.gpart_mass;
-            const Tscal gamma    = solver_config.get_eos_gamma();
-            const Tscal tol      = cfg.tol;
-            const u32 max_iter   = cfg.max_iter;
-            const bool do_energy = has_uint;
+            const Tscal pmass          = solver_config.gpart_mass;
+            const Tscal gamma          = solver_config.get_eos_gamma();
+            const Tscal tol            = cfg.tol;
+            const u32 max_iter         = cfg.max_iter;
+            const bool do_energy       = has_uint;
+            const bool use_inutsuka_v2 = solver_config.is_force_inutsuka_v2();
 
             // Use shamrock's ObjectCacheIterator for neighbor traversal
             tree::ObjectCacheIterator particle_looper(ploop_ptrs);
 
             constexpr Tscal Rker2 = Kernel::Rkern * Kernel::Rkern;
+            constexpr Tscal sqrt2 = Tscal{1.4142135623730951};
 
             shambase::parallel_for(cgh, pdat.get_obj_cnt(), "GSPH derivs iterative", [=](u64 gid) {
                 u32 id_a = (u32) gid;
@@ -221,25 +224,50 @@ void shammodels::gsph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_ite
                     const Tscal p_star = riemann_result.p_star;
                     const Tscal v_star = riemann_result.v_star;
 
-                    // Kernel gradients
-                    const Tscal Fab_a = Kernel::dW_3d(rab, h_a);
-                    const Tscal Fab_b = Kernel::dW_3d(rab, h_b);
+                    if (use_inutsuka_v2) {
+                        // Effective volume/face interpolation (Inutsuka 2002), linear
+                        // (1st order): specific volume is 1/rho for equal-mass particles.
+                        const Tscal vol_a = Tscal{1} / rho_a;
+                        const Tscal vol_b = Tscal{1} / rho_b;
 
-                    // GSPH force contribution
-                    shammodels::gsph::add_gsph_force_contribution<Tvec, Tscal>(
-                        pmass,
-                        p_star,
-                        v_star,
-                        rho_a,
-                        rho_b,
-                        omega_a,
-                        omega_b,
-                        Fab_a,
-                        Fab_b,
-                        r_ab_unit,
-                        vxyz_a,
-                        sum_axyz,
-                        sum_du_a);
+                        auto face = lin_v2_sast_ij<Tscal>(vol_a, vol_b, h_a, h_b, rab_inv);
+
+                        // Pair-symmetrized kernel gradient at sqrt(2)*h (Inutsuka 2002)
+                        const Tscal Fab2_a   = Kernel::dW_3d(rab, sqrt2 * h_a);
+                        const Tscal Fab2_b   = Kernel::dW_3d(rab, sqrt2 * h_b);
+                        const Tvec grad_W_ij = (Fab2_a + Fab2_b) * r_ab_unit;
+
+                        shammodels::gsph::add_gsph_force_contribution_inutsuka<Tvec, Tscal>(
+                            pmass,
+                            p_star,
+                            v_star,
+                            face.V2,
+                            grad_W_ij,
+                            r_ab_unit,
+                            vxyz_a,
+                            sum_axyz,
+                            sum_du_a);
+                    } else {
+                        // Kernel gradients
+                        const Tscal Fab_a = Kernel::dW_3d(rab, h_a);
+                        const Tscal Fab_b = Kernel::dW_3d(rab, h_b);
+
+                        // GSPH force contribution
+                        shammodels::gsph::add_gsph_force_contribution<Tvec, Tscal>(
+                            pmass,
+                            p_star,
+                            v_star,
+                            rho_a,
+                            rho_b,
+                            omega_a,
+                            omega_b,
+                            Fab_a,
+                            Fab_b,
+                            r_ab_unit,
+                            vxyz_a,
+                            sum_axyz,
+                            sum_du_a);
+                    }
                 });
 
                 // Write accumulated derivatives

--- a/src/shammodels/gsph/src/pyGSPHModel.cpp
+++ b/src/shammodels/gsph/src/pyGSPHModel.cpp
@@ -100,6 +100,30 @@ void add_gsph_instance(py::module &m, std::string name_config, std::string name_
     Sets all gradients to zero. Most diffusive but most stable.
     Good for very strong shocks or initial testing.
 )==")
+        // Force formulation config
+        .def(
+            "set_force_cha_whitworth",
+            [](TConfig &self) {
+                self.set_force_cha_whitworth();
+            },
+            R"==(
+    Set the Cha & Whitworth (2003) symmetric SPH force formulation (default).
+
+    Uses the standard SPH momentum equation (nabla_W/rho^2/Omega) with the
+    Riemann-solved interface pressure p* substituted for pressure.
+)==")
+        .def(
+            "set_force_inutsuka_v2",
+            [](TConfig &self) {
+                self.set_force_inutsuka_v2();
+            },
+            R"==(
+    Set the Inutsuka (2002) effective volume/face force formulation.
+
+    Uses linear (1st order) interpolation of the volume element between each
+    particle pair to build an effective face (V2_ij, s*), following the
+    original GSPH momentum equation: acc -= m * p* * V2_ij * grad_W_ij.
+)==")
         // EOS config
         .def(
             "set_eos_adiabatic",

--- a/src/tests/shammodels/gsph/GSPHReconstructionTests.cpp
+++ b/src/tests/shammodels/gsph/GSPHReconstructionTests.cpp
@@ -1,0 +1,123 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2026 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+/**
+ * @file GSPHReconstructionTests.cpp
+ * @author Guo Yansong (guo.yansong.ngy@gmail.com)
+ * @brief Unit tests for the Inutsuka (2002) effective face interpolation (V2_ij, s*)
+ *
+ * Tests cover:
+ * - Symmetric pair (equal volume/h) gives V2 = D^2 and s* = 0
+ * - General case matches the closed-form V2/s* expressions directly
+ * - The Inutsuka force contribution satisfies Newton's 3rd law
+ */
+
+#include "shammodels/gsph/math/forces.hpp"
+#include "shammodels/gsph/math/reconstruction.hpp"
+#include "shamtest/shamtest.hpp"
+
+namespace {
+
+    using namespace shammodels::gsph;
+
+    //==========================================================================
+    // SCENARIO: symmetric pair (equal volume and smoothing length)
+    //==========================================================================
+
+    void test_lin_v2_sast_symmetric_pair() {
+        using Tscal = f64;
+
+        const Tscal vol     = 1.5;
+        const Tscal h       = 0.2;
+        const Tscal rab_inv = 1.0 / 0.1;
+
+        auto face = lin_v2_sast_ij<Tscal>(vol, vol, h, h, rab_inv);
+
+        // C = 0 when vol_a == vol_b, so V2 reduces to D^2 and s* = 0
+        REQUIRE_FLOAT_EQUAL_NAMED("V2 == D^2 for symmetric pair", face.V2, vol * vol, 1e-12);
+        REQUIRE_FLOAT_EQUAL_NAMED("s* == 0 for symmetric pair", face.s_ast, 0.0, 1e-12);
+    }
+
+    //==========================================================================
+    // SCENARIO: general pair matches the closed-form expression
+    //==========================================================================
+
+    void test_lin_v2_sast_general_pair() {
+        using Tscal = f64;
+
+        const Tscal vol_a   = 1.2;
+        const Tscal vol_b   = 0.8;
+        const Tscal h_a     = 0.3;
+        const Tscal h_b     = 0.25;
+        const Tscal rab     = 0.4;
+        const Tscal rab_inv = 1.0 / rab;
+
+        auto face = lin_v2_sast_ij<Tscal>(vol_a, vol_b, h_a, h_b, rab_inv);
+
+        const Tscal C_expect    = (vol_a - vol_b) / rab;
+        const Tscal D_expect    = 0.5 * (vol_a + vol_b);
+        const Tscal h2_expect   = 0.5 * (h_a * h_a + h_b * h_b);
+        const Tscal V2_expect   = 0.25 * h2_expect * C_expect * C_expect + D_expect * D_expect;
+        const Tscal sast_expect = 0.5 * h2_expect * C_expect * D_expect / V2_expect;
+
+        REQUIRE_FLOAT_EQUAL_NAMED("V2 matches closed form", face.V2, V2_expect, 1e-12);
+        REQUIRE_FLOAT_EQUAL_NAMED("s* matches closed form", face.s_ast, sast_expect, 1e-12);
+    }
+
+    //==========================================================================
+    // SCENARIO: Inutsuka force contribution satisfies Newton's 3rd law
+    //==========================================================================
+
+    void test_inutsuka_force_newtons_third_law() {
+        using Tvec  = f64_3;
+        using Tscal = f64;
+
+        const Tscal m      = 1.0;
+        const Tscal p_star = 1.3;
+        const Tscal v_star = 0.2;
+        const Tscal V2_ij  = 0.7;
+        const Tvec v_a     = Tvec{0, 0, 0};
+
+        // Force on a from b (b is at +x from a)
+        Tvec grad_W_ab = Tvec{-1.5, 0, 0};
+        Tvec r_ab_unit = Tvec{1, 0, 0};
+        Tvec dv_a      = Tvec{0, 0, 0};
+        Tscal du_a     = 0;
+
+        add_gsph_force_contribution_inutsuka<Tvec, Tscal>(
+            m, p_star, v_star, V2_ij, grad_W_ab, r_ab_unit, v_a, dv_a, du_a);
+
+        // Force on b from a: pair axis reverses, so grad_W and r_ab_unit flip sign
+        Tvec grad_W_ba = -grad_W_ab;
+        Tvec r_ba_unit = -r_ab_unit;
+        Tvec dv_b      = Tvec{0, 0, 0};
+        Tscal du_b     = 0;
+
+        add_gsph_force_contribution_inutsuka<Tvec, Tscal>(
+            m, p_star, v_star, V2_ij, grad_W_ba, r_ba_unit, v_a, dv_b, du_b);
+
+        Tvec total = dv_a + dv_b;
+        REQUIRE_FLOAT_EQUAL_NAMED("x momentum conserved", total[0], 0.0, 1e-12);
+        REQUIRE_FLOAT_EQUAL_NAMED("y momentum conserved", total[1], 0.0, 1e-12);
+        REQUIRE_FLOAT_EQUAL_NAMED("z momentum conserved", total[2], 0.0, 1e-12);
+    }
+
+} // namespace
+
+NEW_TEST(Unittest, "shammodels/gsph/reconstruction/lin_v2_sast_symmetric", 1) {
+    test_lin_v2_sast_symmetric_pair();
+}
+
+NEW_TEST(Unittest, "shammodels/gsph/reconstruction/lin_v2_sast_general", 1) {
+    test_lin_v2_sast_general_pair();
+}
+
+NEW_TEST(Unittest, "shammodels/gsph/reconstruction/inutsuka_force_newton3", 1) {
+    test_inutsuka_force_newtons_third_law();
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in `InutsukaV2` GSPH force formulation alongside the existing `ChaWhitworth` (2003) default, reconstructing the effective face between each particle pair via **linear (1st order) interpolation** of the volume element (`V2_ij`, `s*`), following Inutsuka (2002).
- Ported from a reference FDPS-based GSPH implementation (`kitajima-code/GSPH/IMBH_Cloud_3D`), which exposes this as `INTERPOLATION_ACCURACY=1` (linear) vs `3` (cubic — not ported here).
- New: `math/reconstruction.hpp` (`lin_v2_sast_ij`), `config/ForceFormulationConfig.hpp` (`ChaWhitworth` | `InutsukaV2`).
- Edited: `math/forces.hpp` (`add_gsph_force_contribution_inutsuka`), `modules/UpdateDerivs.cpp` (wired into `update_derivs_iterative()` only), `pyGSPHModel.cpp` (`set_force_cha_whitworth`/`set_force_inutsuka_v2`).
- Default behavior is unchanged (`ChaWhitworth` remains the default); this is purely additive and opt-in.

**Scope / follow-up left for later PRs:**
- The HLLC Riemann path (`update_derivs_hllc`) is not wired to this formulation yet.
- The effective face location `s*` is computed but not yet consumed by a MUSCL-style state reconstruction correction (mirrors `GODUNOV_ACCURACY==2` in the reference implementation) — `ReconstructConfig`'s MUSCL gradients are a separate, pre-existing gap unrelated to this PR.

## Test plan

- [x] `make shammodels_gsph` builds clean
- [x] `make shamrock_test` builds clean (added `GSPHReconstructionTests.cpp`)
- [x] New unit tests pass: `lin_v2_sast_symmetric`, `lin_v2_sast_general` (closed-form `V2`/`s*` checks), `inutsuka_force_newton3` (Newton's 3rd law for the new force contribution)
- [x] Existing GSPH force/riemann tests still pass (sampled `force/newtons_third`, `force/symmetry`, `force/complete_interaction`, `force/different_kernels`, `riemann/iterative_standard`) — no regression to the default `ChaWhitworth` path
- [ ] No shock-tube (e.g. Sod/Brio-Wu style) validation of the `InutsukaV2` path yet — recommended before relying on it for production runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)