### PR TITLE
[Tests] avoid including sycl.hpp in tests

### DIFF
--- a/src/shamtest/details/TestAssertList.hpp
+++ b/src/shamtest/details/TestAssertList.hpp
@@ -16,9 +16,9 @@
  */
 
 #include "shambase/SourceLocation.hpp"
+#include "shambase/aliases_float.hpp"
 #include "shambase/string.hpp"
 #include "TestAssert.hpp"
-#include "shambackends/sycl.hpp"
 #include <utility>
 
 namespace shamtest::details {
@@ -117,7 +117,7 @@ namespace shamtest::details {
         [[deprecated("Please use the supplied testing macros instead")]]
         inline void assert_float_equal(
             std::string assert_name, f64 a, f64 b, f64 eps, SourceLocation loc = SourceLocation{}) {
-            f64 diff = sycl::fabs(a - b);
+            f64 diff = std::fabs(a - b);
 
             bool t              = diff < eps;
             std::string comment = "";

--- a/src/shamtest/shamtest.hpp
+++ b/src/shamtest/shamtest.hpp
@@ -17,6 +17,7 @@
 
 #include "shambase/unique_name_macro.hpp"
 #include "details/Test.hpp"
+#include <optional>
 
 /**
  * @brief namespace containing stuff related to the test library

--- a/src/tests/shambase/ConstantsTests.cpp
+++ b/src/tests/shambase/ConstantsTests.cpp
@@ -8,6 +8,7 @@
 // -------------------------------------------------------//
 
 #include "shambase/constants.hpp"
+#include "shambackends/sycl.hpp"
 #include "shamtest/shamtest.hpp"
 
 NEW_TEST(Unittest, "shambase/constants", 1) {

--- a/src/tests/shambase/WithUUID_tests.cpp
+++ b/src/tests/shambase/WithUUID_tests.cpp
@@ -16,6 +16,7 @@
 #include "shambase/WithUUID.hpp"
 #include "shamtest/shamtest.hpp"
 #include <unordered_set>
+#include <mutex>
 #include <thread>
 
 template<bool thread_safe>

--- a/src/tests/shamformat/format_tests.cpp
+++ b/src/tests/shamformat/format_tests.cpp
@@ -11,6 +11,7 @@
 #include "sham/format/human_readable.hpp"
 #include "shamtest/shamtest.hpp"
 #include <string_view>
+#include <iostream>
 
 namespace {
     void throwing_format_std() {

--- a/src/tests/shammodels/gsph/GSPHIntegrationTests.cpp
+++ b/src/tests/shammodels/gsph/GSPHIntegrationTests.cpp
@@ -20,6 +20,7 @@
  * - Edge cases (zero acceleration, constant force)
  */
 
+#include "shambackends/sycl.hpp"
 #include "shamtest/shamtest.hpp"
 #include <cmath>
 #include <vector>

--- a/src/tests/shamsys/LogTests.cpp
+++ b/src/tests/shamsys/LogTests.cpp
@@ -10,6 +10,7 @@
 #include "shambackends/typeAliasVec.hpp"
 #include "shamsys/Log.hpp"
 #include "shamtest/shamtest.hpp"
+#include <iostream>
 
 NEW_TEST(Unittest, "shamsys/Log", 1) {
 


### PR DESCRIPTION
Shave off around 30 sec of build wall time on my Mac
393s of sycl.hpp header cost -> 361s