### PR TITLE
[CI] Forward CODECOV_TOKEN to scheduled main workflow

### DIFF
--- a/.github/workflows/on_schedule_main.yml
+++ b/.github/workflows/on_schedule_main.yml
@@ -25,9 +25,12 @@ jobs:
           else
             echo "TOKEN EXISTS"
           fi
+
   main_workflow:
     name: CI
     uses: ./.github/workflows/main_workflow.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       run_build_push_docker: true
       light_ci: false


### PR DESCRIPTION
Scheduled CI calls the reusable main workflow without inheriting repo secrets, so coverage jobs could not access CODECOV_TOKEN.