### PR TITLE
[CI] upload doxygen warning count as a JSON metric artifact

### DIFF
--- a/.github/workflows/make_documentation.yml
+++ b/.github/workflows/make_documentation.yml
@@ -90,3 +90,16 @@ jobs:
         with:
           name: doxygen_warning
           path: doc/_build/doxygen/warn_doxygen.txt
+
+      - name: Write doxygen warning count metric
+        shell: bash
+        run: |
+          warn_count=$(wc -l < doc/_build/doxygen/warn_doxygen.txt | tr -d '[:space:]')
+          printf '{"doxygen_warning_count":%s}\n' "${warn_count}" > metric__doxygen_warn.json
+          cat metric__doxygen_warn.json
+
+      - name: Upload doxygen warning count metric
+        uses: actions/upload-artifact@v4
+        with:
+          name: metric__doxygen_warn.json
+          path: metric__doxygen_warn.json


### PR DESCRIPTION
Count lines in warn_doxygen.txt after documentation generation and upload {"doxygen_warning_count":N} as artifact metric__doxygen_warn.json.