### PR TITLE
[Base] Stop pulling string.hpp and fmt into ubiquitous headers

### DIFF
--- a/src/shambackends/include/shambackends/EventList.hpp
+++ b/src/shambackends/include/shambackends/EventList.hpp
@@ -16,6 +16,7 @@
  */
 
 #include "shambase/stacktrace.hpp"
+#include "sham/format/format.hpp"
 #include "shambackends/DeviceContext.hpp"
 
 namespace sham {

--- a/src/shambackends/include/shambackends/gpu_core_timeline.hpp
+++ b/src/shambackends/include/shambackends/gpu_core_timeline.hpp
@@ -26,6 +26,8 @@
 #include "shamcomm/logs.hpp"
 #include <shambackends/sycl.hpp>
 #include <unordered_map>
+#include <fstream>
+#include <iostream>
 #include <vector>
 
 #if __has_include(<nlohmann/json.hpp>)

--- a/src/shambackends/src/SyclMpiTypes.cpp
+++ b/src/shambackends/src/SyclMpiTypes.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "shambackends/SyclMpiTypes.hpp"
+#include "shambase/exception.hpp"
 #include "shamcomm/logs.hpp"
 #include "shamcomm/mpiErrorCheck.hpp"
 

--- a/src/shambase/include/shambase/logs/msgformat.hpp
+++ b/src/shambase/include/shambase/logs/msgformat.hpp
@@ -18,7 +18,9 @@
 
 #include "shambase/aliases_int.hpp"
 #include "shambase/print.hpp"
-#include "shambase/string.hpp"
+#include "sham/format/format.hpp"
+#include <type_traits>
+#include <string>
 
 namespace shambase::logs {
 

--- a/src/shambase/include/shambase/logs/printer_base.hpp
+++ b/src/shambase/include/shambase/logs/printer_base.hpp
@@ -19,7 +19,6 @@
 #include "shambase/aliases_int.hpp"
 #include "shambase/logs/msgformat.hpp"
 #include "shambase/print.hpp"
-#include "shambase/string.hpp"
 
 namespace shambase::logs {
 

--- a/src/shambase/include/shambase/memory.hpp
+++ b/src/shambase/include/shambase/memory.hpp
@@ -18,10 +18,12 @@
 
 #include "shambase/aliases_int.hpp"
 #include "shambase/exception.hpp"
-#include "shambase/string.hpp"
+#include "sham/format/format.hpp"
+#include <array>
 #include <memory>
 #include <optional>
 #include <utility>
+#include <vector>
 
 namespace shambase {
 

--- a/src/shambase/include/shambase/narrowing.hpp
+++ b/src/shambase/include/shambase/narrowing.hpp
@@ -12,8 +12,8 @@
 #include "shambase/SourceLocation.hpp"
 #include "shambase/exception.hpp"
 #include "shambase/stacktrace.hpp"
-#include "shambase/string.hpp"
 #include "shambase/type_traits.hpp"
+#include "sham/format/format.hpp"
 #include <limits>
 #include <stdexcept>
 

--- a/src/shambase/include/shambase/stacktrace.hpp
+++ b/src/shambase/include/shambase/stacktrace.hpp
@@ -19,9 +19,9 @@
 #include "shambase/aliases_float.hpp"
 #include "shambase/aliases_int.hpp"
 #include "shambase/profiling/profiling.hpp"
-#include "shambase/string.hpp"
 #include "shambase/unique_name_macro.hpp"
 #include <stack>
+#include <string>
 
 namespace shambase::details {
 

--- a/src/shambase/include/shambase/string.hpp
+++ b/src/shambase/include/shambase/string.hpp
@@ -20,11 +20,6 @@
 #include "shambase/exception.hpp"
 #include "sham/format/format.hpp"
 #include "sham/format/human_readable.hpp"
-#include <fmt/base.h>
-#include <fmt/core.h>
-#include <fmt/format.h>
-#include <fmt/printf.h>
-#include <fmt/ranges.h>
 #include <string_view>
 #include <array>
 #include <fstream>

--- a/src/shambase/include/shambase/string.hpp
+++ b/src/shambase/include/shambase/string.hpp
@@ -20,6 +20,7 @@
 #include "shambase/exception.hpp"
 #include "sham/format/format.hpp"
 #include "sham/format/human_readable.hpp"
+#include <fmt/ranges.h>
 #include <string_view>
 #include <array>
 #include <fstream>

--- a/src/shambase/src/stacktrace.cpp
+++ b/src/shambase/src/stacktrace.cpp
@@ -16,6 +16,7 @@
 
 #include "shambase/stacktrace.hpp"
 #include "shambase/time.hpp"
+#include "sham/format/format.hpp"
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/shambase/src/stacktrace.cpp
+++ b/src/shambase/src/stacktrace.cpp
@@ -17,6 +17,7 @@
 #include "shambase/stacktrace.hpp"
 #include "shambase/time.hpp"
 #include "sham/format/format.hpp"
+#include <fstream>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/shamcomm/include/shamcomm/logs.hpp
+++ b/src/shamcomm/include/shamcomm/logs.hpp
@@ -19,7 +19,6 @@
 #include "shambase/aliases_int.hpp"
 #include "shambase/logs.hpp"
 #include "shambase/print.hpp"
-#include "shambase/string.hpp"
 #include "shambase/term_colors.hpp"
 #include <string>
 

--- a/src/shamcomm/src/mpiInfo.cpp
+++ b/src/shamcomm/src/mpiInfo.cpp
@@ -14,6 +14,7 @@
  *
  */
 
+#include "shambase/exception.hpp"
 #include "shambase/term_colors.hpp"
 #include "fmt/core.h"
 #include "shamcomm/logs.hpp"

--- a/src/shamcomm/src/worldInfo.cpp
+++ b/src/shamcomm/src/worldInfo.cpp
@@ -16,6 +16,7 @@
 #include "shambase/numeric_limits.hpp"
 #include "shambase/profiling/chrome.hpp"
 #include "shambase/stacktrace.hpp"
+#include "sham/format/format.hpp"
 #include "shamcomm/local_rank.hpp"
 #include "shamcomm/mpi.hpp"
 #include "shamcomm/mpiErrorCheck.hpp"

--- a/src/shamcomm/src/wrapper.cpp
+++ b/src/shamcomm/src/wrapper.cpp
@@ -14,6 +14,7 @@
  *
  */
 
+#include "shambase/exception.hpp"
 #include "shambase/profiling/profiling.hpp"
 #include "shambase/stacktrace.hpp"
 #include "shambase/time.hpp"

--- a/src/shamcomm/src/wrapper.cpp
+++ b/src/shamcomm/src/wrapper.cpp
@@ -17,6 +17,7 @@
 #include "shambase/profiling/profiling.hpp"
 #include "shambase/stacktrace.hpp"
 #include "shambase/time.hpp"
+#include "sham/format/format.hpp"
 #include "shamcomm/mpiErrorCheck.hpp"
 #include "shamcomm/worldInfo.hpp"
 #include "shamcomm/wrapper.hpp"

--- a/src/shammodels/ramses/src/modules/ComputeSumOverV.cpp
+++ b/src/shammodels/ramses/src/modules/ComputeSumOverV.cpp
@@ -15,10 +15,10 @@
  */
 
 #include "shambase/string.hpp"
-#include "shammodels/ramses/modules/ComputeSumOverV.hpp"
 #include "shambackends/kernel_call_distrib.hpp"
 #include "shamcomm/logs.hpp"
 #include "shammath/riemann.hpp"
+#include "shammodels/ramses/modules/ComputeSumOverV.hpp"
 #include "shamrock/patch/PatchDataField.hpp"
 #include "shamsys/NodeInstance.hpp"
 

--- a/src/shammodels/ramses/src/modules/ComputeSumOverV.cpp
+++ b/src/shammodels/ramses/src/modules/ComputeSumOverV.cpp
@@ -14,6 +14,7 @@
  *
  */
 
+#include "shambase/string.hpp"
 #include "shammodels/ramses/modules/ComputeSumOverV.hpp"
 #include "shambackends/kernel_call_distrib.hpp"
 #include "shamcomm/logs.hpp"

--- a/src/shammodels/sph/src/modules/ComputeLuminosity.cpp
+++ b/src/shammodels/sph/src/modules/ComputeLuminosity.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "shambase/stacktrace.hpp"
+#include "shambase/string.hpp"
 #include "shambackends/kernel_call_distrib.hpp"
 #include "shammodels/sph/SPHUtilities.hpp"
 #include "shammodels/sph/math/forces.hpp"

--- a/src/shammodels/sph/src/modules/IterateSmoothingLengthDensity.cpp
+++ b/src/shammodels/sph/src/modules/IterateSmoothingLengthDensity.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "shambase/stacktrace.hpp"
+#include "shambase/string.hpp"
 #include "shambackends/kernel_call_distrib.hpp"
 #include "shamcomm/logs.hpp"
 #include "shammath/sphkernels.hpp"

--- a/src/shammodels/sph/src/modules/IterateSmoothingLengthDensityNeighLim.cpp
+++ b/src/shammodels/sph/src/modules/IterateSmoothingLengthDensityNeighLim.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "shambase/stacktrace.hpp"
+#include "shambase/string.hpp"
 #include "shambackends/kernel_call_distrib.hpp"
 #include "shamcomm/logs.hpp"
 #include "shammath/sphkernels.hpp"

--- a/src/shamrock/include/shamrock/io/LegacyVtkWriter.hpp
+++ b/src/shamrock/include/shamrock/io/LegacyVtkWriter.hpp
@@ -19,6 +19,7 @@
 #include "shambase/endian.hpp"
 #include "shambase/memory.hpp"
 #include "shambase/stacktrace.hpp"
+#include "shambase/string.hpp"
 #include "shambase/time.hpp"
 #include "shamalgs/collective/io.hpp"
 #include "shamalgs/collective/reduction.hpp"

--- a/src/shamrock/src/banner.cpp
+++ b/src/shamrock/src/banner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "shambase/stacktrace.hpp"
+#include "shambase/string.hpp"
 #include "sham/term/tty.hpp"
 #include "shamcomm/logs.hpp"
 #include "shamcomm/worldInfo.hpp"

--- a/src/shamrock/src/io/ShamrockDump.cpp
+++ b/src/shamrock/src/io/ShamrockDump.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "shambase/stacktrace.hpp"
+#include "shambase/string.hpp"
 #include "shamcmdopt/env.hpp"
 #include "shamcomm/logs.hpp"
 #include "shamrock/io/ShamrockDump.hpp"

--- a/src/shamsolvergraph/include/shamsolvergraph/node/NodeMapEdge.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/node/NodeMapEdge.hpp
@@ -16,6 +16,7 @@
  */
 
 #include "shambase/stacktrace.hpp"
+#include "shambase/string.hpp"
 #include "shamsolvergraph/edge/IEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include <functional>

--- a/src/shamsolvergraph/include/shamsolvergraph/node/NodeSetEdge.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/node/NodeSetEdge.hpp
@@ -17,6 +17,7 @@
  */
 
 #include "shambase/stacktrace.hpp"
+#include "shambase/string.hpp"
 #include "shamsolvergraph/edge/IEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include <functional>

--- a/src/shamsys/src/change_log_format.cpp
+++ b/src/shamsys/src/change_log_format.cpp
@@ -13,6 +13,7 @@
  * @brief
  */
 
+#include "shambase/exception.hpp"
 #include "shambase/stacktrace.hpp"
 #include "shambase/term_colors.hpp"
 #include "sham/term/tty.hpp"

--- a/src/shamsys/src/device_select.cpp
+++ b/src/shamsys/src/device_select.cpp
@@ -16,6 +16,7 @@
 #include "shambase/aliases_int.hpp"
 #include "shambase/exception.hpp"
 #include "shambase/stacktrace.hpp"
+#include "shambase/string.hpp"
 #include "shambackends/Device.hpp"
 #include "shambackends/sycl.hpp"
 #include "shambackends/sycl_utils.hpp"

--- a/src/tests/shambackends/memoryBenchmark.cpp
+++ b/src/tests/shambackends/memoryBenchmark.cpp
@@ -7,6 +7,7 @@
 //
 // -------------------------------------------------------//
 
+#include "shambase/string.hpp"
 #include "shambase/time.hpp"
 #include "shamcomm/logs.hpp"
 #include "shamsys/NodeInstance.hpp"


### PR DESCRIPTION
stacktrace, memory, narrowing, and the log path included shambase/string.hpp only for std::string or a single format() call. That dragged fmt (including ranges and extra format headers) into every DeviceBuffer and kernel TU.

Drop string.hpp from stacktrace.hpp. Include sham/format/format.hpp from memory.hpp, narrowing.hpp, and msgformat.hpp. Drop redundant fmt headers from string.hpp. Add direct includes where call sites used format() or string helpers only through those headers.