### PR TITLE
[SPH] Migrate gpart_mass from ScalarEdge to IDataEdge

### DIFF
--- a/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLDust1Fluid.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLDust1Fluid.hpp
@@ -21,13 +21,14 @@
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
 #include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include "shamsys/NodeInstance.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \
     X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, C_1_fluid)                                      \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, pmass)                                          \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, pmass)                                           \
     X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, hfactd)                                         \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, hpart)                                          \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, soundspeed)                                     \
@@ -53,7 +54,7 @@ class ComputeCFLDust1Fluid : public shamrock::solvergraph::INode {
         auto dev_sched = shamsys::instance::get_compute_scheduler_ptr();
 
         Tscal C_1_fluid = edges.C_1_fluid.value;
-        Tscal pmass     = edges.pmass.value;
+        Tscal pmass     = edges.pmass.data;
         Tscal hfactd    = edges.hfactd.value;
 
         sham::distributed_data_kernel_call(

--- a/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLDustDrift.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLDustDrift.hpp
@@ -21,6 +21,7 @@
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
 #include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include "shamsys/NodeInstance.hpp"
 
@@ -28,7 +29,7 @@
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \
     X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, C_drift)                                        \
     X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, cfl_density_threshold)                          \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, pmass)                                          \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, pmass)                                           \
     X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, hfactd)                                         \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, hpart)                                          \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, s_j)                                            \
@@ -55,7 +56,7 @@ class ComputeCFLDustDrift : public shamrock::solvergraph::INode {
         Tscal C_drift               = edges.C_drift.value;
         Tscal cfl_density_threshold = edges.cfl_density_threshold.value;
 
-        Tscal pmass  = edges.pmass.value;
+        Tscal pmass  = edges.pmass.data;
         Tscal hfactd = edges.hfactd.value;
 
         sham::distributed_data_kernel_call(

--- a/src/shammodels/sph/include/shammodels/sph/modules/ComputeDustTtilde.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/ComputeDustTtilde.hpp
@@ -22,13 +22,13 @@
 #include "shammodels/sph/math/density.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include "shamsys/NodeInstance.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     /* scalars */                                                                                  \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, gpart_mass)                                     \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, gpart_mass)                                      \
                                                                                                    \
     /* counts */                                                                                   \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \
@@ -74,7 +74,7 @@ namespace shammodels::sph::modules {
             // ensure that the output edges are of size part_counts (output without ghosts zones)
             edges.Ttilde_sj.ensure_sizes(part_counts);
 
-            const Tscal pmass = edges.gpart_mass.value;
+            const Tscal pmass = edges.gpart_mass.data;
 
             auto total_specie_count = part_counts.template map<u32>([&](u64 id, u32 count) {
                 return count * ndust;

--- a/src/shammodels/sph/include/shammodels/sph/modules/MonoFluidTVADeltav.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/MonoFluidTVADeltav.hpp
@@ -21,13 +21,13 @@
 #include "shammodels/sph/math/density.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include "shamsys/NodeInstance.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     /* scalars */                                                                                  \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, gpart_mass)                                     \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, gpart_mass)                                      \
                                                                                                    \
     /* counts */                                                                                   \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \
@@ -73,7 +73,7 @@ namespace shammodels::sph::modules {
             // ensure that the output edges are of size part_counts (output without ghosts zones)
             edges.delta_v.ensure_sizes(part_counts);
 
-            const Tscal pmass = edges.gpart_mass.value;
+            const Tscal pmass = edges.gpart_mass.data;
 
             auto total_specie_count = part_counts.template map<u32>([&](u64 id, u32 count) {
                 return count * ndust;

--- a/src/shammodels/sph/include/shammodels/sph/modules/NodeComputePressureGrad.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/NodeComputePressureGrad.hpp
@@ -20,12 +20,12 @@
 #include "shammodels/sph/solvergraph/NeighCache.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     /* scalars */                                                                                  \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, gpart_mass)                                     \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, gpart_mass)                                      \
                                                                                                    \
     /* counts */                                                                                   \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \

--- a/src/shammodels/sph/include/shammodels/sph/modules/NodeUpdateDerivsMonofluidTVA.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/NodeUpdateDerivsMonofluidTVA.hpp
@@ -20,13 +20,13 @@
 #include "shammodels/sph/solvergraph/NeighCache.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     /* ------------------- inputs ------------------- */                                           \
     /* scalars */                                                                                  \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, gpart_mass)                                     \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, gpart_mass)                                      \
                                                                                                    \
     /* counts */                                                                                   \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \

--- a/src/shammodels/sph/include/shammodels/sph/modules/NodeUpdateDerivsVaryingAlphaAV.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/NodeUpdateDerivsVaryingAlphaAV.hpp
@@ -21,11 +21,12 @@
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
 #include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     /* scalars */                                                                                  \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, gpart_mass)                                     \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, gpart_mass)                                      \
     X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, alpha_u)                                        \
     X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, beta_AV)                                        \
                                                                                                    \

--- a/src/shammodels/sph/include/shammodels/sph/modules/NodeUpdateDerivsVaryingAlphaAVDustTVA.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/NodeUpdateDerivsVaryingAlphaAVDustTVA.hpp
@@ -21,11 +21,12 @@
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
 #include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     /* scalars */                                                                                  \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, gpart_mass)                                     \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, gpart_mass)                                      \
     X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, alpha_u)                                        \
     X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, beta_AV)                                        \
                                                                                                    \

--- a/src/shammodels/sph/include/shammodels/sph/modules/SetDustStoppingTimeEpstein.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/SetDustStoppingTimeEpstein.hpp
@@ -25,13 +25,14 @@
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
 #include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include "shamsys/NodeInstance.hpp"
 #include <vector>
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     /* scalars */                                                                                  \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, gpart_mass)                                     \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, gpart_mass)                                      \
     X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, gamma)                                          \
     X_RO(shamrock::solvergraph::ScalarEdge<std::vector<Tscal>>, sgrain_j)                          \
     X_RO(shamrock::solvergraph::ScalarEdge<std::vector<Tscal>>, rho_grain_j)                       \
