### PR TITLE
[CI] Generate Plotly top-10 compile peak RSS dataset

### DIFF
--- a/doc/sphinx/source/_static/compile_memory_top10.html
+++ b/doc/sphinx/source/_static/compile_memory_top10.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Top 10 compile peak RSS</title>
+    <script src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.3/plotly.min.js"></script>
+    <style>
+      :root {
+        --bg: #fff;
+        --fg: #3c3836;
+        --muted: #665c54;
+        --grid: #d5c4a1;
+      }
+
+      html[data-theme="dark"] {
+        --bg: #282828;
+        --fg: #ebdbb2;
+        --muted: #a89984;
+        --grid: #504945;
+      }
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: system-ui, sans-serif;
+      }
+
+      #chart {
+        width: 100%;
+        height: 100%;
+      }
+
+      #status {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+        text-align: center;
+        color: var(--muted);
+      }
+
+      #status[hidden] {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="status">Loading compile peak RSS history…</div>
+    <div id="chart"></div>
+    <script>
+      const DATA_URLS = [
+        "https://raw.githubusercontent.com/Shamrock-code/Shamrock/refs/heads/metrics-history/output/compile_memory_top10.json",
+        "https://cdn.jsdelivr.net/gh/Shamrock-code/Shamrock@metrics-history/output/compile_memory_top10.json",
+      ];
+
+      function parentTheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            const theme = window.parent.document.documentElement.getAttribute("data-theme");
+            if (theme === "dark" || theme === "light") {
+              return theme;
+            }
+          }
+        } catch (err) {
+          /* Cross-origin parent: fall back to prefers-color-scheme. */
+        }
+        return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+      }
+
+      function applyTheme(theme) {
+        document.documentElement.setAttribute("data-theme", theme);
+      }
+
+      function themedLayout(baseLayout, theme) {
+        const dark = theme === "dark";
+        const bg = dark ? "#282828" : "#fff";
+        const fg = dark ? "#ebdbb2" : "#3c3836";
+        const muted = dark ? "#a89984" : "#665c54";
+        const grid = dark ? "#504945" : "#d5c4a1";
+        const layout = Object.assign({}, baseLayout || {});
+        const title = Object.assign({}, layout.title || {});
+        title.font = Object.assign({ size: 18 }, title.font || {}, { color: fg });
+        layout.title = title;
+        layout.paper_bgcolor = bg;
+        layout.plot_bgcolor = bg;
+        layout.font = Object.assign({}, layout.font || {}, { color: fg });
+        layout.xaxis = Object.assign({}, layout.xaxis || {}, {
+          gridcolor: grid,
+          zerolinecolor: grid,
+          linecolor: muted,
+          tickfont: { color: muted },
+        });
+        layout.yaxis = Object.assign({}, layout.yaxis || {}, {
+          gridcolor: grid,
+          zerolinecolor: grid,
+          linecolor: muted,
+          tickfont: { color: muted },
+        });
+        return layout;
+      }
+
+      function plotlyTraces(payload) {
+        if (!payload || !Array.isArray(payload.data)) {
+          throw new Error("Unexpected dataset shape: missing Plotly data[]");
+        }
+        return payload.data.filter(
+          (trace) =>
+            trace &&
+            Array.isArray(trace.x) &&
+            Array.isArray(trace.y) &&
+            trace.x.length === trace.y.length &&
+            trace.x.length > 0
+        );
+      }
+
+      async function fetchDataset() {
+        const errors = [];
+        for (const url of DATA_URLS) {
+          try {
+            const response = await fetch(url, { cache: "no-store" });
+            if (!response.ok) {
+              throw new Error(`${response.status} ${response.statusText}`);
+            }
+            return await response.json();
+          } catch (err) {
+            errors.push(`${url}: ${err.message}`);
+          }
+        }
+        throw new Error(errors.join("; "));
+      }
+
+      function setStatus(message) {
+        const status = document.getElementById("status");
+        if (message) {
+          status.textContent = message;
+          status.hidden = false;
+        } else {
+          status.hidden = true;
+        }
+      }
+
+      async function main() {
+        const chart = document.getElementById("chart");
+        let theme = parentTheme();
+        applyTheme(theme);
+
+        let payload;
+        try {
+          payload = await fetchDataset();
+        } catch (err) {
+          setStatus(`Could not load compile peak RSS history.\n${err.message}`);
+          return;
+        }
+
+        const traces = plotlyTraces(payload);
+        if (traces.length === 0) {
+          setStatus("The compile peak RSS dataset is empty.");
+          return;
+        }
+
+        const config = { responsive: true, displaylogo: false };
+        await Plotly.newPlot(chart, traces, themedLayout(payload.layout, theme), config);
+        setStatus("");
+
+        const restyle = () => {
+          theme = parentTheme();
+          applyTheme(theme);
+          Plotly.react(chart, traces, themedLayout(payload.layout, theme));
+        };
+
+        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", restyle);
+
+        try {
+          if (window.parent && window.parent !== window) {
+            const observer = new MutationObserver(restyle);
+            observer.observe(window.parent.document.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-theme"],
+            });
+          }
+        } catch (err) {
+          /* Ignore if the parent document is not readable. */
+        }
+      }
+
+      main();
+    </script>
+  </body>
+</html>

