### PR TITLE
[Scheduler] Split PatchSchedulerConfig out of PatchScheduler.hpp

### DIFF
--- a/src/shammodels/gsph/include/shammodels/gsph/SolverConfig.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/SolverConfig.hpp
@@ -43,7 +43,7 @@
 #include "shamrock/io/json_utils.hpp"
 #include "shamrock/io/units_json.hpp"
 #include "shamrock/patch/PatchDataLayerLayout.hpp"
-#include "shamrock/scheduler/PatchScheduler.hpp"
+#include "shamrock/scheduler/PatchSchedulerConfig.hpp"
 #include "shamsys/NodeInstance.hpp"
 #include "shamsys/legacy/log.hpp"
 #include "shamtree/CompressedLeafBVH.hpp"

--- a/src/shammodels/ramses/include/shammodels/ramses/SolverConfig.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/SolverConfig.hpp
@@ -33,7 +33,7 @@
 #include "shammodels/ramses/config/enum_SlopeMode.hpp"
 #include "shamrock/experimental_features.hpp"
 #include "shamrock/patch/PatchDataLayerLayout.hpp"
-#include "shamrock/scheduler/PatchScheduler.hpp"
+#include "shamrock/scheduler/PatchSchedulerConfig.hpp"
 #include <nlohmann/json.hpp>
 #include <shamrock/io/json_std_optional.hpp>
 #include <shamunits/Constants.hpp>

--- a/src/shammodels/sph/include/shammodels/sph/SolverConfig.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/SolverConfig.hpp
@@ -36,7 +36,7 @@
 #include "shamrock/io/json_utils.hpp"
 #include "shamrock/io/units_json.hpp"
 #include "shamrock/patch/PatchDataLayerLayout.hpp"
-#include "shamrock/scheduler/PatchScheduler.hpp"
+#include "shamrock/scheduler/PatchSchedulerConfig.hpp"
 #include "shamsys/NodeInstance.hpp"
 #include "shamsys/legacy/log.hpp"
 #include "shamtree/CompressedLeafBVH.hpp"

--- a/src/shammodels/zeus/include/shammodels/zeus/SolverConfig.hpp
+++ b/src/shammodels/zeus/include/shammodels/zeus/SolverConfig.hpp
@@ -20,10 +20,7 @@
 #include "shambase/string.hpp"
 #include "shambackends/vec.hpp"
 #include "shammodels/common/amr/AMRBlock.hpp"
