### PR TITLE
[Docs] Share Plotly iframe helpers across history graphs

### DIFF
--- a/doc/sphinx/source/_static/build_time_total.html
+++ b/doc/sphinx/source/_static/build_time_total.html
@@ -5,215 +5,56 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Build time</title>
     <script src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.3/plotly.min.js"></script>
-    <style>
-      :root {
-        --bg: #fff;
-        --fg: #3c3836;
-        --muted: #665c54;
-        --grid: #d5c4a1;
-      }
-
-      html[data-theme="dark"] {
-        --bg: #282828;
-        --fg: #ebdbb2;
-        --muted: #a89984;
-        --grid: #504945;
-      }
-
-      html,
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        overflow: hidden;
-        background: var(--bg);
-        color: var(--fg);
-        font-family: system-ui, sans-serif;
-      }
-
-      #chart {
-        width: 100%;
-        height: 100%;
-      }
-
-      #status {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1rem;
-        text-align: center;
-        color: var(--muted);
-      }
-
-      #status[hidden] {
-        display: none;
-      }
-    </style>
+    <link rel="stylesheet" href="css/metrics-chart.css" />
   </head>
   <body>
     <div id="status">Loading build time history…</div>
     <div id="chart"></div>
+    <script src="js/metrics-chart.js"></script>
     <script>
-      const DATA_URLS = [
-        "https://raw.githubusercontent.com/Shamrock-code/Shamrock/refs/heads/metrics-history/output/build_time_total.json",
-        "https://cdn.jsdelivr.net/gh/Shamrock-code/Shamrock@metrics-history/output/build_time_total.json",
-      ];
       const SECONDS_PER_HOUR = 3600;
-      // Vertical markers on the date axis (ISO datetime, UTC).
-      const PLOT_EVENTS = [
-        { date: "2026-08-17T13:43:38Z", text: "force -j 4 in gh-runners" },
-      ];
-
-      function parentTheme() {
-        try {
-          if (window.parent && window.parent !== window) {
-            const theme = window.parent.document.documentElement.getAttribute("data-theme");
-            if (theme === "dark" || theme === "light") {
-              return theme;
-            }
-          }
-        } catch (err) {
-          /* Cross-origin parent: fall back to prefers-color-scheme. */
-        }
-        return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-      }
-
-      function applyTheme(theme) {
-        document.documentElement.setAttribute("data-theme", theme);
-      }
-
-      function seriesColors(theme) {
-        const dark = theme === "dark";
-        return {
-          parsing: dark ? "#83a598" : "#076678",
-          codegen: dark ? "#fe8019" : "#af3a03",
-          total: dark ? "#b8bb26" : "#79740e",
-          tus: dark ? "#d3869b" : "#8f3f71",
-        };
-      }
 
       function hasTranslationUnits(series) {
-        return series.translation_unit_count.some((value) => value !== null);
-      }
-
-      function paddedRange(values, integer) {
-        const nums = values.filter((value) => typeof value === "number" && Number.isFinite(value));
-        if (nums.length === 0) {
-          return undefined;
-        }
-        const min = Math.min(...nums);
-        const max = Math.max(...nums);
-        const span = max - min;
-        const pad = span === 0 ? Math.max(Math.abs(min) * 0.05, integer ? 1 : 0.05) : span * 0.1;
-        let lo = min - pad;
-        let hi = max + pad;
-        if (integer) {
-          lo = Math.floor(lo);
-          hi = Math.ceil(hi);
-          if (lo === hi) {
-            lo -= 1;
-            hi += 1;
-          }
-        }
-        if (min >= 0) {
-          lo = Math.max(0, lo);
-        }
-        return [lo, hi];
-      }
-
-      function eventDecorations(theme, series) {
-        const dark = theme === "dark";
-        const color = dark ? "#fabd2f" : "#b57614";
-        const bgcolor = dark ? "rgba(40, 40, 40, 0.9)" : "rgba(255, 255, 255, 0.9)";
-        let xMin = null;
-        let xMax = null;
-        if (series && series.x && series.x.length > 0) {
-          xMin = Date.parse(series.x[0]);
-          xMax = Date.parse(series.x[series.x.length - 1]);
-        }
-        const shapes = [];
-        const annotations = [];
-        for (const event of PLOT_EVENTS) {
-          const eventMs = Date.parse(event.date);
-          const nearEnd =
-            xMin !== null && xMax !== null && xMax > xMin
-              ? (eventMs - xMin) / (xMax - xMin) > 0.7
-              : true;
-          shapes.push({
-            type: "line",
-            x0: event.date,
-            x1: event.date,
-            y0: 0,
-            y1: 1,
-            xref: "x",
-            yref: "paper",
-            line: { color, width: 1.5, dash: "dot" },
-          });
-          annotations.push({
-            x: event.date,
-            y: 0.98,
-            xref: "x",
-            yref: "paper",
-            text: event.text,
-            showarrow: false,
-            xanchor: nearEnd ? "right" : "left",
-            yanchor: "top",
-            xshift: nearEnd ? -8 : 8,
-            font: { color, size: 12 },
-            bgcolor,
-            bordercolor: color,
-            borderwidth: 1,
-            borderpad: 4,
-          });
-        }
-        return { shapes, annotations };
+        return series.translation_unit_count.some(function (value) {
+          return value !== null;
+        });
       }
 
       function chartLayout(theme, series) {
-        const dark = theme === "dark";
-        const bg = dark ? "#282828" : "#fff";
-        const fg = dark ? "#ebdbb2" : "#3c3836";
-        const muted = dark ? "#a89984" : "#665c54";
-        const grid = dark ? "#504945" : "#d5c4a1";
+        const colors = MetricsChart.themeColors(theme);
+        const axis = MetricsChart.axisStyle(theme);
         const showTu = hasTranslationUnits(series);
-        const tuColor = seriesColors(theme).tus;
-        const events = eventDecorations(theme, series);
+        const tuColor = colors.tus;
+        const events = MetricsChart.eventDecorations(theme, series.x);
         const layout = {
-          title: { text: "Build time (ClangBuildAnalyzer)", font: { color: fg, size: 18 } },
+          title: { text: "Build time (ClangBuildAnalyzer)", font: { color: colors.fg, size: 18 } },
           margin: { l: 64, r: showTu ? 72 : 24, t: 48, b: 80 },
-          paper_bgcolor: bg,
-          plot_bgcolor: bg,
-          font: { color: fg },
+          paper_bgcolor: colors.bg,
+          plot_bgcolor: colors.bg,
+          font: { color: colors.fg },
           legend: {
             orientation: "h",
             x: 0,
             y: -0.18,
-            font: { color: fg },
+            font: { color: colors.fg },
             bgcolor: "rgba(0,0,0,0)",
             borderwidth: 0,
           },
-          xaxis: {
-            title: { text: "Date (UTC)" },
-            type: "date",
-            gridcolor: grid,
-            zerolinecolor: grid,
-            linecolor: muted,
-            tickfont: { color: muted },
-          },
-          yaxis: {
-            title: { text: "Time (hours)" },
-            gridcolor: grid,
-            zerolinecolor: grid,
-            linecolor: muted,
-            tickfont: { color: muted },
-            autorange: false,
-            range: paddedRange(
-              [].concat(series.parsing_h, series.codegen_h, series.total_h)
-            ),
-          },
+          xaxis: Object.assign(
+            {
+              title: { text: "Date (UTC)" },
+              type: "date",
+            },
+            axis
+          ),
+          yaxis: Object.assign(
+            {
+              title: { text: "Time (hours)" },
+              autorange: false,
+              range: MetricsChart.paddedRange([].concat(series.parsing_h, series.codegen_h, series.total_h)),
+            },
+            axis
+          ),
           hovermode: "x unified",
           shapes: events.shapes,
           annotations: events.annotations,
@@ -224,20 +65,15 @@
             overlaying: "y",
             side: "right",
             showgrid: false,
-            zerolinecolor: grid,
+            zerolinecolor: colors.grid,
             linecolor: tuColor,
             tickfont: { color: tuColor },
             tickformat: "d",
             autorange: false,
-            range: paddedRange(series.translation_unit_count, true),
+            range: MetricsChart.paddedRange(series.translation_unit_count, true),
           };
         }
         return layout;
-      }
-
-      function finiteNumber(value) {
-        const number = Number(value);
-        return Number.isFinite(number) ? number : null;
       }
 
       function toSeries(payload) {
@@ -245,32 +81,50 @@
           throw new Error("Unexpected dataset shape: missing data[]");
         }
         const rows = payload.data
