### PR TITLE
[CI] count lines of code and upload a JSON metric artifact

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Count lines of code
         shell: bash
         run: |
-          python3 buildbot/count_loc.py metric__loc.json
+          python3 tools/count_loc.py metric__loc.json
           cat metric__loc.json
 
       - name: Upload lines of code metric

--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -70,6 +70,30 @@ jobs:
           name: report_email
           path: ./report_______email.md
 
+  count_loc:
+    name: Lines of code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Reconfigure git
+        run: |
+          git config --global --add safe.directory '*'
+          git config --global --list
+
+      - uses: actions/checkout@v4
+
+      - name: Count lines of code
+        shell: bash
+        run: |
+          python3 buildbot/count_loc.py metric__loc.json
+          cat metric__loc.json
+
+      - name: Upload lines of code metric
+        uses: actions/upload-artifact@v4
+        with:
+          name: metric__loc.json
+          path: metric__loc.json
+
   src_check:
     name: Linting
     #needs: [detect_changes]

--- a/buildbot/count_loc.py
+++ b/buildbot/count_loc.py
@@ -1,0 +1,88 @@
+# Count lines of tracked source files, excluding git submodules.
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def submodule_prefixes():
+    try:
+        out = subprocess.check_output(
+            [
+                "git",
+                "config",
+                "--file",
+                ".gitmodules",
+                "--get-regexp",
+                r"^submodule\..*\.path$",
+            ],
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return []
+    return [line.split(maxsplit=1)[1].strip() for line in out.splitlines() if line.strip()]
+
+
+def in_submodule(path, prefixes):
+    s = str(path)
+    return any(s == prefix or s.startswith(prefix + "/") for prefix in prefixes)
+
+
+def list_files(patterns, prefixes):
+    out = subprocess.check_output(["git", "ls-files", "-z", "--"] + patterns)
+    files = []
+    seen = set()
+    for raw in out.split(b"\0"):
+        if not raw:
+            continue
+        path = Path(raw.decode())
+        if path in seen or in_submodule(path, prefixes) or not path.is_file():
+            continue
+        seen.add(path)
+        files.append(path)
+    return files
+
+
+def count_lines(files):
+    total = 0
+    for path in files:
+        with path.open("rb") as handle:
+            total += sum(1 for _ in handle)
+    return total
+
+
+def count_loc():
+    prefixes = submodule_prefixes()
+    categories = {
+        "*.cpp": ["*.cpp"],
+        "*.hpp": ["*.hpp"],
+        "*.py": ["*.py"],
+        "CMakeLists.txt + *.cmake": [
+            "CMakeLists.txt",
+            "**/CMakeLists.txt",
+            "*.cmake",
+        ],
+    }
+
+    result = {}
+    for name, patterns in categories.items():
+        result[name] = count_lines(list_files(patterns, prefixes))
+    result["total"] = sum(result.values())
+    return result
+
+
+def main():
+    os.chdir(subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip())
+
+    result = count_loc()
+    text = json.dumps(result, indent=3) + "\n"
+
+    if len(sys.argv) > 1:
+        Path(sys.argv[1]).write_text(text)
+    sys.stdout.write(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/buildbot/count_loc.py
+++ b/buildbot/count_loc.py
@@ -6,6 +6,19 @@ import subprocess
 import sys
 from pathlib import Path
 
+KINDS = ("code", "examples", "doc")
+
+CATEGORIES = {
+    "*.cpp": ["*.cpp"],
+    "*.hpp": ["*.hpp"],
+    "*.py": ["*.py"],
+    "CMakeLists.txt + *.cmake": [
+        "CMakeLists.txt",
+        "**/CMakeLists.txt",
+        "*.cmake",
+    ],
+}
+
 
 def submodule_prefixes():
     try:
@@ -30,6 +43,18 @@ def in_submodule(path, prefixes):
     return any(s == prefix or s.startswith(prefix + "/") for prefix in prefixes)
 
 
+def file_kind(path):
+    parts = path.parts
+    if parts and parts[0] == "examples":
+        return "examples"
+    # doc/sphinx/examples is a symlink to examples/; count it as examples if listed.
+    if len(parts) >= 3 and parts[0] == "doc" and parts[1] == "sphinx" and parts[2] == "examples":
+        return "examples"
+    if parts and parts[0] == "doc":
+        return "doc"
+    return "code"
+
+
 def list_files(patterns, prefixes):
     out = subprocess.check_output(["git", "ls-files", "-z", "--"] + patterns)
     files = []
@@ -45,31 +70,26 @@ def list_files(patterns, prefixes):
     return files
 
 
-def count_lines(files):
-    total = 0
-    for path in files:
-        with path.open("rb") as handle:
-            total += sum(1 for _ in handle)
-    return total
+def empty_kind_counts():
+    return {kind: 0 for kind in KINDS}
 
 
 def count_loc():
     prefixes = submodule_prefixes()
-    categories = {
-        "*.cpp": ["*.cpp"],
-        "*.hpp": ["*.hpp"],
-        "*.py": ["*.py"],
-        "CMakeLists.txt + *.cmake": [
-            "CMakeLists.txt",
-            "**/CMakeLists.txt",
-            "*.cmake",
-        ],
-    }
-
     result = {}
-    for name, patterns in categories.items():
-        result[name] = count_lines(list_files(patterns, prefixes))
-    result["total"] = sum(result.values())
+    grand = empty_kind_counts()
+
+    for name, patterns in CATEGORIES.items():
+        counts = empty_kind_counts()
+        for path in list_files(patterns, prefixes):
+            kind = file_kind(path)
+            with path.open("rb") as handle:
+                n = sum(1 for _ in handle)
+            counts[kind] += n
+            grand[kind] += n
+        result[name] = counts
+
+    result["total"] = {**grand, "all": sum(grand.values())}
     return result
 
 

--- a/tools/count_loc.py
+++ b/tools/count_loc.py
@@ -6,12 +6,27 @@ import subprocess
 import sys
 from pathlib import Path
 
-KINDS = ("code", "examples", "doc")
+# Kind -> repository path prefixes it covers (relative to the repo root).
+# First matching kind wins, so more specific prefixes must come first.
+# "code" has no prefixes: it is the fallback for unmatched files
+# (src/, cmake/, tools/, env/, buildbot/, ...).
+KINDS = {
+    "code": [],
+    "examples": [
+        "examples",
+        "doc/sphinx/examples",
+    ],
+    "doc": [
+        "doc",
+    ],
+}
 
 CATEGORIES = {
     "*.cpp": ["*.cpp"],
     "*.hpp": ["*.hpp"],
     "*.py": ["*.py"],
+    "*.md": ["*.md"],
+    "*.rst": ["*.rst"],
     "CMakeLists.txt + *.cmake": [
         "CMakeLists.txt",
         "**/CMakeLists.txt",
@@ -44,14 +59,11 @@ def in_submodule(path, prefixes):
 
 
 def file_kind(path):
-    parts = path.parts
-    if parts and parts[0] == "examples":
-        return "examples"
-    # doc/sphinx/examples is a symlink to examples/; count it as examples if listed.
-    if len(parts) >= 3 and parts[0] == "doc" and parts[1] == "sphinx" and parts[2] == "examples":
-        return "examples"
-    if parts and parts[0] == "doc":
-        return "doc"
+    s = path.as_posix()
+    for kind, prefixes in KINDS.items():
+        for prefix in prefixes:
+            if s == prefix or s.startswith(prefix + "/"):
+                return kind
     return "code"
 
 

--- a/tools/count_loc.py
+++ b/tools/count_loc.py
@@ -12,6 +12,18 @@ from pathlib import Path
 # (src/, cmake/, tools/, env/, buildbot/, ...).
 KINDS = {
     "code": [],
+    "shammodels/sph": [
+        "src/shammodels/sph",
+    ],
+    "shammodels/ramses": [
+        "src/shammodels/ramses",
+    ],
+    "shammodels/zeus": [
+        "src/shammodels/zeus",
+    ],
+    "shammodels/gsph": [
+        "src/shammodels/gsph",
+    ],
     "examples": [
         "examples",
         "doc/sphinx/examples",

--- a/tools/count_loc.py
+++ b/tools/count_loc.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 # Kind -> repository path prefixes it covers (relative to the repo root).
-# First matching kind wins, so more specific prefixes must come first.
+# First matching partition kind wins, so more specific prefixes must come first.
 # "code" has no prefixes: it is the fallback for unmatched files
 # (src/, cmake/, tools/, env/, buildbot/, ...).
 KINDS = {
@@ -31,6 +31,15 @@ KINDS = {
     "doc": [
         "doc",
     ],
+}
+
+# Detail kinds are also counted in their parent. They are extra breakdowns,
+# not exclusive buckets. total.all sums partition kinds only.
+KIND_PARENT = {
+    "shammodels/sph": "code",
+    "shammodels/ramses": "code",
+    "shammodels/zeus": "code",
+    "shammodels/gsph": "code",
 }
 
 CATEGORIES = {
@@ -70,13 +79,22 @@ def in_submodule(path, prefixes):
     return any(s == prefix or s.startswith(prefix + "/") for prefix in prefixes)
 
 
-def file_kind(path):
+def matches_prefix(path_str, prefix):
+    return path_str == prefix or path_str.startswith(prefix + "/")
+
+
+def classify(path):
     s = path.as_posix()
+    primary = None
+    details = []
     for kind, prefixes in KINDS.items():
-        for prefix in prefixes:
-            if s == prefix or s.startswith(prefix + "/"):
-                return kind
-    return "code"
+        if not any(matches_prefix(s, prefix) for prefix in prefixes):
+            continue
+        if kind in KIND_PARENT:
+            details.append(kind)
+        elif primary is None:
+            primary = kind
+    return primary or "code", details
 
 
 def list_files(patterns, prefixes):
@@ -106,14 +124,18 @@ def count_loc():
     for name, patterns in CATEGORIES.items():
         counts = empty_kind_counts()
         for path in list_files(patterns, prefixes):
-            kind = file_kind(path)
+            kind, details = classify(path)
             with path.open("rb") as handle:
                 n = sum(1 for _ in handle)
             counts[kind] += n
             grand[kind] += n
+            for detail in details:
+                counts[detail] += n
+                grand[detail] += n
         result[name] = counts
 
-    result["total"] = {**grand, "all": sum(grand.values())}
+    partition_total = sum(grand[kind] for kind in KINDS if kind not in KIND_PARENT)
+    result["total"] = {**grand, "all": partition_total}
     return result
 
 


### PR DESCRIPTION
Add a job that counts tracked *.cpp, *.hpp, *.py, and CMake files (excluding git submodules) and uploads metric__loc.json.

Assisted-by: Cursor