-#include "shammodels/zeus/modules/SolverStorage.hpp"
-#include "shamrock/scheduler/PatchScheduler.hpp"
-#include "shamrock/scheduler/SerialPatchTree.hpp"
-#include "shamrock/scheduler/ShamrockCtx.hpp"
+#include "shamrock/scheduler/PatchSchedulerConfig.hpp"
 
 namespace shammodels::zeus {
 

--- a/src/shammodels/zeus/include/shammodels/zeus/modules/AnalysisSodTube.hpp
+++ b/src/shammodels/zeus/include/shammodels/zeus/modules/AnalysisSodTube.hpp
@@ -18,7 +18,11 @@
 
 #include "shambackends/vec.hpp"
 #include "shammodels/zeus/SolverConfig.hpp"
+#include "shammodels/zeus/modules/SolverStorage.hpp"
 #include "shamphys/SodTube.hpp"
+#include "shamrock/scheduler/PatchScheduler.hpp"
+#include "shamrock/scheduler/ShamrockCtx.hpp"
+
 namespace shammodels::zeus::modules {
 
     template<class Tvec, class TgridVec>

--- a/src/shamrock/include/shamrock/scheduler/PatchScheduler.hpp
+++ b/src/shamrock/include/shamrock/scheduler/PatchScheduler.hpp
@@ -23,11 +23,11 @@
 #include "shambase/DistributedData.hpp"
 #include "shambase/stacktrace.hpp"
 #include "shambase/time.hpp"
+#include "nlohmann/json_fwd.hpp"
 #include "shamalgs/collective/distributedDataComm.hpp"
 #include "shamrock/legacy/patch/utility/patch_field.hpp"
 #include "shamrock/solvergraph/PatchDataLayerRefs.hpp"
 #include "shamsolvergraph/node/NodeSetEdge.hpp"
-#include <nlohmann/json.hpp>
 #include <unordered_set>
 #include <fstream>
 #include <functional>
@@ -45,39 +45,11 @@
 #include "shamrock/patch/PatchDataLayerLayout.hpp"
 #include "shamrock/patch/PatchField.hpp"
 #include "shamrock/scheduler/HilbertLoadBalance.hpp"
+#include "shamrock/scheduler/PatchSchedulerConfig.hpp"
 #include "shamrock/scheduler/PatchTree.hpp"
 #include "shamrock/scheduler/SchedulerPatchData.hpp"
 #include "shamsolvergraph/SolverGraphSerializable.hpp"
 #include "shamsys/legacy/sycl_handler.hpp"
-
-struct PatchSchedulerConfig {
-    u64 split_load_value = 0_u64;
-    u64 merge_load_value = 0_u64;
-};
-
-/**
- * @brief Converts a PatchSchedulerConfig object to a JSON object.
- *
- * @param j The JSON object to be populated.
- * @param p The PatchSchedulerConfig object to be converted.
- */
-inline void to_json(nlohmann::json &j, const PatchSchedulerConfig &p) {
-    j = nlohmann::json{
-        {"split_load_value", p.split_load_value},
-        {"merge_load_value", p.merge_load_value},
-    };
-}
-
-/**
- * @brief Deserializes a PatchSchedulerConfig object from a JSON object.
- *
- * @param j The JSON object to deserialize from.
- * @param p The PatchSchedulerConfig object to populate.
- */
-inline void from_json(const nlohmann::json &j, PatchSchedulerConfig &p) {
-    j.at("split_load_value").get_to<u64>(p.split_load_value);
-    j.at("merge_load_value").get_to<u64>(p.merge_load_value);
-}
 
 /**
  * @brief The MPI scheduler

--- a/src/shamrock/include/shamrock/scheduler/PatchSchedulerConfig.hpp
+++ b/src/shamrock/include/shamrock/scheduler/PatchSchedulerConfig.hpp
@@ -1,0 +1,43 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2026 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file PatchSchedulerConfig.hpp
+ * @author Timothée David--Cléris (tim.shamrock@proton.me)
+ * @brief Load-split/merge thresholds for PatchScheduler
+ *
+ * Kept in a dedicated header so solver configs can include this type without
+ * the full scheduler (json, trees, MPI, SYCL).
+ */
+
+#include "shambase/aliases_int.hpp"
+#include "nlohmann/json_fwd.hpp"
+
+struct PatchSchedulerConfig {
+    u64 split_load_value = 0_u64;
+    u64 merge_load_value = 0_u64;
+};
+
+/**
+ * @brief Converts a PatchSchedulerConfig object to a JSON object.
+ *
+ * @param j The JSON object to be populated.
+ * @param p The PatchSchedulerConfig object to be converted.
+ */
+void to_json(nlohmann::json &j, const PatchSchedulerConfig &p);
+
+/**
+ * @brief Deserializes a PatchSchedulerConfig object from a JSON object.
+ *
+ * @param j The JSON object to deserialize from.
+ * @param p The PatchSchedulerConfig object to populate.
+ */
+void from_json(const nlohmann::json &j, PatchSchedulerConfig &p);

--- a/src/shamrock/src/scheduler/PatchSchedulerConfig.cpp
+++ b/src/shamrock/src/scheduler/PatchSchedulerConfig.cpp
@@ -1,0 +1,29 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2026 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+/**
+ * @file PatchSchedulerConfig.cpp
+ * @author Timothée David--Cléris (tim.shamrock@proton.me)
+ * @brief
+ */
+
+#include "shamrock/scheduler/PatchSchedulerConfig.hpp"
+#include <nlohmann/json.hpp>
+
+void to_json(nlohmann::json &j, const PatchSchedulerConfig &p) {
+    j = nlohmann::json{
+        {"split_load_value", p.split_load_value},
+        {"merge_load_value", p.merge_load_value},
+    };
+}
+
+void from_json(const nlohmann::json &j, PatchSchedulerConfig &p) {
+    j.at("split_load_value").get_to<u64>(p.split_load_value);
+    j.at("merge_load_value").get_to<u64>(p.merge_load_value);
+}


### PR DESCRIPTION
Solver configs only need the split/merge load thresholds, but including PatchScheduler.hpp pulled json, trees, MPI, and SYCL into SPH/GSPH/Ramses config TUs. Move the struct to a tiny header with json_fwd and out-of-line to_json/from_json.