### PR TITLE
[Tests] Fix undefined behavior in shammath/solve::least_squares test

### DIFF
--- a/src/tests/shammath/matrixTests.cpp
+++ b/src/tests/shammath/matrixTests.cpp
@@ -597,11 +597,11 @@ NEW_TEST(Unittest, "shammath/solve::least_squares", 1) {
     auto pfit                     = ls.first;
     auto R2                       = ls.second;
     std::vector<f64> res          = {pfit[0], pfit[1], pfit[2], R2};
-    std::vector<f64> ex_res       = {1.55, 4.08, 4.5154e2};
+    std::vector<f64> ex_res       = {1.55, 4.08, 4.5154e2, 0.997};
     std::vector<f64> ex_deviation = {2e-2, 4.7e-2, 4.7e-2, 1e-2};
 
     bool test_fit = true;
-    for (size_t i; i < 4; i++) {
+    for (size_t i = 0; i < 4; i++) {
         if (sham::abs(res[i] - ex_res[i]) > ex_deviation[i]) {
             test_fit = false;
         }


### PR DESCRIPTION
The comparison loop used an uninitialized loop counter (`size_t i;` instead of `size_t i = 0;`), so its starting value was whatever garbage was left on the stack. Depending on compiler/optimization level, this could skip comparisons entirely (silently passing a bad fit) or read out of bounds, explaining the flaky/non-deterministic CI failures. Also fixed a related out-of-bounds read: `ex_res` only had 3 entries but was indexed up to 3 (missing the expected R^2 value).

Assisted-by: Claude