### PR TITLE
[Docs] Add interactive Plotly chart of build time history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__
 
 #compile/build/test folders
 build_*
+# Sphinx Plotly page; would otherwise match build_*
+!doc/sphinx/source/_static/build_time_total.html
 build
 
 test_pipeline

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@ __pycache__
 
 #compile/build/test folders
 build_*
-# Sphinx Plotly page; would otherwise match build_*
-!doc/sphinx/source/_static/build_time_total.html
 build
 
 test_pipeline

--- a/doc/sphinx/source/_static/build_time_total.html
+++ b/doc/sphinx/source/_static/build_time_total.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Build time</title>
+    <script src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.3/plotly.min.js"></script>
+    <style>
+      :root {
+        --bg: #fff;
+        --fg: #3c3836;
+        --muted: #665c54;
+        --grid: #d5c4a1;
+      }
+
+      html[data-theme="dark"] {
+        --bg: #282828;
+        --fg: #ebdbb2;
+        --muted: #a89984;
+        --grid: #504945;
+      }
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: system-ui, sans-serif;
+      }
+
+      #chart {
+        width: 100%;
+        height: 100%;
+      }
+
+      #status {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+        text-align: center;
+        color: var(--muted);
+      }
+
+      #status[hidden] {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="status">Loading build time history…</div>
+    <div id="chart"></div>
+    <script>
+      const DATA_URLS = [
+        "https://raw.githubusercontent.com/Shamrock-code/Shamrock/refs/heads/metrics-history/output/build_time_total.json",
+        "https://cdn.jsdelivr.net/gh/Shamrock-code/Shamrock@metrics-history/output/build_time_total.json",
+      ];
+      const SECONDS_PER_HOUR = 3600;
+
+      function parentTheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            const theme = window.parent.document.documentElement.getAttribute("data-theme");
+            if (theme === "dark" || theme === "light") {
+              return theme;
+            }
+          }
+        } catch (err) {
+          /* Cross-origin parent: fall back to prefers-color-scheme. */
+        }
+        return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+      }
+
+      function applyTheme(theme) {
+        document.documentElement.setAttribute("data-theme", theme);
+      }
+
+      function seriesColors(theme) {
+        const dark = theme === "dark";
+        return {
+          parsing: dark ? "#83a598" : "#076678",
+          codegen: dark ? "#fe8019" : "#af3a03",
+          total: dark ? "#b8bb26" : "#79740e",
+        };
+      }
+
+      function chartLayout(theme) {
+        const dark = theme === "dark";
+        const bg = dark ? "#282828" : "#fff";
+        const fg = dark ? "#ebdbb2" : "#3c3836";
+        const muted = dark ? "#a89984" : "#665c54";
+        const grid = dark ? "#504945" : "#d5c4a1";
+        return {
+          title: { text: "Build time (ClangBuildAnalyzer)", font: { color: fg, size: 18 } },
+          margin: { l: 64, r: 24, t: 48, b: 56 },
+          paper_bgcolor: bg,
+          plot_bgcolor: bg,
+          font: { color: fg },
+          legend: {
+            x: 1,
+            xanchor: "right",
+            y: 1,
+            yanchor: "top",
+            font: { color: fg },
+            bgcolor: "rgba(0,0,0,0)",
+            borderwidth: 0,
+          },
+          xaxis: {
+            title: { text: "Date (UTC)" },
+            type: "date",
+            gridcolor: grid,
+            zerolinecolor: grid,
+            linecolor: muted,
+            tickfont: { color: muted },
+          },
+          yaxis: {
+            title: { text: "Time (hours)" },
+            gridcolor: grid,
+            zerolinecolor: grid,
+            linecolor: muted,
+            tickfont: { color: muted },
+            rangemode: "tozero",
+          },
+          hovermode: "x unified",
+        };
+      }
+
+      function finiteNumber(value) {
+        const number = Number(value);
+        return Number.isFinite(number) ? number : null;
+      }
+
+      function toSeries(payload) {
+        if (!payload || !Array.isArray(payload.data)) {
+          throw new Error("Unexpected dataset shape: missing data[]");
+        }
+        const rows = payload.data
+          .filter((row) => {
+            if (!row || typeof row.datetime !== "string") {
+              return false;
+            }
+            return (
+              finiteNumber(row.parsing_time_s) !== null &&
+              finiteNumber(row.codegen_time_s) !== null &&
+              finiteNumber(row.total_time_s) !== null
+            );
+          })
+          .slice()
+          .sort((a, b) => a.datetime.localeCompare(b.datetime));
+        return {
+          x: rows.map((row) => row.datetime),
+          parsing_h: rows.map((row) => Number(row.parsing_time_s) / SECONDS_PER_HOUR),
+          codegen_h: rows.map((row) => Number(row.codegen_time_s) / SECONDS_PER_HOUR),
+          total_h: rows.map((row) => Number(row.total_time_s) / SECONDS_PER_HOUR),
+          parsing_s: rows.map((row) => Number(row.parsing_time_s)),
+          codegen_s: rows.map((row) => Number(row.codegen_time_s)),
+          total_s: rows.map((row) => Number(row.total_time_s)),
+          translation_unit_count: rows.map((row) => finiteNumber(row.translation_unit_count)),
+        };
+      }
+
+      function traces(theme, series) {
+        const colors = seriesColors(theme);
+        const tu = series.translation_unit_count;
+        const hover = (includeTu) => {
+          const tuPart = includeTu
+            ? "<br>translation units: %{customdata[1]}<extra></extra>"
+            : "<extra></extra>";
+          return "%{fullData.name}: %{y:.2f} h (%{customdata[0]:.1f} s)" + tuPart;
+        };
+        return [
+          {
+            type: "scatter",
+            mode: "lines+markers",
+            name: "parsing (frontend)",
+            x: series.x,
+            y: series.parsing_h,
+            customdata: series.parsing_s.map((seconds, i) => [seconds, tu[i]]),
+            line: { color: colors.parsing, width: 2 },
+            marker: { color: colors.parsing, size: 8 },
+            hovertemplate: hover(false),
+          },
+          {
+            type: "scatter",
+            mode: "lines+markers",
+            name: "codegen & opts (backend)",
+            x: series.x,
+            y: series.codegen_h,
+            customdata: series.codegen_s.map((seconds, i) => [seconds, tu[i]]),
+            line: { color: colors.codegen, width: 2 },
+            marker: { color: colors.codegen, size: 8 },
+            hovertemplate: hover(false),
+          },
+          {
+            type: "scatter",
+            mode: "lines+markers",
+            name: "total",
+            x: series.x,
+            y: series.total_h,
+            customdata: series.total_s.map((seconds, i) => [seconds, tu[i]]),
+            line: { color: colors.total, width: 2 },
+            marker: { color: colors.total, size: 8 },
+            hovertemplate: hover(true),
+          },
+        ];
+      }
+
+      async function fetchDataset() {
+        const errors = [];
+        for (const url of DATA_URLS) {
+          try {
+            const response = await fetch(url, { cache: "no-store" });
+            if (!response.ok) {
+              throw new Error(`${response.status} ${response.statusText}`);
+            }
+            return await response.json();
+          } catch (err) {
+            errors.push(`${url}: ${err.message}`);
+          }
+        }
+        throw new Error(errors.join("; "));
+      }
+
+      function setStatus(message) {
+        const status = document.getElementById("status");
+        if (message) {
+          status.textContent = message;
+          status.hidden = false;
+        } else {
+          status.hidden = true;
+        }
+      }
+
+      async function main() {
+        const chart = document.getElementById("chart");
+        let theme = parentTheme();
+        applyTheme(theme);
+
+        let payload;
+        try {
+          payload = await fetchDataset();
+        } catch (err) {
+          setStatus(`Could not load build time history.\n${err.message}`);
+          return;
+        }
+
+        const series = toSeries(payload);
+        if (series.x.length === 0) {
+          setStatus("The build time dataset is empty.");
+          return;
+        }
+
+        await Plotly.newPlot(chart, traces(theme, series), chartLayout(theme), {
+          responsive: true,
+          displaylogo: false,
+        });
+        setStatus("");
+
+        const restyle = () => {
+          theme = parentTheme();
+          applyTheme(theme);
+          Plotly.react(chart, traces(theme, series), chartLayout(theme));
+        };
+
+        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", restyle);
+
+        try {
+          if (window.parent && window.parent !== window) {
+            const observer = new MutationObserver(restyle);
+            observer.observe(window.parent.document.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-theme"],
+            });
+          }
+        } catch (err) {
+          /* Ignore if the parent document is not readable. */
+        }
+      }
+
+      main();
+    </script>
+  </body>
+</html>

