### PR TITLE
[CI] Make light-ci default unless full-ci set

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -11,12 +11,14 @@ concurrency:
 
 jobs:
 
+  # Full CI runs when the `full-ci` label is set, or on Mergify merge-queue
+  # branches (e.g. mergify/merge-queue/7da018d0ff). Every other PR uses light CI.
   main_workflow:
     name: CI
     uses: ./.github/workflows/main_workflow.yml
     with:
       run_build_push_docker: true
-      light_ci: ${{ contains(github.event.pull_request.labels.*.name, 'light-ci') }}
+      light_ci: ${{ !(contains(github.event.pull_request.labels.*.name, 'full-ci') || startsWith(github.head_ref, 'mergify/merge-queue/')) }}
 
   collect_metrics:
     name: Collect metrics
@@ -33,7 +35,7 @@ jobs:
 
   light_ci:
     name: Notify Light CI
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'light-ci') }}
+    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'full-ci') || startsWith(github.head_ref, 'mergify/merge-queue/')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Echo message
@@ -41,8 +43,9 @@ jobs:
           cat >> report_______light_ci.md <<'EOF'
 
 
-          Light CI is enabled. This will only run the basic tests and not the full tests.
-          Merging a PR require the job "on PR / all" to pass which is disabled in this case.
+          Light CI is enabled (the default for pull requests). This will only run the basic tests and not the full tests.
+          Full CI runs if the `full-ci` label is set, or automatically on Mergify merge-queue branches (`mergify/merge-queue/*`).
+          The merge gate job "on PR / all" is skipped in this case. Queue entry uses "on PR / all_light"; full CI runs in the merge queue.
           EOF
 
       - uses: actions/upload-artifact@v4
@@ -50,8 +53,9 @@ jobs:
           name: report_light_ci
           path: ./report_______light_ci.md
 
-  # Mergify merge gate (merge_conditions: check-success = all). Skipped when the
-  # light-ci label is set — those PRs use all_light for queue entry instead.
+  # Mergify merge gate (merge_conditions: check-success = all). Runs only when
+  # full CI ran (`full-ci` label or Mergify merge-queue branch). Other PRs use
+  # all_light for queue entry instead.
   #
   # needs.main_workflow.result / needs.upload_metrics_history.result can be:
   #   - success   : reusable workflow completed without failure
@@ -64,8 +68,8 @@ jobs:
   #                 non-success — do not whitelist only failure/cancelled.
   all:
     needs: [ main_workflow, upload_metrics_history ]
-    # run always except for cancel
-    if: ${{ always() && !cancelled() && !contains(github.event.pull_request.labels.*.name, 'light-ci') }}
+    # run always except for cancel, and only when full CI ran
+    if: ${{ always() && !cancelled() && (contains(github.event.pull_request.labels.*.name, 'full-ci') || startsWith(github.head_ref, 'mergify/merge-queue/')) }}
     runs-on: ubuntu-latest
     steps:
     - name: Status summary
@@ -80,7 +84,7 @@ jobs:
         fi
 
   # Mergify merge-queue entry gate (queue_conditions: check-success = all_light).
-  # Runs regardless of the light-ci label.
+  # Runs for both light and full CI.
   # Same gate logic as all; see comment above for needs.*.result states.
   all_light:
     needs: [ main_workflow, upload_metrics_history ]

--- a/.github/workflows/on_pr_opened.yml
+++ b/.github/workflows/on_pr_opened.yml
@@ -29,7 +29,7 @@ jobs:
             1 - Comment `pre-commit.ci run` to run pre-commit checks.
             2 - Comment `pre-commit.ci autofix` to apply fixes.
             3 - Add label `autofix.ci` to fix authorship & pre-commit for every commit made.
-            4 - Add label `light-ci` to only trigger a reduced & faster version of the CI (need the full one before merge).
+            4 - Add label `full-ci` to run the full test suite (default is light CI; full CI also runs on Mergify merge-queue branches).
             5 - Add label `trigger-ci` to create an empty commit to trigger the CI.
 
             Once the workflow completes a message will appear displaying informations related to the run.


### PR DESCRIPTION
Pull requests now default to light CI. Full CI runs when the full-ci label is set, or automatically on Mergify merge-queue branches (mergify/merge-queue/*). The on PR / all merge gate follows the same condition so queue batches still require full CI.