-          .filter((row) => {
+          .filter(function (row) {
             if (!row || typeof row.datetime !== "string") {
               return false;
             }
             return (
-              finiteNumber(row.parsing_time_s) !== null &&
-              finiteNumber(row.codegen_time_s) !== null &&
-              finiteNumber(row.total_time_s) !== null
+              MetricsChart.finiteNumber(row.parsing_time_s) !== null &&
+              MetricsChart.finiteNumber(row.codegen_time_s) !== null &&
+              MetricsChart.finiteNumber(row.total_time_s) !== null
             );
           })
           .slice()
-          .sort((a, b) => a.datetime.localeCompare(b.datetime));
+          .sort(function (a, b) {
+            return a.datetime.localeCompare(b.datetime);
+          });
         return {
-          x: rows.map((row) => row.datetime),
-          parsing_h: rows.map((row) => Number(row.parsing_time_s) / SECONDS_PER_HOUR),
-          codegen_h: rows.map((row) => Number(row.codegen_time_s) / SECONDS_PER_HOUR),
-          total_h: rows.map((row) => Number(row.total_time_s) / SECONDS_PER_HOUR),
-          parsing_s: rows.map((row) => Number(row.parsing_time_s)),
-          codegen_s: rows.map((row) => Number(row.codegen_time_s)),
-          total_s: rows.map((row) => Number(row.total_time_s)),
-          translation_unit_count: rows.map((row) => finiteNumber(row.translation_unit_count)),
+          x: rows.map(function (row) {
+            return row.datetime;
+          }),
+          parsing_h: rows.map(function (row) {
+            return Number(row.parsing_time_s) / SECONDS_PER_HOUR;
+          }),
+          codegen_h: rows.map(function (row) {
+            return Number(row.codegen_time_s) / SECONDS_PER_HOUR;
+          }),
+          total_h: rows.map(function (row) {
+            return Number(row.total_time_s) / SECONDS_PER_HOUR;
+          }),
+          parsing_s: rows.map(function (row) {
+            return Number(row.parsing_time_s);
+          }),
+          codegen_s: rows.map(function (row) {
+            return Number(row.codegen_time_s);
+          }),
+          total_s: rows.map(function (row) {
+            return Number(row.total_time_s);
+          }),
+          translation_unit_count: rows.map(function (row) {
+            return MetricsChart.finiteNumber(row.translation_unit_count);
+          }),
         };
       }
 
       function traces(theme, series) {
-        const colors = seriesColors(theme);
+        const colors = MetricsChart.themeColors(theme);
         const timeHover = "%{fullData.name}: %{y:.2f} h (%{customdata:.1f} s)<extra></extra>";
         const result = [
           {
@@ -323,79 +177,19 @@
         return result;
       }
 
-      async function fetchDataset() {
-        const errors = [];
-        for (const url of DATA_URLS) {
-          try {
-            const response = await fetch(url, { cache: "no-store" });
-            if (!response.ok) {
-              throw new Error(`${response.status} ${response.statusText}`);
-            }
-            return await response.json();
-          } catch (err) {
-            errors.push(`${url}: ${err.message}`);
+      MetricsChart.mount({
+        urls: MetricsChart.metricsUrls("build_time_total.json"),
+        loading: "Loading build time history…",
+        empty: "The build time dataset is empty.",
+        error: "Could not load build time history.",
+        makePlot: function (payload, theme) {
+          const series = toSeries(payload);
+          if (series.x.length === 0) {
+            return { traces: [] };
           }
-        }
-        throw new Error(errors.join("; "));
-      }
-
-      function setStatus(message) {
-        const status = document.getElementById("status");
-        if (message) {
-          status.textContent = message;
-          status.hidden = false;
-        } else {
-          status.hidden = true;
-        }
-      }
-
-      async function main() {
-        const chart = document.getElementById("chart");
-        let theme = parentTheme();
-        applyTheme(theme);
-
-        let payload;
-        try {
-          payload = await fetchDataset();
-        } catch (err) {
-          setStatus(`Could not load build time history.\n${err.message}`);
-          return;
-        }
-
-        const series = toSeries(payload);
-        if (series.x.length === 0) {
-          setStatus("The build time dataset is empty.");
-          return;
-        }
-
-        await Plotly.newPlot(chart, traces(theme, series), chartLayout(theme, series), {
-          responsive: true,
-          displaylogo: false,
-        });
-        setStatus("");
-
-        const restyle = () => {
-          theme = parentTheme();
-          applyTheme(theme);
-          Plotly.react(chart, traces(theme, series), chartLayout(theme, series));
-        };
-
-        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", restyle);
-
-        try {
-          if (window.parent && window.parent !== window) {
-            const observer = new MutationObserver(restyle);
-            observer.observe(window.parent.document.documentElement, {
-              attributes: true,
-              attributeFilter: ["data-theme"],
-            });
-          }
-        } catch (err) {
-          /* Ignore if the parent document is not readable. */
-        }
-      }
-
-      main();
+          return { traces: traces(theme, series), layout: chartLayout(theme, series) };
+        },
+      });
     </script>
   </body>
 </html>

--- a/doc/sphinx/source/_static/codegen_time_top10.html
+++ b/doc/sphinx/source/_static/codegen_time_top10.html
@@ -5,250 +5,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Top 10 codegen time</title>
     <script src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.3/plotly.min.js"></script>
-    <style>
-      :root {
-        --bg: #fff;
-        --fg: #3c3836;
-        --muted: #665c54;
-        --grid: #d5c4a1;
-      }
-
-      html[data-theme="dark"] {
-        --bg: #282828;
-        --fg: #ebdbb2;
-        --muted: #a89984;
-        --grid: #504945;
-      }
-
-      html,
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        overflow: hidden;
-        background: var(--bg);
-        color: var(--fg);
-        font-family: system-ui, sans-serif;
-      }
-
-      #chart {
-        width: 100%;
-        height: 100%;
-      }
-
-      #status {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1rem;
-        text-align: center;
-        color: var(--muted);
-      }
-
-      #status[hidden] {
-        display: none;
-      }
-    </style>
+    <link rel="stylesheet" href="css/metrics-chart.css" />
   </head>
   <body>
     <div id="status">Loading codegen time history…</div>
     <div id="chart"></div>
+    <script src="js/metrics-chart.js"></script>
     <script>