--- a/doc/sphinx/source/_static/build_time_total.html
+++ b/doc/sphinx/source/_static/build_time_total.html
@@ -87,26 +87,32 @@
           parsing: dark ? "#83a598" : "#076678",
           codegen: dark ? "#fe8019" : "#af3a03",
           total: dark ? "#b8bb26" : "#79740e",
+          tus: dark ? "#d3869b" : "#8f3f71",
         };
       }
 
-      function chartLayout(theme) {
+      function hasTranslationUnits(series) {
+        return series.translation_unit_count.some((value) => value !== null);
+      }
+
+      function chartLayout(theme, series) {
         const dark = theme === "dark";
         const bg = dark ? "#282828" : "#fff";
         const fg = dark ? "#ebdbb2" : "#3c3836";
         const muted = dark ? "#a89984" : "#665c54";
         const grid = dark ? "#504945" : "#d5c4a1";
-        return {
+        const showTu = hasTranslationUnits(series);
+        const tuColor = seriesColors(theme).tus;
+        const layout = {
           title: { text: "Build time (ClangBuildAnalyzer)", font: { color: fg, size: 18 } },
-          margin: { l: 64, r: 24, t: 48, b: 56 },
+          margin: { l: 64, r: showTu ? 72 : 24, t: 48, b: 80 },
           paper_bgcolor: bg,
           plot_bgcolor: bg,
           font: { color: fg },
           legend: {
-            x: 1,
-            xanchor: "right",
-            y: 1,
-            yanchor: "top",
+            orientation: "h",
+            x: 0,
+            y: -0.18,
             font: { color: fg },
             bgcolor: "rgba(0,0,0,0)",
             borderwidth: 0,
@@ -129,6 +135,20 @@
           },
           hovermode: "x unified",
         };
+        if (showTu) {
+          layout.yaxis2 = {
+            title: { text: "Translation units", font: { color: tuColor } },
+            overlaying: "y",
+            side: "right",
+            rangemode: "tozero",
+            showgrid: false,
+            zerolinecolor: grid,
+            linecolor: tuColor,
+            tickfont: { color: tuColor },
+            tickformat: "d",
+          };
+        }
+        return layout;
       }
 
       function finiteNumber(value) {
@@ -167,24 +187,18 @@
 
       function traces(theme, series) {
         const colors = seriesColors(theme);
-        const tu = series.translation_unit_count;
-        const hover = (includeTu) => {
-          const tuPart = includeTu
-            ? "<br>translation units: %{customdata[1]}<extra></extra>"
-            : "<extra></extra>";
-          return "%{fullData.name}: %{y:.2f} h (%{customdata[0]:.1f} s)" + tuPart;
-        };
-        return [
+        const timeHover = "%{fullData.name}: %{y:.2f} h (%{customdata:.1f} s)<extra></extra>";
+        const result = [
           {
             type: "scatter",
             mode: "lines+markers",
             name: "parsing (frontend)",
             x: series.x,
             y: series.parsing_h,
-            customdata: series.parsing_s.map((seconds, i) => [seconds, tu[i]]),
+            customdata: series.parsing_s,
             line: { color: colors.parsing, width: 2 },
             marker: { color: colors.parsing, size: 8 },
-            hovertemplate: hover(false),
+            hovertemplate: timeHover,
           },
           {
             type: "scatter",
@@ -192,10 +206,10 @@
             name: "codegen & opts (backend)",
             x: series.x,
             y: series.codegen_h,
-            customdata: series.codegen_s.map((seconds, i) => [seconds, tu[i]]),
+            customdata: series.codegen_s,
             line: { color: colors.codegen, width: 2 },
             marker: { color: colors.codegen, size: 8 },
-            hovertemplate: hover(false),
+            hovertemplate: timeHover,
           },
           {
             type: "scatter",
@@ -203,12 +217,26 @@
             name: "total",
             x: series.x,
             y: series.total_h,
-            customdata: series.total_s.map((seconds, i) => [seconds, tu[i]]),
+            customdata: series.total_s,
             line: { color: colors.total, width: 2 },
             marker: { color: colors.total, size: 8 },
-            hovertemplate: hover(true),
+            hovertemplate: timeHover,
           },
         ];
+        if (hasTranslationUnits(series)) {
+          result.push({
+            type: "scatter",
+            mode: "lines+markers",
+            name: "translation units",
+            x: series.x,
+            y: series.translation_unit_count,
+            yaxis: "y2",
+            line: { color: colors.tus, width: 2, dash: "dot" },
+            marker: { color: colors.tus, size: 8 },
+            hovertemplate: "%{fullData.name}: %{y}<extra></extra>",
+          });
+        }
+        return result;
       }
 
       async function fetchDataset() {
@@ -256,7 +284,7 @@
           return;
         }
 
-        await Plotly.newPlot(chart, traces(theme, series), chartLayout(theme), {
+        await Plotly.newPlot(chart, traces(theme, series), chartLayout(theme, series), {
           responsive: true,
           displaylogo: false,
         });
@@ -265,7 +293,7 @@
         const restyle = () => {
           theme = parentTheme();
           applyTheme(theme);
-          Plotly.react(chart, traces(theme, series), chartLayout(theme));
+          Plotly.react(chart, traces(theme, series), chartLayout(theme, series));
         };
 
         window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", restyle);

--- a/doc/sphinx/source/_static/build_time_total.html
+++ b/doc/sphinx/source/_static/build_time_total.html
@@ -95,6 +95,31 @@
         return series.translation_unit_count.some((value) => value !== null);
       }
 
+      function paddedRange(values, integer) {
+        const nums = values.filter((value) => typeof value === "number" && Number.isFinite(value));
+        if (nums.length === 0) {
+          return undefined;
+        }
+        const min = Math.min(...nums);
+        const max = Math.max(...nums);
+        const span = max - min;
+        const pad = span === 0 ? Math.max(Math.abs(min) * 0.05, integer ? 1 : 0.05) : span * 0.1;
+        let lo = min - pad;
+        let hi = max + pad;
+        if (integer) {
+          lo = Math.floor(lo);
+          hi = Math.ceil(hi);
+          if (lo === hi) {
+            lo -= 1;
+            hi += 1;
+          }
+        }
+        if (min >= 0) {
+          lo = Math.max(0, lo);
+        }
+        return [lo, hi];
+      }
+
       function chartLayout(theme, series) {
         const dark = theme === "dark";
         const bg = dark ? "#282828" : "#fff";
@@ -131,7 +156,10 @@
             zerolinecolor: grid,
             linecolor: muted,
             tickfont: { color: muted },
-            rangemode: "tozero",
+            autorange: false,
+            range: paddedRange(
+              [].concat(series.parsing_h, series.codegen_h, series.total_h)
+            ),
           },
           hovermode: "x unified",
         };
@@ -140,12 +168,13 @@
             title: { text: "Translation units", font: { color: tuColor } },
             overlaying: "y",
             side: "right",
-            rangemode: "tozero",
             showgrid: false,
             zerolinecolor: grid,
             linecolor: tuColor,
             tickfont: { color: tuColor },
             tickformat: "d",
+            autorange: false,
+            range: paddedRange(series.translation_unit_count, true),
           };
         }
         return layout;

--- a/doc/sphinx/source/_static/doxygen_warnings.html
+++ b/doc/sphinx/source/_static/doxygen_warnings.html
@@ -82,7 +82,32 @@
         document.documentElement.setAttribute("data-theme", theme);
       }
 
-      function chartLayout(theme) {
+      function paddedRange(values, integer) {
+        const nums = values.filter((value) => typeof value === "number" && Number.isFinite(value));
+        if (nums.length === 0) {
+          return undefined;
+        }
+        const min = Math.min(...nums);
+        const max = Math.max(...nums);
+        const span = max - min;
+        const pad = span === 0 ? Math.max(Math.abs(min) * 0.05, integer ? 1 : 0.05) : span * 0.1;
+        let lo = min - pad;
+        let hi = max + pad;
+        if (integer) {
+          lo = Math.floor(lo);
+          hi = Math.ceil(hi);
+          if (lo === hi) {
+            lo -= 1;
+            hi += 1;
+          }
+        }
+        if (min >= 0) {
+          lo = Math.max(0, lo);
+        }
+        return [lo, hi];
+      }
+
+      function chartLayout(theme, series) {
         const dark = theme === "dark";
         const bg = dark ? "#282828" : "#fff";
         const fg = dark ? "#ebdbb2" : "#3c3836";
@@ -108,7 +133,9 @@
             zerolinecolor: grid,
             linecolor: muted,
             tickfont: { color: muted },
-            rangemode: "tozero",
+            tickformat: "d",
+            autorange: false,
+            range: paddedRange(series.y, true),
           },
           hovermode: "x unified",
         };
@@ -194,7 +221,7 @@
                 "%{x|%Y-%m-%d %H:%M UTC}<br>warnings: %{y}<extra></extra>",
             },
           ],
