### PR TITLE
[CI] pin build profile job to ninja -j nproc

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -113,7 +113,7 @@ jobs:
   shamrock_linux_acpp_build_profile:
     name: Tests
     needs: [src_check]
-    # TEMP: run build profile in light CI for testing; restore `if: ${{ !inputs.light_ci }}` afterward
+    if: ${{ !inputs.light_ci }}
     uses: ./.github/workflows/shamrock-acpp-clang-build-profile.yml
 
   shamrock_linux_acpp_conda:

--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -113,7 +113,7 @@ jobs:
   shamrock_linux_acpp_build_profile:
     name: Tests
     needs: [src_check]
-    if: ${{ !inputs.light_ci }}
+    # TEMP: run build profile in light CI for testing; restore `if: ${{ !inputs.light_ci }}` afterward
     uses: ./.github/workflows/shamrock-acpp-clang-build-profile.yml
 
   shamrock_linux_acpp_conda:

--- a/.github/workflows/shamrock-acpp-clang-build-profile.yml
+++ b/.github/workflows/shamrock-acpp-clang-build-profile.yml
@@ -90,7 +90,7 @@ jobs:
           mkdir -p memlog
           export MEMLOG_DIR="$PWD/memlog"
           ClangBuildAnalyzer --start .
-          shammake
+          ninja -j "$(nproc)"
           ClangBuildAnalyzer --stop . capture_build.bin
 
       - name: Write ClangBuildAnalyzer.ini


### PR DESCRIPTION
Replace shammake with explicit ninja -j $(nproc) in the build profile workflow so ClangBuildAnalyzer timing reflects exactly the available CPU count instead of ninja's default oversubscription. It should reduce timing inconsitencies.