### PR TITLE
[Ci] ensure that all checks report failure if not success

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -63,7 +63,7 @@ jobs:
         fi
 
   # Mergify merge-queue entry gate (queue_conditions: check-success = all_light).
-  # Runs regardless of the light-ci label so every PR can enter the queue.
+  # Runs regardless of the light-ci label.
   # Same gate logic as all; see comment above for needs.main_workflow.result states.
   all_light:
     needs: [ main_workflow ]

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -45,11 +45,9 @@ jobs:
     steps:
     - name: Status summary
       run: |
-        if [ "${{ needs.main_workflow.result }}" == "failure" ] || [ "${{ needs.main_workflow.result }}" == "canceled" ]; then
-          echo "Tests failed."
+        if [ "${{ needs.main_workflow.result }}" != "success" ]; then
+          echo "CI did not succeed (result: ${{ needs.main_workflow.result }})."
           exit 1
-        else
-          exit 0
         fi
 
   # this job notify the end of the build regardless of light-ci value
@@ -61,9 +59,7 @@ jobs:
     steps:
     - name: Status summary
       run: |
-        if [ "${{ needs.main_workflow.result }}" == "failure" ] || [ "${{ needs.main_workflow.result }}" == "canceled" ]; then
-          echo "Tests failed."
+        if [ "${{ needs.main_workflow.result }}" != "success" ]; then
+          echo "CI did not succeed (result: ${{ needs.main_workflow.result }})."
           exit 1
-        else
-          exit 0
         fi

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -37,6 +37,17 @@ jobs:
           name: report_light_ci
           path: ./report_______light_ci.md
 
+  # Gate job used by Mergify (check-success = all).
+  #
+  # needs.main_workflow.result can be:
+  #   - success   : reusable workflow completed without failure
+  #   - failure   : at least one job in the called workflow failed
+  #   - cancelled : workflow or caller job was cancelled (e.g. concurrency)
+  #   - skipped   : caller job was skipped by its if: condition
+  #   - abandoned : undocumented by GitHub, but observed in practice when a
+  #                 workflow re-run is triggered while the current attempt is
+  #                 still finishing (e.g. Mergify CI auto-retry). Treat as
+  #                 non-success — do not whitelist only failure/cancelled.
   all:
     needs: [ main_workflow ]
     # run always except for cancel
@@ -50,7 +61,7 @@ jobs:
           exit 1
         fi
 
-  # this job notify the end of the build regardless of light-ci value
+  # Same gate logic as all; see comment above for needs.main_workflow.result states.
   all_light:
     needs: [ main_workflow ]
     # run always except for cancel

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -37,7 +37,8 @@ jobs:
           name: report_light_ci
           path: ./report_______light_ci.md
 
-  # Gate job used by Mergify (check-success = all).
+  # Mergify merge gate (merge_conditions: check-success = all). Skipped when the
+  # light-ci label is set — those PRs use all_light for queue entry instead.
   #
   # needs.main_workflow.result can be:
   #   - success   : reusable workflow completed without failure
@@ -61,6 +62,8 @@ jobs:
           exit 1
         fi
 
+  # Mergify merge-queue entry gate (queue_conditions: check-success = all_light).
+  # Runs regardless of the light-ci label so every PR can enter the queue.
   # Same gate logic as all; see comment above for needs.main_workflow.result states.
   all_light:
     needs: [ main_workflow ]


### PR DESCRIPTION
Treat abandoned and other non-success reusable-workflow results as failures in the on PR all and all_light gate jobs. This prevents a green all check when CI failed but Mergify auto-retry left main_workflow in an abandoned state.

Assisted-by: Cursor