### PR TITLE
[CI] Drop texlive-full from documentation jobs

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -197,14 +197,6 @@ jobs:
           sudo apt update && \
           sudo apt install -y -qq doxygen graphviz
 
-      - name : Modify texlive packages
-        run: |
-          sudo apt install -y \
-            texlive-full \
-            dvipng \
-            ghostscript \
-            latexmk
-
       - name : Run doxygen
         run: |
           cd doc/doxygen

--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -197,6 +197,14 @@ jobs:
           sudo apt update && \
           sudo apt install -y -qq doxygen graphviz
 
+      - name : Install bibtex for doxygen citations
+        run: |
+          sudo apt install -y \
+            texlive-latex-base \
+            texlive-latex-recommended \
+            texlive-latex-extra \
+            texlive-fonts-recommended
+
       - name : Run doxygen
         run: |
           cd doc/doxygen

--- a/.github/workflows/make_documentation.yml
+++ b/.github/workflows/make_documentation.yml
@@ -48,13 +48,15 @@ jobs:
           sudo apt update && \
           sudo apt install -y -qq doxygen graphviz
 
-      - name : Modify texlive packages
+      - name : Install slim texlive packages
         run: |
           sudo apt install -y \
-            texlive-full \
+            texlive-latex-base \
+            texlive-latex-recommended \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
             dvipng \
-            ghostscript \
-            latexmk
+            ghostscript
 
       - name: create venv
         shell: bash

--- a/.github/workflows/make_documentation.yml
+++ b/.github/workflows/make_documentation.yml
@@ -55,6 +55,7 @@ jobs:
             texlive-latex-recommended \
             texlive-latex-extra \
             texlive-fonts-recommended \
+            cm-super \
             dvipng \
             ghostscript
 


### PR DESCRIPTION
The Doxygen Main job only generates HTML warnings (MathJax, no LaTeX output), so TeX is unused there. The documentation build only needs a slim TeX subset for matplotlib usetex, matching the other CI jobs.