-          chartLayout(theme),
+          chartLayout(theme, series),
           { responsive: true, displaylogo: false }
         );
         setStatus("");
@@ -218,7 +245,7 @@
                   "%{x|%Y-%m-%d %H:%M UTC}<br>warnings: %{y}<extra></extra>",
               },
             ],
-            chartLayout(theme)
+            chartLayout(theme, series)
           );
         };
 

--- a/doc/sphinx/source/dev_doc/history-graphs.md
+++ b/doc/sphinx/source/dev_doc/history-graphs.md
@@ -39,14 +39,15 @@ published Sphinx docs, so it can embed this chart with:
 
 CI records ClangBuildAnalyzer compile times: the sum of frontend parsing and
 backend codegen across translation units. That is cumulative compiler work, not
-wall-clock time. See [Profiling build performance / time](build-profiling.md).
+wall-clock time. The right axis shows how many translation units were profiled.
+See [Profiling build performance / time](build-profiling.md).
 
 ```{raw} html
 <iframe
   src="../_static/build_time_total.html"
-  title="Build time over time"
+  title="Build time and translation units over time"
   width="100%"
-  height="600"
+  height="640"
   style="border: none;"
 ></iframe>
 ```
@@ -59,9 +60,9 @@ The org website can embed this chart with:
 ```html
 <iframe
   src="https://shamrock-code.github.io/Shamrock/sphinx/_static/build_time_total.html"
-  title="Build time over time"
+  title="Build time and translation units over time"
   width="100%"
-  height="600"
+  height="640"
   style="border: none;"
 ></iframe>
 ```