-      const DATA_URLS = [
-        "https://raw.githubusercontent.com/Shamrock-code/Shamrock/refs/heads/metrics-history/output/codegen_time_top10.json",
-        "https://cdn.jsdelivr.net/gh/Shamrock-code/Shamrock@metrics-history/output/codegen_time_top10.json",
-      ];
-      // Vertical markers on the date axis (ISO datetime, UTC).
-      const PLOT_EVENTS = [
-        { date: "2026-08-17T13:43:38Z", text: "force -j 4 in gh-runners" },
-      ];
-
-      function parentTheme() {
-        try {
-          if (window.parent && window.parent !== window) {
-            const theme = window.parent.document.documentElement.getAttribute("data-theme");
-            if (theme === "dark" || theme === "light") {
-              return theme;
-            }
-          }
-        } catch (err) {
-          /* Cross-origin parent: fall back to prefers-color-scheme. */
-        }
-        return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-      }
-
-      function applyTheme(theme) {
-        document.documentElement.setAttribute("data-theme", theme);
-      }
-
-      function eventDecorations(theme, traces) {
-        const dark = theme === "dark";
-        const color = dark ? "#fabd2f" : "#b57614";
-        const bgcolor = dark ? "rgba(40, 40, 40, 0.9)" : "rgba(255, 255, 255, 0.9)";
-        let xMin = null;
-        let xMax = null;
-        const xs = traces && traces[0] && traces[0].x;
-        if (xs && xs.length > 0) {
-          xMin = Date.parse(xs[0]);
-          xMax = Date.parse(xs[xs.length - 1]);
-        }
-        const shapes = [];
-        const annotations = [];
-        for (const event of PLOT_EVENTS) {
-          const eventMs = Date.parse(event.date);
-          const nearEnd =
-            xMin !== null && xMax !== null && xMax > xMin
-              ? (eventMs - xMin) / (xMax - xMin) > 0.7
-              : true;
-          shapes.push({
-            type: "line",
-            x0: event.date,
-            x1: event.date,
-            y0: 0,
-            y1: 1,
-            xref: "x",
-            yref: "paper",
-            line: { color, width: 1.5, dash: "dot" },
-          });
-          annotations.push({
-            x: event.date,
-            y: 0.98,
-            xref: "x",
-            yref: "paper",
-            text: event.text,
-            showarrow: false,
-            xanchor: nearEnd ? "right" : "left",
-            yanchor: "top",
-            xshift: nearEnd ? -8 : 8,
-            font: { color, size: 12 },
-            bgcolor,
-            bordercolor: color,
-            borderwidth: 1,
-            borderpad: 4,
-          });
-        }
-        return { shapes, annotations };
-      }
-
-      function themedLayout(baseLayout, theme, traces) {
-        const dark = theme === "dark";
-        const bg = dark ? "#282828" : "#fff";
-        const fg = dark ? "#ebdbb2" : "#3c3836";
-        const muted = dark ? "#a89984" : "#665c54";
-        const grid = dark ? "#504945" : "#d5c4a1";
-        const layout = Object.assign({}, baseLayout || {});
-        const title = Object.assign({}, layout.title || {});
-        title.font = Object.assign({ size: 18 }, title.font || {}, { color: fg });
-        layout.title = title;
-        layout.paper_bgcolor = bg;
-        layout.plot_bgcolor = bg;
-        layout.font = Object.assign({}, layout.font || {}, { color: fg });
-        layout.xaxis = Object.assign({}, layout.xaxis || {}, {
-          gridcolor: grid,
-          zerolinecolor: grid,
-          linecolor: muted,
-          tickfont: { color: muted },
-        });
-        layout.yaxis = Object.assign({}, layout.yaxis || {}, {
-          gridcolor: grid,
-          zerolinecolor: grid,
-          linecolor: muted,
-          tickfont: { color: muted },
-        });
-        const events = eventDecorations(theme, traces);
-        layout.shapes = events.shapes;
-        layout.annotations = events.annotations;
-        return layout;
-      }
-
-      function plotlyTraces(payload) {
-        if (!payload || !Array.isArray(payload.data)) {
-          throw new Error("Unexpected dataset shape: missing Plotly data[]");
-        }
-        return payload.data.filter(
-          (trace) =>
-            trace &&
-            Array.isArray(trace.x) &&
-            Array.isArray(trace.y) &&
-            trace.x.length === trace.y.length &&
-            trace.x.length > 0
-        );
-      }
-
-      async function fetchDataset() {
-        const errors = [];
-        for (const url of DATA_URLS) {
-          try {
-            const response = await fetch(url, { cache: "no-store" });
-            if (!response.ok) {
-              throw new Error(`${response.status} ${response.statusText}`);
-            }
-            return await response.json();
-          } catch (err) {
-            errors.push(`${url}: ${err.message}`);
-          }
-        }
-        throw new Error(errors.join("; "));
-      }
-
-      function setStatus(message) {
-        const status = document.getElementById("status");
-        if (message) {
-          status.textContent = message;
-          status.hidden = false;
-        } else {
-          status.hidden = true;
-        }
-      }
-
-      async function main() {
-        const chart = document.getElementById("chart");
-        let theme = parentTheme();
-        applyTheme(theme);
-
-        let payload;
-        try {
-          payload = await fetchDataset();
-        } catch (err) {
-          setStatus(`Could not load codegen time history.\n${err.message}`);
-          return;
-        }
-
-        const traces = plotlyTraces(payload);
-        if (traces.length === 0) {
-          setStatus("The codegen time dataset is empty.");
-          return;
-        }
-
-        const config = { responsive: true, displaylogo: false };
-        await Plotly.newPlot(chart, traces, themedLayout(payload.layout, theme, traces), config);
-        setStatus("");
-
-        const restyle = () => {
-          theme = parentTheme();
-          applyTheme(theme);
-          Plotly.react(chart, traces, themedLayout(payload.layout, theme, traces));
-        };
-
-        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", restyle);
-
-        try {
-          if (window.parent && window.parent !== window) {
-            const observer = new MutationObserver(restyle);
-            observer.observe(window.parent.document.documentElement, {
-              attributes: true,
-              attributeFilter: ["data-theme"],
-            });
-          }
-        } catch (err) {
-          /* Ignore if the parent document is not readable. */
-        }
-      }
-
-      main();
+      MetricsChart.mount({
+        urls: MetricsChart.metricsUrls("codegen_time_top10.json"),
+        loading: "Loading codegen time history…",
+        empty: "The codegen time dataset is empty.",
+        error: "Could not load codegen time history.",
+        events: true,
+        makePlot: function (payload, theme) {
+          const traces = MetricsChart.plotlyTraces(payload);
+          return {
+            traces: traces,
+            layout: MetricsChart.themedLayout(payload.layout, theme, { traces: traces }),
+          };
+        },
+      });
     </script>
   </body>
 </html>

--- a/doc/sphinx/source/_static/compile_memory_top10.html
+++ b/doc/sphinx/source/_static/compile_memory_top10.html
@@ -5,194 +5,26 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Top 10 compile peak RSS</title>
     <script src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.3/plotly.min.js"></script>
-    <style>
-      :root {
-        --bg: #fff;
-        --fg: #3c3836;
-        --muted: #665c54;
-        --grid: #d5c4a1;
-      }
-
-      html[data-theme="dark"] {
-        --bg: #282828;
-        --fg: #ebdbb2;
-        --muted: #a89984;
-        --grid: #504945;
-      }
-
-      html,
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        overflow: hidden;
-        background: var(--bg);
-        color: var(--fg);
-        font-family: system-ui, sans-serif;
-      }
-
-      #chart {
-        width: 100%;
-        height: 100%;
-      }
-
-      #status {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1rem;
-        text-align: center;
-        color: var(--muted);
-      }
-
-      #status[hidden] {
-        display: none;
-      }
-    </style>
+    <link rel="stylesheet" href="css/metrics-chart.css" />
   </head>
   <body>
     <div id="status">Loading compile peak RSS history…</div>
     <div id="chart"></div>
+    <script src="js/metrics-chart.js"></script>
     <script>
-      const DATA_URLS = [
-        "https://raw.githubusercontent.com/Shamrock-code/Shamrock/refs/heads/metrics-history/output/compile_memory_top10.json",
-        "https://cdn.jsdelivr.net/gh/Shamrock-code/Shamrock@metrics-history/output/compile_memory_top10.json",
-      ];
-
-      function parentTheme() {
-        try {
-          if (window.parent && window.parent !== window) {
-            const theme = window.parent.document.documentElement.getAttribute("data-theme");
-            if (theme === "dark" || theme === "light") {
-              return theme;
-            }
-          }
-        } catch (err) {
-          /* Cross-origin parent: fall back to prefers-color-scheme. */
-        }
-        return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-      }
-
-      function applyTheme(theme) {
-        document.documentElement.setAttribute("data-theme", theme);
-      }
-
-      function themedLayout(baseLayout, theme) {
-        const dark = theme === "dark";
-        const bg = dark ? "#282828" : "#fff";
-        const fg = dark ? "#ebdbb2" : "#3c3836";
-        const muted = dark ? "#a89984" : "#665c54";
-        const grid = dark ? "#504945" : "#d5c4a1";
-        const layout = Object.assign({}, baseLayout || {});
-        const title = Object.assign({}, layout.title || {});
-        title.font = Object.assign({ size: 18 }, title.font || {}, { color: fg });
-        layout.title = title;
-        layout.paper_bgcolor = bg;
-        layout.plot_bgcolor = bg;
-        layout.font = Object.assign({}, layout.font || {}, { color: fg });
-        layout.xaxis = Object.assign({}, layout.xaxis || {}, {
-          gridcolor: grid,
-          zerolinecolor: grid,
-          linecolor: muted,
-          tickfont: { color: muted },
-        });
-        layout.yaxis = Object.assign({}, layout.yaxis || {}, {
-          gridcolor: grid,
-          zerolinecolor: grid,
-          linecolor: muted,
-          tickfont: { color: muted },
-        });
-        return layout;
-      }
-
-      function plotlyTraces(payload) {
-        if (!payload || !Array.isArray(payload.data)) {
-          throw new Error("Unexpected dataset shape: missing Plotly data[]");
-        }
-        return payload.data.filter(
-          (trace) =>
-            trace &&
-            Array.isArray(trace.x) &&
-            Array.isArray(trace.y) &&
-            trace.x.length === trace.y.length &&
-            trace.x.length > 0
-        );
-      }
-
-      async function fetchDataset() {
-        const errors = [];
-        for (const url of DATA_URLS) {
-          try {
-            const response = await fetch(url, { cache: "no-store" });
-            if (!response.ok) {
-              throw new Error(`${response.status} ${response.statusText}`);
-            }
-            return await response.json();
-          } catch (err) {
-            errors.push(`${url}: ${err.message}`);
-          }
-        }
-        throw new Error(errors.join("; "));
-      }
-
-      function setStatus(message) {
-        const status = document.getElementById("status");
-        if (message) {
-          status.textContent = message;
-          status.hidden = false;
-        } else {
-          status.hidden = true;
-        }
-      }
-
-      async function main() {
-        const chart = document.getElementById("chart");
-        let theme = parentTheme();
-        applyTheme(theme);
-
-        let payload;
-        try {
-          payload = await fetchDataset();
-        } catch (err) {
-          setStatus(`Could not load compile peak RSS history.\n${err.message}`);
-          return;
-        }
-
-        const traces = plotlyTraces(payload);
-        if (traces.length === 0) {
-          setStatus("The compile peak RSS dataset is empty.");
-          return;
-        }
-
-        const config = { responsive: true, displaylogo: false };
-        await Plotly.newPlot(chart, traces, themedLayout(payload.layout, theme), config);
-        setStatus("");
-
-        const restyle = () => {
-          theme = parentTheme();
-          applyTheme(theme);
-          Plotly.react(chart, traces, themedLayout(payload.layout, theme));
-        };
-
-        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", restyle);
-
-        try {
-          if (window.parent && window.parent !== window) {
-            const observer = new MutationObserver(restyle);
-            observer.observe(window.parent.document.documentElement, {
-              attributes: true,
-              attributeFilter: ["data-theme"],
-            });
-          }
-        } catch (err) {
-          /* Ignore if the parent document is not readable. */
-        }
-      }
-
-      main();
+      MetricsChart.mount({
+        urls: MetricsChart.metricsUrls("compile_memory_top10.json"),
+        loading: "Loading compile peak RSS history…",
+        empty: "The compile peak RSS dataset is empty.",
+        error: "Could not load compile peak RSS history.",
+        makePlot: function (payload, theme) {
+          const traces = MetricsChart.plotlyTraces(payload);
+          return {
+            traces: traces,
+            layout: MetricsChart.themedLayout(payload.layout, theme),
+          };
+        },
+      });
     </script>
   </body>
 </html>