--- a/doc/sphinx/source/dev_doc/history-graphs.md
+++ b/doc/sphinx/source/dev_doc/history-graphs.md
@@ -22,6 +22,25 @@ built.
 Raw JSON:
 [doxygen_warnings.json](https://raw.githubusercontent.com/Shamrock-code/Shamrock/refs/heads/metrics-history/output/doxygen_warnings.json).
 
+## Compile peak RSS (top 10 files)
+
+CI records per-translation-unit compiler peak RSS. The chart keeps only the
+top 10 files of each commit: a file that drops out of that ranking is omitted
+at that date (`null` y, `connectgaps: false`).
+
+```{raw} html
+<iframe
+  src="../_static/compile_memory_top10.html"
+  title="Top 10 compile peak RSS over time"
+  width="100%"
+  height="700"
+  style="border: none;"
+></iframe>
+```
+
+Raw Plotly JSON:
+[compile_memory_top10.json](https://raw.githubusercontent.com/Shamrock-code/Shamrock/refs/heads/metrics-history/output/compile_memory_top10.json).
+
 The org website (`https://shamrock-code.github.io/`) is same-origin with the
 published Sphinx docs, so it can embed this chart with:
 

--- a/tools/make_metrics_datasets.py
+++ b/tools/make_metrics_datasets.py
@@ -71,6 +71,99 @@ def build_build_time_total(snapshots):
     return data
 
 
+COMPILE_MEMORY_TOP_N = 10
+REPO_PATH_MARKER = "/Shamrock/Shamrock/"
+
+
+def normalize_compile_path(path):
+    path = (path or "").replace("\\", "/").strip()
+    path = path.removeprefix("./")
+    idx = path.rfind(REPO_PATH_MARKER)
+    if idx != -1:
+        path = path[idx + len(REPO_PATH_MARKER) :]
+    return path
+
+
+def top_compile_memory_files(usage, limit=COMPILE_MEMORY_TOP_N):
+    by_path = {}
+    for item in usage:
+        path = normalize_compile_path(item.get("path"))
+        rss = item.get("rss_mb")
+        if not path or rss is None:
+            continue
+        rss = float(rss)
+        prev = by_path.get(path)
+        if prev is None or rss > prev:
+            by_path[path] = rss
+    ranked = sorted(by_path.items(), key=lambda item: (-item[1], item[0]))
+    return ranked[:limit]
+
+
+def compile_memory_top10_layout():
+    return {
+        "title": {"text": "Top 10 compile peak RSS"},
+        "margin": {"l": 72, "r": 24, "t": 56, "b": 180},
+        "xaxis": {
+            "title": {"text": "Date (UTC)"},
+            "type": "date",
+        },
+        "yaxis": {
+            "title": {"text": "Peak RSS (MB)"},
+            "rangemode": "tozero",
+        },
+        "legend": {
+            "orientation": "h",
+            "yanchor": "top",
+            "y": -0.28,
+            "x": 0,
+            "xanchor": "left",
+            "font": {"size": 11},
+        },
+        "hovermode": "x unified",
+    }
+
+
+def build_compile_memory_top10(snapshots):
+    # One trace per file that is in any snapshot's top 10. y is null when that
+    # file is outside the top 10 of a given commit, so Plotly drops it there.
+    dated_top = []
+    for snapshot in snapshots:
+        profile = snapshot.get("metrics", {}).get("build_profile") or {}
+        usage = profile.get("compile_memory_usage")
+        if not usage:
+            continue
+        dated_top.append((to_iso8601(snapshot["datetime"]), top_compile_memory_files(usage)))
+
+    xs = [dt for dt, _ranking in dated_top]
+    rss_by_file = {}
+    for dt_idx, (_dt, ranking) in enumerate(dated_top):
+        for path, rss in ranking:
+            series = rss_by_file.setdefault(path, [None] * len(xs))
+            series[dt_idx] = rss
+
+    files = sorted(
+        rss_by_file,
+        key=lambda path: (-max(v for v in rss_by_file[path] if v is not None), path),
+    )
+
+    traces = []
+    for path in files:
+        traces.append(
+            {
+                "type": "scatter",
+                "mode": "lines+markers",
+                "name": path,
+                "x": xs,
+                "y": rss_by_file[path],
+                "connectgaps": False,
+                "hovertemplate": (
+                    "%{fullData.name}<br>%{x|%Y-%m-%d %H:%M UTC}<br>RSS: %{y:.1f} MB<extra></extra>"
+                ),
+            }
+        )
+    return traces
+
+
 # Exclusive loc partitions from tools/count_loc.py. Nested shammodels/* counts
 # are subsets of "code" and must not be added into an extension total.
 LOC_PARTITION_KINDS = ("code", "examples", "doc")
@@ -106,9 +199,11 @@ def build_loc(snapshots):
     return data
 
 
-def write_dataset(output_dir, name, data):
+def write_dataset(output_dir, name, data, layout=None):
     path = output_dir / f"{name}.json"
     payload = {"name": name, "data": data}
+    if layout is not None:
+        payload["layout"] = layout
     path.write_text(json.dumps(payload, indent=3) + "\n")
     print(path)
 
@@ -123,6 +218,12 @@ def build_datasets(root, output_dir):
     write_dataset(output_dir, "doxygen_warnings", build_doxygen_warnings(snapshots))
     write_dataset(output_dir, "build_time_total", build_build_time_total(snapshots))
     write_dataset(output_dir, "loc", build_loc(snapshots))
+    write_dataset(
+        output_dir,
+        "compile_memory_top10",
+        build_compile_memory_top10(snapshots),
+        layout=compile_memory_top10_layout(),
+    )
 
 
 def main():


### PR DESCRIPTION
Build output/compile_memory_top10.json from
metrics.build_profile.compile_memory_usage. Each commit keeps only its current top 10 files; a file that drops out is emitted as null so Plotly evicts that trace at that date.