--- a/doc/sphinx/source/dev_doc/history-graphs.md
+++ b/doc/sphinx/source/dev_doc/history-graphs.md
@@ -34,3 +34,34 @@ published Sphinx docs, so it can embed this chart with:
   style="border: none;"
 ></iframe>
 ```
+
+## Build time
+
+CI records ClangBuildAnalyzer compile times: the sum of frontend parsing and
+backend codegen across translation units. That is cumulative compiler work, not
+wall-clock time. See [Profiling build performance / time](build-profiling.md).
+
+```{raw} html
+<iframe
+  src="../_static/build_time_total.html"
+  title="Build time over time"
+  width="100%"
+  height="600"
+  style="border: none;"
+></iframe>
+```
+
+Raw JSON:
+[build_time_total.json](https://raw.githubusercontent.com/Shamrock-code/Shamrock/refs/heads/metrics-history/output/build_time_total.json).
+
+The org website can embed this chart with:
+
+```html
+<iframe
+  src="https://shamrock-code.github.io/Shamrock/sphinx/_static/build_time_total.html"
+  title="Build time over time"
+  width="100%"
+  height="600"
+  style="border: none;"
+></iframe>
+```


### PR DESCRIPTION
Serve a self-contained Plotly page from Sphinx _static that fetches the live build_time_total.json series, and embed it from the history-graphs Dev Doc page.

Assisted-by: Cursor Agent