--- a/doc/sphinx/source/_static/css/metrics-chart.css
+++ b/doc/sphinx/source/_static/css/metrics-chart.css
@@ -1,0 +1,45 @@
+:root {
+  --bg: #fff;
+  --fg: #3c3836;
+  --muted: #665c54;
+  --grid: #d5c4a1;
+}
+
+html[data-theme="dark"] {
+  --bg: #282828;
+  --fg: #ebdbb2;
+  --muted: #a89984;
+  --grid: #504945;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: system-ui, sans-serif;
+}
+
+#chart {
+  width: 100%;
+  height: 100%;
+}
+
+#status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+#status[hidden] {
+  display: none;
+}

--- a/doc/sphinx/source/_static/doxygen_warnings.html
+++ b/doc/sphinx/source/_static/doxygen_warnings.html
@@ -5,138 +5,38 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Doxygen warning count</title>
     <script src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.3/plotly.min.js"></script>
-    <style>
-      :root {
-        --bg: #fff;
-        --fg: #3c3836;
-        --muted: #665c54;
-        --grid: #d5c4a1;
-        --line: #076678;
-      }
-
-      html[data-theme="dark"] {
-        --bg: #282828;
-        --fg: #ebdbb2;
-        --muted: #a89984;
-        --grid: #504945;
-        --line: #83a598;
-      }
-
-      html,
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        overflow: hidden;
-        background: var(--bg);
-        color: var(--fg);
-        font-family: system-ui, sans-serif;
-      }
-
-      #chart {
-        width: 100%;
-        height: 100%;
-      }
-
-      #status {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1rem;
-        text-align: center;
-        color: var(--muted);
-      }
-
-      #status[hidden] {
-        display: none;
-      }
-    </style>
+    <link rel="stylesheet" href="css/metrics-chart.css" />
   </head>
   <body>
     <div id="status">Loading Doxygen warning history…</div>
     <div id="chart"></div>
+    <script src="js/metrics-chart.js"></script>
     <script>
-      const DATA_URLS = [
-        "https://raw.githubusercontent.com/Shamrock-code/Shamrock/refs/heads/metrics-history/output/doxygen_warnings.json",
-        "https://cdn.jsdelivr.net/gh/Shamrock-code/Shamrock@metrics-history/output/doxygen_warnings.json",
-      ];
-
-      function parentTheme() {
-        try {
-          if (window.parent && window.parent !== window) {
-            const theme = window.parent.document.documentElement.getAttribute("data-theme");
-            if (theme === "dark" || theme === "light") {
-              return theme;
-            }
-          }
-        } catch (err) {
-          /* Cross-origin parent: fall back to prefers-color-scheme. */
-        }
-        return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-      }
-
-      function applyTheme(theme) {
-        document.documentElement.setAttribute("data-theme", theme);
-      }
-
-      function paddedRange(values, integer) {
-        const nums = values.filter((value) => typeof value === "number" && Number.isFinite(value));
-        if (nums.length === 0) {
-          return undefined;
-        }
-        const min = Math.min(...nums);
-        const max = Math.max(...nums);
-        const span = max - min;
-        const pad = span === 0 ? Math.max(Math.abs(min) * 0.05, integer ? 1 : 0.05) : span * 0.1;
-        let lo = min - pad;
-        let hi = max + pad;
-        if (integer) {
-          lo = Math.floor(lo);
-          hi = Math.ceil(hi);
-          if (lo === hi) {
-            lo -= 1;
-            hi += 1;
-          }
-        }
-        if (min >= 0) {
-          lo = Math.max(0, lo);
-        }
-        return [lo, hi];
-      }
-
       function chartLayout(theme, series) {
-        const dark = theme === "dark";
-        const bg = dark ? "#282828" : "#fff";
-        const fg = dark ? "#ebdbb2" : "#3c3836";
-        const muted = dark ? "#a89984" : "#665c54";
-        const grid = dark ? "#504945" : "#d5c4a1";
+        const colors = MetricsChart.themeColors(theme);
+        const axis = MetricsChart.axisStyle(theme);
         return {
-          title: { text: "Doxygen warning count", font: { color: fg, size: 18 } },
+          title: { text: "Doxygen warning count", font: { color: colors.fg, size: 18 } },
           margin: { l: 64, r: 24, t: 48, b: 56 },
-          paper_bgcolor: bg,
-          plot_bgcolor: bg,
-          font: { color: fg },
-          xaxis: {
-            title: { text: "Date (UTC)" },
-            type: "date",
-            gridcolor: grid,
-            zerolinecolor: grid,
-            linecolor: muted,
-            tickfont: { color: muted },
-          },
-          yaxis: {
-            title: { text: "Warning count" },
-            gridcolor: grid,
-            zerolinecolor: grid,
-            linecolor: muted,
-            tickfont: { color: muted },
-            tickformat: "d",
-            autorange: false,
-            range: paddedRange(series.y, true),
-          },
+          paper_bgcolor: colors.bg,
+          plot_bgcolor: colors.bg,
+          font: { color: colors.fg },
+          xaxis: Object.assign(
+            {
+              title: { text: "Date (UTC)" },
+              type: "date",
+            },
+            axis
+          ),
+          yaxis: Object.assign(
+            {
+              title: { text: "Warning count" },
+              tickformat: "d",
+              autorange: false,
+              range: MetricsChart.paddedRange(series.y, true),
+            },
+            axis
+          ),
           hovermode: "x unified",
         };
       }
@@ -146,125 +46,52 @@
           throw new Error("Unexpected dataset shape: missing data[]");
         }
         const rows = payload.data
-          .filter(
-            (row) =>
-              row &&
-              typeof row.datetime === "string" &&
-              Number.isFinite(Number(row.doxygen_warning_count))
-          )
+          .filter(function (row) {
+            return row && typeof row.datetime === "string" && Number.isFinite(Number(row.doxygen_warning_count));
+          })
           .slice()
-          .sort((a, b) => a.datetime.localeCompare(b.datetime));
+          .sort(function (a, b) {
+            return a.datetime.localeCompare(b.datetime);
+          });
         return {
-          x: rows.map((row) => row.datetime),
-          y: rows.map((row) => Number(row.doxygen_warning_count)),
+          x: rows.map(function (row) {
+            return row.datetime;
+          }),
+          y: rows.map(function (row) {
+            return Number(row.doxygen_warning_count);
+          }),
         };
       }
 