@@ -93,7 +94,7 @@ namespace shammodels::sph::modules {
 
             auto &q = shamsys::instance::get_compute_scheduler().get_queue();
 
-            const Tscal pmass = edges.gpart_mass.value;
+            const Tscal pmass = edges.gpart_mass.data;
             const Tscal gamma = edges.gamma.value;
 
             part_counts.for_each([&](u64 id, u32 count) {

--- a/src/shammodels/sph/src/Solver.cpp
+++ b/src/shammodels/sph/src/Solver.cpp
@@ -141,7 +141,7 @@ void shammodels::sph::Solver<Tvec, Kern>::init_solver_graph() {
     solver_graph.register_edge("part_counts", Indexes<u32>("Npart_patch", "N_{\\rm part}_p"));
 
     solver_graph.register_edge("dt_half", IDataEdge<Tscal>("dt_half", "\\frac{dt}{2}"));
-    solver_graph.register_edge("gpart_mass", ScalarEdge<Tscal>("m", "m"));
+    solver_graph.register_edge("gpart_mass", IDataEdge<Tscal>("m", "m"));
 
     solver_graph.register_edge("xyz", FieldRefs<Tvec>("xyz", "\\mathbf{r}"));
     solver_graph.register_edge("vxyz", FieldRefs<Tvec>("vxyz", "\\mathbf{v}"));
@@ -176,11 +176,11 @@ void shammodels::sph::Solver<Tvec, Kern>::init_solver_graph() {
 
     {
         auto set_gpart_mass = solver_graph.register_node(
-            "set_gpart_mass", NodeSetEdge<ScalarEdge<Tscal>>([&](ScalarEdge<Tscal> &gpart_mass) {
-                gpart_mass.value = solver_config.gpart_mass;
+            "set_gpart_mass", NodeSetEdge<IDataEdge<Tscal>>([&](IDataEdge<Tscal> &gpart_mass) {
+                gpart_mass.data = solver_config.gpart_mass;
             }));
         shambase::get_check_ref(set_gpart_mass)
-            .set_edges(solver_graph.get_edge_ptr<ScalarEdge<Tscal>>("gpart_mass"));
+            .set_edges(solver_graph.get_edge_ptr<IDataEdge<Tscal>>("gpart_mass"));
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////
@@ -1685,7 +1685,7 @@ void shammodels::sph::Solver<Tvec, Kern>::update_derivs(Tscal dt_hydro) {
         }
 
         auto gpart_mass
-            = storage.solver_graph.template get_edge_ptr<shamrock::solvergraph::ScalarEdge<Tscal>>(
+            = storage.solver_graph.template get_edge_ptr<shamrock::solvergraph::IDataEdge<Tscal>>(
                 "gpart_mass");
         auto t_j_field
             = storage.solver_graph.template get_edge_ptr<shamrock::solvergraph::Field<Tscal>>(
@@ -2827,7 +2827,7 @@ shammodels::sph::TimestepLog shammodels::sph::Solver<Tvec, Kern>::evolve_once() 
 
                 auto pmass_edge
                     = storage.solver_graph
-                          .template get_edge_ptr<shamrock::solvergraph::ScalarEdge<Tscal>>(
+                          .template get_edge_ptr<shamrock::solvergraph::IDataEdge<Tscal>>(
                               "gpart_mass");
 
                 s_j_refs = std::make_shared<shamrock::solvergraph::FieldRefs<Tscal>>("s_j", "s_j");
@@ -2884,7 +2884,7 @@ shammodels::sph::TimestepLog shammodels::sph::Solver<Tvec, Kern>::evolve_once() 
 
                 auto pmass_edge
                     = storage.solver_graph
-                          .template get_edge_ptr<shamrock::solvergraph::ScalarEdge<Tscal>>(
+                          .template get_edge_ptr<shamrock::solvergraph::IDataEdge<Tscal>>(
                               "gpart_mass");
 
                 compute_cfl_dust_drift->set_edges(

--- a/src/shammodels/sph/src/modules/NodeComputePressureGrad.cpp
+++ b/src/shammodels/sph/src/modules/NodeComputePressureGrad.cpp
@@ -114,7 +114,7 @@ void shammodels::sph::modules::NodeComputePressureGrad<Tvec, SPHKernel>::_impl_e
     // ensure that the output edges are of size part_counts (output without ghosts zones)
     edges.grad_P_on_rho.ensure_sizes(part_counts);
 
-    const Tscal pmass = edges.gpart_mass.value;
+    const Tscal pmass = edges.gpart_mass.data;
 
     using ComputeKernel = KernelComputePressureGrad<Tvec, SPHKernel>;
 

--- a/src/shammodels/sph/src/modules/NodeUpdateDerivsMonofluidTVA.cpp
+++ b/src/shammodels/sph/src/modules/NodeUpdateDerivsMonofluidTVA.cpp
@@ -132,7 +132,7 @@ void shammodels::sph::modules::NodeUpdateDerivsMonofluidTVA<Tvec, SPHKernel>::
     // ensure that the output edges are of size part_counts (output without ghosts zones)
     edges.ds_j_dt.ensure_sizes(part_counts);
 
-    const Tscal pmass = edges.gpart_mass.value;
+    const Tscal pmass = edges.gpart_mass.data;
 
     using ComputeKernel = KernelUpdateDerivsMonofluidTVA<Tvec, SPHKernel>;
 

--- a/src/shammodels/sph/src/modules/NodeUpdateDerivsVaryingAlphaAV.cpp
+++ b/src/shammodels/sph/src/modules/NodeUpdateDerivsVaryingAlphaAV.cpp
@@ -163,7 +163,7 @@ void shammodels::sph::modules::NodeUpdateDerivsVaryingAlphaAV<Tvec, SPHKernel>::
     edges.axyz.ensure_sizes(part_counts);
     edges.duint.ensure_sizes(part_counts);
 
-    const Tscal pmass   = edges.gpart_mass.value;
+    const Tscal pmass   = edges.gpart_mass.data;
     const Tscal alpha_u = edges.alpha_u.value;
     const Tscal beta_AV = edges.beta_AV.value;
 

--- a/src/shammodels/sph/src/modules/NodeUpdateDerivsVaryingAlphaAVDustTVA.cpp
+++ b/src/shammodels/sph/src/modules/NodeUpdateDerivsVaryingAlphaAVDustTVA.cpp
@@ -178,7 +178,7 @@ void shammodels::sph::modules::NodeUpdateDerivsVaryingAlphaAVDustTVA<Tvec, SPHKe
     edges.axyz.ensure_sizes(part_counts);
     edges.duint.ensure_sizes(part_counts);
 
-    const Tscal pmass   = edges.gpart_mass.value;
+    const Tscal pmass   = edges.gpart_mass.data;
     const Tscal alpha_u = edges.alpha_u.value;
     const Tscal beta_AV = edges.beta_AV.value;
 

--- a/src/shammodels/sph/src/modules/UpdateDerivs.cpp
+++ b/src/shammodels/sph/src/modules/UpdateDerivs.cpp
@@ -45,6 +45,7 @@
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
 #include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include <memory>
 #include <vector>
 
@@ -374,7 +375,7 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_mm97
     auto axyz_refs  = solver_graph.get_edge_ptr<shamrock::solvergraph::FieldRefs<Tvec>>("axyz");
     auto duint_refs = solver_graph.get_edge_ptr<shamrock::solvergraph::FieldRefs<Tscal>>("duint");
     auto gpart_mass
-        = solver_graph.get_edge_ptr<shamrock::solvergraph::ScalarEdge<Tscal>>("gpart_mass");
+        = solver_graph.get_edge_ptr<shamrock::solvergraph::IDataEdge<Tscal>>("gpart_mass");
 
     std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> alpha_u
         = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>("alpha_u", "alpha_u");
@@ -499,7 +500,7 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_cd10
     auto axyz_refs  = solver_graph.get_edge_ptr<shamrock::solvergraph::FieldRefs<Tvec>>("axyz");
     auto duint_refs = solver_graph.get_edge_ptr<shamrock::solvergraph::FieldRefs<Tscal>>("duint");
     auto gpart_mass
-        = solver_graph.get_edge_ptr<shamrock::solvergraph::ScalarEdge<Tscal>>("gpart_mass");
+        = solver_graph.get_edge_ptr<shamrock::solvergraph::IDataEdge<Tscal>>("gpart_mass");
 
     std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> alpha_u
         = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>("alpha_u", "alpha_u");
@@ -1149,7 +1150,7 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_dust
 
     shamrock::solvergraph::SolverGraph &solver_graph = storage.solver_graph;
     auto gpart_mass
-        = solver_graph.get_edge_ptr<shamrock::solvergraph::ScalarEdge<Tscal>>("gpart_mass");
+        = solver_graph.get_edge_ptr<shamrock::solvergraph::IDataEdge<Tscal>>("gpart_mass");
 
     std::shared_ptr<shamrock::solvergraph::FieldRefs<Tvec>> vxyz_refs
         = std::make_shared<shamrock::solvergraph::FieldRefs<Tvec>>("vxyz", "v");


### PR DESCRIPTION
Finish converting the last ScalarEdge<Tscal> consumers of gpart_mass (pressure gradient, dust drag/AV derivs nodes, dust CFL nodes) to IDataEdge<Tscal>, matching the pattern already used for dt_half and the self-gravity/render/sink modules.