### PR TITLE
[SPH] Refresh solver-graph edges after particle killing

### DIFF
--- a/src/shammodels/sph/src/Solver.cpp
+++ b/src/shammodels/sph/src/Solver.cpp
@@ -568,8 +568,7 @@ void shammodels::sph::Solver<Tvec, Kern>::init_solver_graph() {
 
         // update part counts and spans since particles have been killed and thus
         // patches can become empty
-        part_kill_sequence.push_back(
-            solver_graph.get_node_ptr_base("attach fields to scheduler"));
+        part_kill_sequence.push_back(solver_graph.get_node_ptr_base("attach fields to scheduler"));
 
         solver_graph.register_node(
             "part killing step",

--- a/src/shammodels/sph/src/Solver.cpp
+++ b/src/shammodels/sph/src/Solver.cpp
@@ -566,6 +566,11 @@ void shammodels::sph::Solver<Tvec, Kern>::init_solver_graph() {
                 std::make_shared<decltype(node_killer)>(std::move(node_killer)));
         }
 
+        // update part counts and spans since particles have been killed and thus
+        // patches can become empty
+        part_kill_sequence.push_back(
+            solver_graph.get_node_ptr_base("attach fields to scheduler"));
+
         solver_graph.register_node(
             "part killing step",
             OperationSequence("part killing step", std::move(part_kill_sequence)));


### PR DESCRIPTION
Re-run attach fields to scheduler after KillParticles so part counts, field refs, and spans stay in sync, and empty patches are dropped.