-      async function fetchDataset() {
-        const errors = [];
-        for (const url of DATA_URLS) {
-          try {
-            const response = await fetch(url, { cache: "no-store" });
-            if (!response.ok) {
-              throw new Error(`${response.status} ${response.statusText}`);
-            }
-            return await response.json();
-          } catch (err) {
-            errors.push(`${url}: ${err.message}`);
+      function traces(theme, series) {
+        const lineColor = MetricsChart.themeColors(theme).parsing;
+        return [
+          {
+            type: "scatter",
+            mode: "lines+markers",
+            name: "doxygen_warning_count",
+            x: series.x,
+            y: series.y,
+            line: { color: lineColor, width: 2 },
+            marker: { color: lineColor, size: 8 },
+            hovertemplate: "%{x|%Y-%m-%d %H:%M UTC}<br>warnings: %{y}<extra></extra>",
+          },
+        ];
+      }
+
+      MetricsChart.mount({
+        urls: MetricsChart.metricsUrls("doxygen_warnings.json"),
+        loading: "Loading Doxygen warning history…",
+        empty: "The Doxygen warning dataset is empty.",
+        error: "Could not load Doxygen warning history.",
+        makePlot: function (payload, theme) {
+          const series = toSeries(payload);
+          if (series.x.length === 0) {
+            return { traces: [] };
           }
-        }
-        throw new Error(errors.join("; "));
-      }
-
-      function setStatus(message) {
-        const status = document.getElementById("status");
-        if (message) {
-          status.textContent = message;
-          status.hidden = false;
-        } else {
-          status.hidden = true;
-        }
-      }
-
-      async function main() {
-        const chart = document.getElementById("chart");
-        let theme = parentTheme();
-        applyTheme(theme);
-
-        let payload;
-        try {
-          payload = await fetchDataset();
-        } catch (err) {
-          setStatus(`Could not load Doxygen warning history.\n${err.message}`);
-          return;
-        }
-
-        const series = toSeries(payload);
-        if (series.x.length === 0) {
-          setStatus("The Doxygen warning dataset is empty.");
-          return;
-        }
-
-        const lineColor = theme === "dark" ? "#83a598" : "#076678";
-        await Plotly.newPlot(
-          chart,
-          [
-            {
-              type: "scatter",
-              mode: "lines+markers",
-              name: "doxygen_warning_count",
-              x: series.x,
-              y: series.y,
-              line: { color: lineColor, width: 2 },
-              marker: { color: lineColor, size: 8 },
-              hovertemplate:
-                "%{x|%Y-%m-%d %H:%M UTC}<br>warnings: %{y}<extra></extra>",
-            },
-          ],
-          chartLayout(theme, series),
-          { responsive: true, displaylogo: false }
-        );
-        setStatus("");
-
-        const restyle = () => {
-          theme = parentTheme();
-          applyTheme(theme);
-          const nextLine = theme === "dark" ? "#83a598" : "#076678";
-          Plotly.react(
-            chart,
-            [
-              {
-                type: "scatter",
-                mode: "lines+markers",
-                name: "doxygen_warning_count",
-                x: series.x,
-                y: series.y,
-                line: { color: nextLine, width: 2 },
-                marker: { color: nextLine, size: 8 },
-                hovertemplate:
-                  "%{x|%Y-%m-%d %H:%M UTC}<br>warnings: %{y}<extra></extra>",
-              },
-            ],
-            chartLayout(theme, series)
-          );
-        };
-
-        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", restyle);
-
-        try {
-          if (window.parent && window.parent !== window) {
-            const observer = new MutationObserver(restyle);
-            observer.observe(window.parent.document.documentElement, {
-              attributes: true,
-              attributeFilter: ["data-theme"],
-            });
-          }
-        } catch (err) {
-          /* Ignore if the parent document is not readable. */
-        }
-      }
-
-      main();
+          return { traces: traces(theme, series), layout: chartLayout(theme, series) };
+        },
+      });
     </script>
   </body>
 </html>

--- a/doc/sphinx/source/_static/js/metrics-chart.js
+++ b/doc/sphinx/source/_static/js/metrics-chart.js
@@ -1,0 +1,339 @@
+(function (root) {
+  "use strict";
+
+  const PLOT_EVENTS = [{ date: "2026-08-17T13:43:38Z", text: "force -j 4 in gh-runners" }];
+
+  const THEME = {
+    light: {
+      bg: "#fff",
+      fg: "#3c3836",
+      muted: "#665c54",
+      grid: "#d5c4a1",
+      event: "#b57614",
+      eventBg: "rgba(255, 255, 255, 0.9)",
+      parsing: "#076678",
+      codegen: "#af3a03",
+      total: "#79740e",
+      tus: "#8f3f71",
+      palette: ["#076678", "#af3a03", "#79740e", "#8f3f71", "#9d0006", "#427b58", "#b57614", "#d65d0e"],
+    },
+    dark: {
+      bg: "#282828",
+      fg: "#ebdbb2",
+      muted: "#a89984",
+      grid: "#504945",
+      event: "#fabd2f",
+      eventBg: "rgba(40, 40, 40, 0.9)",
+      parsing: "#83a598",
+      codegen: "#fe8019",
+      total: "#b8bb26",
+      tus: "#d3869b",
+      palette: ["#83a598", "#fe8019", "#b8bb26", "#d3869b", "#fb4934", "#8ec07c", "#fabd2f", "#d65d0e"],
+    },
+  };
+
+  function themeColors(theme) {
+    return THEME[theme === "dark" ? "dark" : "light"];
+  }
+
+  function metricsUrls(filename) {
+    return [
+      "https://raw.githubusercontent.com/Shamrock-code/Shamrock/refs/heads/metrics-history/output/" + filename,
+      "https://cdn.jsdelivr.net/gh/Shamrock-code/Shamrock@metrics-history/output/" + filename,
+    ];
+  }
+
+  function parentTheme() {
+    try {
+      if (window.parent && window.parent !== window) {
+        const theme = window.parent.document.documentElement.getAttribute("data-theme");
+        if (theme === "dark" || theme === "light") {
+          return theme;
+        }
+      }
+    } catch (err) {
+      /* Cross-origin parent: fall back to prefers-color-scheme. */
+    }
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+
+  function applyTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme);
+  }
+
+  function finiteNumber(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : null;
+  }
+
+  function paddedRange(values, integer) {
+    const nums = values.filter((value) => typeof value === "number" && Number.isFinite(value));
+    if (nums.length === 0) {
+      return undefined;
+    }
+    const min = Math.min(...nums);
+    const max = Math.max(...nums);
+    const span = max - min;
+    const pad = span === 0 ? Math.max(Math.abs(min) * 0.05, integer ? 1 : 0.05) : span * 0.1;
+    let lo = min - pad;
+    let hi = max + pad;
+    if (integer) {
+      lo = Math.floor(lo);
+      hi = Math.ceil(hi);
+      if (lo === hi) {
+        lo -= 1;
+        hi += 1;
+      }
+    }
+    if (min >= 0) {
+      lo = Math.max(0, lo);
+    }
+    return [lo, hi];
+  }
+
+  function paddedLogRange(values) {
+    const nums = values.filter(
+      (value) => typeof value === "number" && Number.isFinite(value) && value > 0
+    );
+    if (nums.length === 0) {
+      return undefined;
+    }
+    const logMin = Math.log10(Math.min(...nums));
+    const logMax = Math.log10(Math.max(...nums));
+    const span = logMax - logMin;
+    const pad = span === 0 ? 0.1 : span * 0.1;
+    return [logMin - pad, logMax + pad];
+  }
+
+  function axisStyle(theme) {
+    const colors = themeColors(theme);
+    return {
+      gridcolor: colors.grid,
+      zerolinecolor: colors.grid,
+      linecolor: colors.muted,
+      tickfont: { color: colors.muted },
+    };
+  }
+
+  function eventDecorations(theme, xValues, events) {
+    const colors = themeColors(theme);
+    const color = colors.event;
+    const bgcolor = colors.eventBg;
+    const xs = Array.isArray(xValues) ? xValues : [];
+    let xMin = null;
+    let xMax = null;
+    if (xs.length > 0) {
+      xMin = Date.parse(xs[0]);
+      xMax = Date.parse(xs[xs.length - 1]);
+    }
+    const shapes = [];
+    const annotations = [];
+    const markers = events || PLOT_EVENTS;
+    for (let i = 0; i < markers.length; i++) {
+      const event = markers[i];
+      const eventMs = Date.parse(event.date);
+      const nearEnd =
+        xMin !== null && xMax !== null && xMax > xMin ? (eventMs - xMin) / (xMax - xMin) > 0.7 : true;
+      shapes.push({
+        type: "line",
+        x0: event.date,
+        x1: event.date,
+        y0: 0,
+        y1: 1,
+        xref: "x",
+        yref: "paper",
+        line: { color: color, width: 1.5, dash: "dot" },
+      });
+      annotations.push({
+        x: event.date,
+        y: 0.98,
+        xref: "x",
+        yref: "paper",
+        text: event.text,
+        showarrow: false,
+        xanchor: nearEnd ? "right" : "left",
+        yanchor: "top",
+        xshift: nearEnd ? -8 : 8,
+        font: { color: color, size: 12 },
+        bgcolor: bgcolor,
+        bordercolor: color,
+        borderwidth: 1,
+        borderpad: 4,
+      });
+    }
+    return { shapes: shapes, annotations: annotations };
+  }
+
+  function tracesXValues(traces) {
+    if (traces && traces[0] && Array.isArray(traces[0].x)) {
+      return traces[0].x;
+    }
+    return [];
+  }
+
+  function themedLayout(baseLayout, theme, extra) {
+    const colors = themeColors(theme);
+    const layout = Object.assign({}, baseLayout || {});
+    const title = Object.assign({}, layout.title || {});
+    title.font = Object.assign({ size: 18 }, title.font || {}, { color: colors.fg });
+    layout.title = title;
+    layout.paper_bgcolor = colors.bg;
+    layout.plot_bgcolor = colors.bg;
+    layout.font = Object.assign({}, layout.font || {}, { color: colors.fg });
+    layout.xaxis = Object.assign({}, layout.xaxis || {}, axisStyle(theme));
+    layout.yaxis = Object.assign({}, layout.yaxis || {}, axisStyle(theme));
+    const traces = extra && extra.traces;
+    if (traces) {
+      const eventList = Array.isArray(extra.events) ? extra.events : undefined;
+      const events = eventDecorations(theme, tracesXValues(traces), eventList);
+      layout.shapes = events.shapes;
+      layout.annotations = events.annotations;
+    }
+    return layout;
+  }
+
+  function plotlyTraces(payload) {
+    if (!payload || !Array.isArray(payload.data)) {
+      throw new Error("Unexpected dataset shape: missing Plotly data[]");
+    }
+    return payload.data.filter(function (trace) {
+      return (
+        trace &&
+        Array.isArray(trace.x) &&
+        Array.isArray(trace.y) &&
+        trace.x.length === trace.y.length &&
+        trace.x.length > 0
+      );
+    });
+  }
+
+  async function fetchDataset(urls) {
+    const errors = [];
+    for (let i = 0; i < urls.length; i++) {
+      const url = urls[i];
+      try {
+        const response = await fetch(url, { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(response.status + " " + response.statusText);
+        }
+        return await response.json();
+      } catch (err) {
+        errors.push(url + ": " + err.message);
+      }
+    }
+    throw new Error(errors.join("; "));
+  }
+
+  function setStatus(message) {
+    const status = document.getElementById("status");
+    if (!status) {
+      return;
+    }
+    if (message) {
+      status.textContent = message;
+      status.hidden = false;
+    } else {
+      status.hidden = true;
+    }
+  }
+
+  function applyEventDecorations(plot, theme, events) {
+    const xs = tracesXValues(plot.traces);
+    const decorations = eventDecorations(theme, xs, events);
+    plot.layout = Object.assign({}, plot.layout || {}, {
+      shapes: decorations.shapes,
+      annotations: decorations.annotations,
+    });
+    return plot;
+  }
+
+  function mount(options) {
+    const chart = document.getElementById("chart");
+    const loading = options.loading;
+    const empty = options.empty;
+    const error = options.error;
+    const urls = options.urls;
+    const makePlot = options.makePlot;
+    const useEvents = options.events;
+
+    if (loading) {
+      setStatus(loading);
+    }
+
+    function plotFor(payload, theme) {
+      const plot = makePlot(payload, theme) || {};
+      plot.traces = plot.traces || [];
+      plot.layout = plot.layout || {};
+      if (useEvents) {
+        applyEventDecorations(plot, theme);
+      }
+      return plot;
+    }
+
+    function bindTheme(restyle) {
+      window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", restyle);
+      try {
+        if (window.parent && window.parent !== window) {
+          const observer = new MutationObserver(restyle);
+          observer.observe(window.parent.document.documentElement, {
+            attributes: true,
+            attributeFilter: ["data-theme"],
+          });
+        }
+      } catch (err) {
+        /* Ignore if the parent document is not readable. */
+      }
+    }
+
+    async function main() {
+      let theme = parentTheme();
+      applyTheme(theme);
+
+      let payload;
+      try {
+        payload = await fetchDataset(urls);
+      } catch (err) {
+        setStatus(error + "\n" + err.message);
+        return;
+      }
+
+      const first = plotFor(payload, theme);
+      if (!first.traces.length) {
+        setStatus(empty);
+        return;
+      }
+
+      await Plotly.newPlot(chart, first.traces, first.layout, {
+        responsive: true,
+        displaylogo: false,
+      });
+      setStatus("");
+
+      bindTheme(function () {
+        theme = parentTheme();
+        applyTheme(theme);
+        const next = plotFor(payload, theme);
+        Plotly.react(chart, next.traces, next.layout);
+      });
+    }
+
+    main();
+  }
+
+  root.MetricsChart = {
+    PLOT_EVENTS: PLOT_EVENTS,
+    metricsUrls: metricsUrls,
+    themeColors: themeColors,
+    parentTheme: parentTheme,
+    applyTheme: applyTheme,
+    finiteNumber: finiteNumber,
+    paddedRange: paddedRange,
+    paddedLogRange: paddedLogRange,
+    axisStyle: axisStyle,
+    eventDecorations: eventDecorations,
+    themedLayout: themedLayout,
+    fetchDataset: fetchDataset,
+    plotlyTraces: plotlyTraces,
+    mount: mount,
+  };
+})(window);

--- a/doc/sphinx/source/_static/loc.html
+++ b/doc/sphinx/source/_static/loc.html
@@ -5,63 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Lines of code</title>
     <script src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.3/plotly.min.js"></script>
-    <style>
-      :root {
-        --bg: #fff;
-        --fg: #3c3836;
-        --muted: #665c54;
-        --grid: #d5c4a1;
-      }
-
-      html[data-theme="dark"] {
-        --bg: #282828;
-        --fg: #ebdbb2;
-        --muted: #a89984;
-        --grid: #504945;
-      }
-
-      html,
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        overflow: hidden;
-        background: var(--bg);
-        color: var(--fg);
-        font-family: system-ui, sans-serif;
-      }
-
-      #chart {
-        width: 100%;
-        height: 100%;
-      }
-
-      #status {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1rem;
-        text-align: center;
-        color: var(--muted);
-      }
-
-      #status[hidden] {
-        display: none;
-      }
-    </style>
+    <link rel="stylesheet" href="css/metrics-chart.css" />
   </head>
   <body>
     <div id="status">Loading lines of code history…</div>
     <div id="chart"></div>
+    <script src="js/metrics-chart.js"></script>
     <script>
-      const DATA_URLS = [
-        "https://raw.githubusercontent.com/Shamrock-code/Shamrock/refs/heads/metrics-history/output/loc.json",
-        "https://cdn.jsdelivr.net/gh/Shamrock-code/Shamrock@metrics-history/output/loc.json",
-      ];
-
       // Exclusive partitions (code, examples, doc) sum to "all". Nested
       // shammodels/* counts are subsets of code, not extra buckets.
       const AREA_SPECS = [
@@ -87,75 +37,27 @@
 
       const ALL_SPECS = AREA_SPECS.concat(FILETYPE_SPECS);
 
-      function parentTheme() {
-        try {
-          if (window.parent && window.parent !== window) {
-            const theme = window.parent.document.documentElement.getAttribute("data-theme");
-            if (theme === "dark" || theme === "light") {
-              return theme;
-            }
-          }
-        } catch (err) {
-          /* Cross-origin parent: fall back to prefers-color-scheme. */
-        }
-        return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-      }
-
-      function applyTheme(theme) {
-        document.documentElement.setAttribute("data-theme", theme);
-      }
-
-      function palette(theme) {
-        return theme === "dark"
-          ? ["#83a598", "#fe8019", "#b8bb26", "#d3869b", "#fb4934", "#8ec07c", "#fabd2f", "#d65d0e"]
-          : ["#076678", "#af3a03", "#79740e", "#8f3f71", "#9d0006", "#427b58", "#b57614", "#d65d0e"];
-      }
-
-      // Plotly log-axis range is log10 of the linear limits.
-      function paddedLogRange(values) {
-        const nums = values.filter(
-          (value) => typeof value === "number" && Number.isFinite(value) && value > 0
-        );
-        if (nums.length === 0) {
-          return undefined;
-        }
-        const logMin = Math.log10(Math.min(...nums));
-        const logMax = Math.log10(Math.max(...nums));
-        const span = logMax - logMin;
-        const pad = span === 0 ? 0.1 : span * 0.1;
-        return [logMin - pad, logMax + pad];
-      }
-
       function hasValues(values) {
-        return values.some((value) => typeof value === "number" && Number.isFinite(value));
+        return values.some(function (value) {
+          return typeof value === "number" && Number.isFinite(value);
+        });
       }
 
       function collectedValues(series, specs) {
-        return specs.reduce((acc, spec) => acc.concat(series[spec.key] || []), []);
-      }
-
-      function axisStyle(muted, grid) {
-        return {
-          gridcolor: grid,
-          zerolinecolor: grid,
-          linecolor: muted,
-          tickfont: { color: muted },
-        };
+        return specs.reduce(function (acc, spec) {
+          return acc.concat(series[spec.key] || []);
+        }, []);
       }
 
       function chartLayout(theme, series) {
-        const dark = theme === "dark";
-        const bg = dark ? "#282828" : "#fff";
-        const fg = dark ? "#ebdbb2" : "#3c3836";
-        const muted = dark ? "#a89984" : "#665c54";
-        const grid = dark ? "#504945" : "#d5c4a1";
-        const axis = axisStyle(muted, grid);
+        const colors = MetricsChart.themeColors(theme);
+        const axis = MetricsChart.axisStyle(theme);
         return {
-          title: { text: "Lines of code", font: { color: fg, size: 18 } },
+          title: { text: "Lines of code", font: { color: colors.fg, size: 18 } },
           margin: { l: 72, r: 24, t: 48, b: 96 },
-          paper_bgcolor: bg,
-          plot_bgcolor: bg,
-          font: { color: fg },
+          paper_bgcolor: colors.bg,
+          plot_bgcolor: colors.bg,
+          font: { color: colors.fg },
           grid: {
             rows: 2,
             columns: 1,
@@ -167,43 +69,41 @@
             orientation: "h",
             x: 0,
             y: -0.12,
-            font: { color: fg },
+            font: { color: colors.fg },
             bgcolor: "rgba(0,0,0,0)",
             borderwidth: 0,
           },
-          xaxis: {
-            type: "date",
-            ...axis,
-          },
-          yaxis: {
-            title: { text: "By area" },
-            type: "log",
-            tickformat: ",d",
-            autorange: false,
-            range: paddedLogRange(collectedValues(series, AREA_SPECS)),
-            ...axis,
-          },
-          xaxis2: {
-            title: { text: "Date (UTC)" },
-            type: "date",
-            matches: "x",
-            ...axis,
-          },
-          yaxis2: {
-            title: { text: "By file type" },
-            type: "log",
-            tickformat: ",d",
-            autorange: false,
-            range: paddedLogRange(collectedValues(series, FILETYPE_SPECS)),
-            ...axis,
-          },
+          xaxis: Object.assign({ type: "date" }, axis),
+          yaxis: Object.assign(
+            {
+              title: { text: "By area" },
+              type: "log",
+              tickformat: ",d",
+              autorange: false,
+              range: MetricsChart.paddedLogRange(collectedValues(series, AREA_SPECS)),
+            },
+            axis
+          ),
+          xaxis2: Object.assign(
+            {
+              title: { text: "Date (UTC)" },
+              type: "date",
+              matches: "x",
+            },
+            axis
+          ),
+          yaxis2: Object.assign(
+            {
+              title: { text: "By file type" },
+              type: "log",
+              tickformat: ",d",
+              autorange: false,
+              range: MetricsChart.paddedLogRange(collectedValues(series, FILETYPE_SPECS)),
+            },
+            axis
+          ),
           hovermode: "x unified",
         };
-      }
-
-      function finiteNumber(value) {
-        const number = Number(value);
-        return Number.isFinite(number) ? number : null;
       }
 
       function toSeries(payload) {
@@ -211,18 +111,29 @@
           throw new Error("Unexpected dataset shape: missing data[]");
         }
         const rows = payload.data
-          .filter((row) => row && typeof row.datetime === "string")
+          .filter(function (row) {
+            return row && typeof row.datetime === "string";
+          })
           .slice()
-          .sort((a, b) => a.datetime.localeCompare(b.datetime));
-        const series = { x: rows.map((row) => row.datetime) };
-        ALL_SPECS.forEach((spec) => {
-          series[spec.key] = rows.map((row) => finiteNumber(row[spec.key]));
+          .sort(function (a, b) {
+            return a.datetime.localeCompare(b.datetime);
+          });
+        const series = {
+          x: rows.map(function (row) {
+            return row.datetime;
+          }),
+        };
+        ALL_SPECS.forEach(function (spec) {
+          series[spec.key] = rows.map(function (row) {
+            return MetricsChart.finiteNumber(row[spec.key]);
+          });
         });
         return series;
       }
 
       function traceFor(theme, series, spec, index, axis) {
-        const color = palette(theme)[index % palette(theme).length];
+        const palette = MetricsChart.themeColors(theme).palette;
+        const color = palette[index % palette.length];
         return {
           type: "scatter",
           mode: "lines+markers",
@@ -233,23 +144,23 @@
           yaxis: axis.y,
           legendgroup: spec.key,
           line: {
-            color,
+            color: color,
             width: spec.key === "all" ? 3 : 2,
             dash: spec.nested ? "dash" : "solid",
           },
-          marker: { color, size: 8 },
+          marker: { color: color, size: 8 },
           hovertemplate: "%{fullData.name}: %{y:,}<extra></extra>",
         };
       }
 
       function traces(theme, series) {
         const result = [];
-        AREA_SPECS.forEach((spec, index) => {
+        AREA_SPECS.forEach(function (spec, index) {
           if (hasValues(series[spec.key])) {
             result.push(traceFor(theme, series, spec, index, { x: "x", y: "y" }));
           }
         });
-        FILETYPE_SPECS.forEach((spec, index) => {
+        FILETYPE_SPECS.forEach(function (spec, index) {
           if (hasValues(series[spec.key])) {
             result.push(traceFor(theme, series, spec, index, { x: "x2", y: "y2" }));
           }
@@ -257,79 +168,20 @@
         return result;
       }
 
-      async function fetchDataset() {
-        const errors = [];
-        for (const url of DATA_URLS) {
-          try {
-            const response = await fetch(url, { cache: "no-store" });
-            if (!response.ok) {
-              throw new Error(`${response.status} ${response.statusText}`);
-            }
-            return await response.json();
-          } catch (err) {
-            errors.push(`${url}: ${err.message}`);
+      MetricsChart.mount({
+        urls: MetricsChart.metricsUrls("loc.json"),
+        loading: "Loading lines of code history…",
+        empty: "The lines of code dataset is empty.",
+        error: "Could not load lines of code history.",
+        makePlot: function (payload, theme) {
+          const series = toSeries(payload);
+          const plotTraces = traces(theme, series);
+          if (series.x.length === 0 || plotTraces.length === 0) {
+            return { traces: [] };
           }
-        }
-        throw new Error(errors.join("; "));
-      }
-
-      function setStatus(message) {
-        const status = document.getElementById("status");
-        if (message) {
-          status.textContent = message;
-          status.hidden = false;
-        } else {
-          status.hidden = true;
-        }
-      }
-
-      async function main() {
-        const chart = document.getElementById("chart");
-        let theme = parentTheme();
-        applyTheme(theme);
-
-        let payload;
-        try {
-          payload = await fetchDataset();
-        } catch (err) {
-          setStatus(`Could not load lines of code history.\n${err.message}`);
-          return;
-        }
-
-        const series = toSeries(payload);
-        if (series.x.length === 0 || traces(theme, series).length === 0) {
-          setStatus("The lines of code dataset is empty.");
-          return;
-        }
-
-        await Plotly.newPlot(chart, traces(theme, series), chartLayout(theme, series), {
-          responsive: true,
-          displaylogo: false,
-        });
-        setStatus("");
-
-        const restyle = () => {
-          theme = parentTheme();
-          applyTheme(theme);
-          Plotly.react(chart, traces(theme, series), chartLayout(theme, series));
-        };
-
-        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", restyle);
-
-        try {
-          if (window.parent && window.parent !== window) {
-            const observer = new MutationObserver(restyle);
-            observer.observe(window.parent.document.documentElement, {
-              attributes: true,
-              attributeFilter: ["data-theme"],
-            });
-          }
-        } catch (err) {
-          /* Ignore if the parent document is not readable. */
-        }
-      }
-
-      main();
+          return { traces: plotTraces, layout: chartLayout(theme, series) };
+        },
+      });
     </script>
   </body>
 </html>

--- a/doc/sphinx/source/_static/parse_time_top10.html
+++ b/doc/sphinx/source/_static/parse_time_top10.html
@@ -5,250 +5,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Top 10 files that took longest to parse</title>
     <script src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.3/plotly.min.js"></script>
-    <style>
-      :root {
-        --bg: #fff;
-        --fg: #3c3836;
-        --muted: #665c54;
-        --grid: #d5c4a1;
-      }
-
-      html[data-theme="dark"] {
-        --bg: #282828;
-        --fg: #ebdbb2;
-        --muted: #a89984;
-        --grid: #504945;
-      }
-
-      html,
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        overflow: hidden;
-        background: var(--bg);
-        color: var(--fg);
-        font-family: system-ui, sans-serif;
-      }
-
-      #chart {
-        width: 100%;
-        height: 100%;
-      }
-
-      #status {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1rem;
-        text-align: center;
-        color: var(--muted);
-      }
-
-      #status[hidden] {
-        display: none;
-      }
-    </style>
+    <link rel="stylesheet" href="css/metrics-chart.css" />
   </head>
   <body>
     <div id="status">Loading parse time history…</div>
     <div id="chart"></div>
+    <script src="js/metrics-chart.js"></script>
     <script>
-      const DATA_URLS = [
-        "https://raw.githubusercontent.com/Shamrock-code/Shamrock/refs/heads/metrics-history/output/parse_time_top10.json",
-        "https://cdn.jsdelivr.net/gh/Shamrock-code/Shamrock@metrics-history/output/parse_time_top10.json",
-      ];
-      // Vertical markers on the date axis (ISO datetime, UTC).
-      const PLOT_EVENTS = [
-        { date: "2026-08-17T13:43:38Z", text: "force -j 4 in gh-runners" },
-      ];
-
-      function parentTheme() {
-        try {
-          if (window.parent && window.parent !== window) {
-            const theme = window.parent.document.documentElement.getAttribute("data-theme");
-            if (theme === "dark" || theme === "light") {
-              return theme;
-            }
-          }
-        } catch (err) {
-          /* Cross-origin parent: fall back to prefers-color-scheme. */
-        }
-        return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-      }
-
-      function applyTheme(theme) {
-        document.documentElement.setAttribute("data-theme", theme);
-      }
-
-      function eventDecorations(theme, traces) {
-        const dark = theme === "dark";
-        const color = dark ? "#fabd2f" : "#b57614";
-        const bgcolor = dark ? "rgba(40, 40, 40, 0.9)" : "rgba(255, 255, 255, 0.9)";
-        let xMin = null;
-        let xMax = null;
-        const xs = traces && traces[0] && Array.isArray(traces[0].x) ? traces[0].x : [];
-        if (xs.length > 0) {
-          xMin = Date.parse(xs[0]);
-          xMax = Date.parse(xs[xs.length - 1]);
-        }
-        const shapes = [];
-        const annotations = [];
-        for (const event of PLOT_EVENTS) {
-          const eventMs = Date.parse(event.date);
-          const nearEnd =
-            xMin !== null && xMax !== null && xMax > xMin
-              ? (eventMs - xMin) / (xMax - xMin) > 0.7
-              : true;
-          shapes.push({
-            type: "line",
-            x0: event.date,
-            x1: event.date,
-            y0: 0,
-            y1: 1,
-            xref: "x",
-            yref: "paper",
-            line: { color, width: 1.5, dash: "dot" },
-          });
-          annotations.push({
-            x: event.date,
-            y: 0.98,
-            xref: "x",
-            yref: "paper",
-            text: event.text,
-            showarrow: false,
-            xanchor: nearEnd ? "right" : "left",
-            yanchor: "top",
-            xshift: nearEnd ? -8 : 8,
-            font: { color, size: 12 },
-            bgcolor,
-            bordercolor: color,
-            borderwidth: 1,
-            borderpad: 4,
-          });
-        }
-        return { shapes, annotations };
-      }
-
-      function themedLayout(baseLayout, theme, traces) {
-        const dark = theme === "dark";
-        const bg = dark ? "#282828" : "#fff";
-        const fg = dark ? "#ebdbb2" : "#3c3836";
-        const muted = dark ? "#a89984" : "#665c54";
-        const grid = dark ? "#504945" : "#d5c4a1";
-        const layout = Object.assign({}, baseLayout || {});
-        const title = Object.assign({}, layout.title || {});
-        title.font = Object.assign({ size: 18 }, title.font || {}, { color: fg });
-        layout.title = title;
-        layout.paper_bgcolor = bg;
-        layout.plot_bgcolor = bg;
-        layout.font = Object.assign({}, layout.font || {}, { color: fg });
-        layout.xaxis = Object.assign({}, layout.xaxis || {}, {
-          gridcolor: grid,
-          zerolinecolor: grid,
-          linecolor: muted,
-          tickfont: { color: muted },
-        });
-        layout.yaxis = Object.assign({}, layout.yaxis || {}, {
-          gridcolor: grid,
-          zerolinecolor: grid,
-          linecolor: muted,
-          tickfont: { color: muted },
-        });
-        const events = eventDecorations(theme, traces);
-        layout.shapes = events.shapes;
-        layout.annotations = events.annotations;
-        return layout;
-      }
-
-      function plotlyTraces(payload) {
-        if (!payload || !Array.isArray(payload.data)) {
-          throw new Error("Unexpected dataset shape: missing Plotly data[]");
-        }
-        return payload.data.filter(
-          (trace) =>
-            trace &&
-            Array.isArray(trace.x) &&
-            Array.isArray(trace.y) &&
-            trace.x.length === trace.y.length &&
-            trace.x.length > 0
-        );
-      }
-
-      async function fetchDataset() {
-        const errors = [];
-        for (const url of DATA_URLS) {
-          try {
-            const response = await fetch(url, { cache: "no-store" });
-            if (!response.ok) {
-              throw new Error(`${response.status} ${response.statusText}`);
-            }
-            return await response.json();
-          } catch (err) {
-            errors.push(`${url}: ${err.message}`);
-          }
-        }
-        throw new Error(errors.join("; "));
-      }
-
-      function setStatus(message) {
-        const status = document.getElementById("status");
-        if (message) {
-          status.textContent = message;
-          status.hidden = false;
-        } else {
-          status.hidden = true;
-        }
-      }
-
-      async function main() {
-        const chart = document.getElementById("chart");
-        let theme = parentTheme();
-        applyTheme(theme);
-
-        let payload;
-        try {
-          payload = await fetchDataset();
-        } catch (err) {
-          setStatus(`Could not load parse time history.\n${err.message}`);
-          return;
-        }
-
-        const traces = plotlyTraces(payload);
-        if (traces.length === 0) {
-          setStatus("The parse time dataset is empty.");
-          return;
-        }
-
-        const config = { responsive: true, displaylogo: false };
-        await Plotly.newPlot(chart, traces, themedLayout(payload.layout, theme, traces), config);
-        setStatus("");
-
-        const restyle = () => {
-          theme = parentTheme();
-          applyTheme(theme);
-          Plotly.react(chart, traces, themedLayout(payload.layout, theme, traces));
-        };
-
-        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", restyle);
-
-        try {
-          if (window.parent && window.parent !== window) {
-            const observer = new MutationObserver(restyle);
-            observer.observe(window.parent.document.documentElement, {
-              attributes: true,
-              attributeFilter: ["data-theme"],
-            });
-          }
-        } catch (err) {
-          /* Ignore if the parent document is not readable. */
-        }
-      }
-
-      main();
+      MetricsChart.mount({
+        urls: MetricsChart.metricsUrls("parse_time_top10.json"),
+        loading: "Loading parse time history…",
+        empty: "The parse time dataset is empty.",
+        error: "Could not load parse time history.",
+        events: true,
+        makePlot: function (payload, theme) {
+          const traces = MetricsChart.plotlyTraces(payload);
+          return {
+            traces: traces,
+            layout: MetricsChart.themedLayout(payload.layout, theme, { traces: traces }),
+          };
+        },
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
Extract the duplicated Gruvbox theme, dual-URL fetch, event markers, and boot loop into metrics-chart.css/js so each chart page only keeps its dataset wiring, traces, and layout.