### PR TITLE
[shamformat] migrate shambase::format callsites to sham namespace

### DIFF
--- a/src/shamalgs/include/shamalgs/ImplControl.hpp
+++ b/src/shamalgs/include/shamalgs/ImplControl.hpp
@@ -46,8 +46,7 @@ namespace shamalgs::primitives {
         inline void set_config(const sham::DeviceScheduler_ptr &dev_sched, const std::string &cfg) {
             logger::info_ln(
                 "Algs",
-                shambase::format(
-                    "switching config for alg {} to cfg={}", impl_get_alg_name(), cfg));
+                sham::format("switching config for alg {} to cfg={}", impl_get_alg_name(), cfg));
             impl_set_config(dev_sched, cfg);
         }
 

--- a/src/shamalgs/include/shamalgs/collective/RequestList.hpp
+++ b/src/shamalgs/include/shamalgs/collective/RequestList.hpp
@@ -79,10 +79,10 @@ namespace shamalgs::collective {
             std::string err_msg = "";
             for (size_t i = 0; i < rqs.size(); i++) {
                 if (!is_ready[i]) {
-                    err_msg += shambase::format("request {} is not ready\n", i);
+                    err_msg += sham::format("request {} is not ready\n", i);
                 }
             }
-            std::string msg = shambase::format("timeout : \n{}", err_msg);
+            std::string msg = sham::format("timeout : \n{}", err_msg);
             throw shambase::make_except_with_loc<std::runtime_error>(msg);
         }
 

--- a/src/shamalgs/include/shamalgs/container/BufferEventHandler.hpp
+++ b/src/shamalgs/include/shamalgs/container/BufferEventHandler.hpp
@@ -29,7 +29,7 @@ namespace shamalgs {
 
         const u32 id_hash = gen_buf_hash();
         inline u32 get_hash() { return id_hash; }
-        inline std::string get_hash_log() { return shambase::format("id = {} |", id_hash); }
+        inline std::string get_hash_log() { return sham::format("id = {} |", id_hash); }
 
         bool up_to_date_events = true;
 

--- a/src/shamalgs/include/shamalgs/details/memory/memory.hpp
+++ b/src/shamalgs/include/shamalgs/details/memory/memory.hpp
@@ -188,13 +188,13 @@ namespace shamalgs::memory {
 
             if (i % column_count == 0) {
                 if (i == 0) {
-                    accum += shambase::format("{:8} : ", i);
+                    accum += sham::format("{:8} : ", i);
                 } else {
-                    accum += shambase::format("\n{:8} : ", i);
+                    accum += sham::format("\n{:8} : ", i);
                 }
             }
 
-            accum += shambase::vformat(fmt, fmt::make_format_args(acc[i]));
+            accum += sham::vformat(fmt, fmt::make_format_args(acc[i]));
         }
 
         logger::raw_ln(accum);

--- a/src/shamalgs/include/shamalgs/serialize.hpp
+++ b/src/shamalgs/include/shamalgs/serialize.hpp
@@ -145,7 +145,7 @@ namespace shamalgs {
             SHAM_ASSERT(off == align_repr(len * Helper::szrepr));
 
             if (head_device + off > storage.get_size()) {
-                throw shambase::make_except_with_loc<std::runtime_error>(shambase::format(
+                throw shambase::make_except_with_loc<std::runtime_error>(sham::format(
                     "Serializer device buffer overflow: cannot move device head.\n"
                     "    storage size : {}\n"
                     "    current head_device : {}\n"
@@ -169,7 +169,7 @@ namespace shamalgs {
             SHAM_ASSERT(off == align_repr(len * Helper::szrepr));
 
             if (head_host + off > storage_header.size()) {
-                throw shambase::make_except_with_loc<std::runtime_error>(shambase::format(
+                throw shambase::make_except_with_loc<std::runtime_error>(sham::format(
                     "Serializer host buffer overflow: cannot move host head.\n"
                     "    storage_header size : {}\n"
                     "    current head_host : {}\n"
@@ -382,7 +382,7 @@ namespace shamalgs {
             check_head_move_device<T>(offset, len);
 
             if (buf.get_size() < len) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "SerializeHelper::load_buf: (buf.get_size() < len)\n  buf.get_size()={}\n  "
                     "len={}",
                     buf.get_size(),

--- a/src/shamalgs/src/collective/distributedDataComm.cpp
+++ b/src/shamalgs/src/collective/distributedDataComm.cpp
@@ -141,7 +141,7 @@ namespace shamalgs::collective {
                                   std::vector<std::reference_wrapper<DataTmp>> &sources) {
                 if (byte_sz.get_total_size() > max_comm_size) {
                     throw shambase::make_except_with_loc<std::runtime_error>(
-                        shambase::format("comm size too large: {}", byte_sz.get_total_size()));
+                        sham::format("comm size too large: {}", byte_sz.get_total_size()));
                 }
 
                 auto [sender_rank, receiver_rank] = key;
@@ -406,7 +406,7 @@ namespace shamalgs::collective {
             }
 
             throw make_except_with_loc<std::runtime_error>(
-                shambase::format("message send mismatch : {} != {}", tmp1, tmp2));
+                sham::format("message send mismatch : {} != {}", tmp1, tmp2));
         }
 
         if (comm_table2.messages_send.size() != messages_send.size()) {
@@ -420,7 +420,7 @@ namespace shamalgs::collective {
                 tmp2.push_back(messages_send[i].message_size);
             }
             throw make_except_with_loc<std::runtime_error>(
-                shambase::format("message send mismatch : {} != {}", tmp1, tmp2));
+                sham::format("message send mismatch : {} != {}", tmp1, tmp2));
         }
 
         for (size_t i = 0; i < comm_table2.messages_send.size(); i++) {
@@ -488,7 +488,7 @@ namespace shamalgs::collective {
                         i32 supposed_sender_rank = rank_getter(sender);
                         i32 real_sender_rank     = recv.sender_ranks;
                         if (supposed_sender_rank != real_sender_rank) {
-                            throw make_except_with_loc<std::runtime_error>(shambase::format(
+                            throw make_except_with_loc<std::runtime_error>(sham::format(
                                 "the rank do not matches {} != {}",
                                 supposed_sender_rank,
                                 real_sender_rank));

--- a/src/shamalgs/src/collective/sparseXchg.cpp
+++ b/src/shamalgs/src/collective/sparseXchg.cpp
@@ -45,8 +45,8 @@ namespace {
         auto min_hash = shamalgs::collective::allreduce_min(hash);
 
         if (max_hash != min_hash) {
-            std::string msg = shambase::format(
-                "hash mismatch {} != {}, local hash = {}", max_hash, min_hash, hash);
+            std::string msg
+                = sham::format("hash mismatch {} != {}, local hash = {}", max_hash, min_hash, hash);
             logger::err_ln("Sparse comm", msg);
             shamcomm::mpi::Barrier(MPI_COMM_WORLD);
             shambase::throw_with_loc<std::runtime_error>(msg);
@@ -68,7 +68,7 @@ namespace {
                 }
             }
 
-            shambase::throw_with_loc<std::runtime_error>(shambase::format(
+            shambase::throw_with_loc<std::runtime_error>(sham::format(
                 "payload size {} is too large for MPI (max i32 is {})\n"
                 "message sizes to send: {}",
                 payload_sz,
@@ -95,14 +95,14 @@ namespace {
                   if (!rqs.is_event_ready(i)) {
 
                       if (rqs_infos[i].is_send) {
-                          err_msg += shambase::format(
+                          err_msg += sham::format(
                               "communication timeout : send {} -> {} tag {} size {}\n",
                               rqs_infos[i].sender,
                               rqs_infos[i].receiver,
                               rqs_infos[i].tag,
                               rqs_infos[i].size);
                       } else {
-                          err_msg += shambase::format(
+                          err_msg += sham::format(
                               "communication timeout : recv {} -> {} tag {} size {}\n",
                               rqs_infos[i].sender,
                               rqs_infos[i].receiver,
@@ -111,7 +111,7 @@ namespace {
                       }
                   }
               }
-              std::string msg = shambase::format("communication timeout : \n{}", err_msg);
+              std::string msg = sham::format("communication timeout : \n{}", err_msg);
               logger::err_ln("Sparse comm", msg);
               std::this_thread::sleep_for(std::chrono::seconds(2));
               shambase::throw_with_loc<std::runtime_error>(msg);
@@ -148,7 +148,7 @@ namespace {
                       shamcomm::mpi::Test(&rq, &ready, MPI_STATUS_IGNORE);
                       if (!ready) {
                           loc_done = false;
-                          // logger::raw_ln(shambase::format(
+                          // logger::raw_ln(sham::format(
                           //     "communication pending : send {} -> {} tag {} size {}",
                           //     rqs_infos[i].sender,
                           //     rqs_infos[i].receiver,
@@ -157,7 +157,7 @@ namespace {
                       } else {
                           done_map[i] = true;
                           done_count++;
-                          // logger::raw_ln(shambase::format(
+                          // logger::raw_ln(sham::format(
                           //     "communication done : send {} -> {} tag {} size {}",
                           //     rqs_infos[i].sender,
                           //     rqs_infos[i].receiver,
@@ -175,7 +175,7 @@ namespace {
                   if (twait.elapsed_sec() > t_last_print + 10) {
 
                       std::string msg
-                          = shambase::format("Sparse comm : {} / {} done", done_count, rqs.size());
+                          = sham::format("Sparse comm : {} / {} done", done_count, rqs.size());
                       logger::warn_ln("Sparse comm", msg);
 
                       t_last_print = twait.elapsed_sec();
@@ -187,14 +187,14 @@ namespace {
                           if (!done_map[i]) {
 
                               if (rqs_infos[i].is_send) {
-                                  err_msg += shambase::format(
+                                  err_msg += sham::format(
                                       "communication timeout : send {} -> {} tag {} size {}\n",
                                       rqs_infos[i].sender,
                                       rqs_infos[i].receiver,
                                       rqs_infos[i].tag,
                                       rqs_infos[i].size);
                               } else {
-                                  err_msg += shambase::format(
+                                  err_msg += sham::format(
                                       "communication timeout : recv {} -> {} tag {} size {}\n",
                                       rqs_infos[i].sender,
                                       rqs_infos[i].receiver,
@@ -203,7 +203,7 @@ namespace {
                               }
                           }
                       }
-                      std::string msg = shambase::format("communication timeout : \n{}", err_msg);
+                      std::string msg = sham::format("communication timeout : \n{}", err_msg);
                       logger::err_ln("Sparse comm", msg);
                       std::this_thread::sleep_for(std::chrono::seconds(2));
                       shambase::throw_with_loc<std::runtime_error>(msg);
@@ -222,7 +222,7 @@ auto get_SHAM_SPARSE_COMM_INFLIGHT_LIM = []() {
     } catch (...) {
         logger::err_ln(
             "Sparse comm",
-            shambase::format(
+            sham::format(
                 "Invalid value for SHAM_SPARSE_COMM_INFLIGHT_LIM {}, using default value {}",
                 val,
                 ret));
@@ -257,7 +257,7 @@ namespace shamalgs::collective {
                 u32_2 comm_ranks = sham::unpack32(global_comm_ranks[i]);
 
                 if (comm_ranks.x() == shamcomm::world_rank()) {
-                    accum += shambase::format(
+                    accum += sham::format(
                         "{} # {} # {}\n",
                         comm_ranks.x(),
                         comm_ranks.y(),
@@ -285,7 +285,7 @@ namespace shamalgs::collective {
             StackEntry stack_loc{};
             sham::MemPerfInfos mem_perf_infos_end = sham::details::get_mem_perf_info();
 
-            std::string accum = shambase::format(
+            std::string accum = sham::format(
                 "rank = {} maxmem = {}\n",
                 shamcomm::world_rank(),
                 shambase::readable_sizeof(mem_perf_infos_end.max_allocated_byte_device));
@@ -336,7 +336,7 @@ namespace shamalgs::collective {
 
                 int send_sz = check_payload_size_is_int(payload->get_size(), global_comm_ranks);
 
-                // logger::raw_ln(shambase::format(
+                // logger::raw_ln(sham::format(
                 //     "[{}] send {} bytes to rank {}, tag {}",
                 //     shamcomm::world_rank(),
                 //     payload->get_bytesize(),
@@ -370,7 +370,7 @@ namespace shamalgs::collective {
 
                 payload.payload = std::make_unique<shamcomm::CommunicationBuffer>(cnt, dev_sched);
 
-                // logger::raw_ln(shambase::format(
+                // logger::raw_ln(sham::format(
                 //     "[{}] recv {} bytes from rank {}, tag {}",
                 //     shamcomm::world_rank(),
                 //     cnt,
@@ -476,7 +476,7 @@ namespace shamalgs::collective {
 
                 SHAM_ASSERT(payload->get_size() == comm_sizes_loc[send_idx]);
 
-                // logger::raw_ln(shambase::format(
+                // logger::raw_ln(sham::format(
                 //     "[{}] send {} bytes to rank {}, tag {}",
                 //     shamcomm::world_rank(),
                 //     payload->get_bytesize(),
@@ -510,7 +510,7 @@ namespace shamalgs::collective {
                      .is_send  = false,
                      .is_recv  = true});
 
-                // logger::raw_ln(shambase::format(
+                // logger::raw_ln(sham::format(
                 //     "[{}] recv {} bytes from rank {}, tag {}",
                 //     shamcomm::world_rank(),
                 //     cnt,
@@ -563,7 +563,7 @@ namespace shamalgs::collective {
 
         // shamcomm::mpi::Barrier(MPI_COMM_WORLD);
         // if (shamcomm::world_rank() == 0) {
-        //     logger::raw_ln(shambase::format("sparse comm done"));
+        //     logger::raw_ln(sham::format("sparse comm done"));
         // }
         // shamcomm::mpi::Barrier(MPI_COMM_WORLD);
     }

--- a/src/shamalgs/src/collective/sparse_exchange.cpp
+++ b/src/shamalgs/src/collective/sparse_exchange.cpp
@@ -37,7 +37,7 @@ namespace shamalgs::collective {
         u32 receiver        = comm_ranks.y();
 
         if (message_size == 0) {
-            throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+            throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
                 "Message size is 0 for rank {}, sender = {}, receiver = {}",
                 shamcomm::world_rank(),
                 sender,
@@ -65,7 +65,7 @@ namespace shamalgs::collective {
             size_t message_size = messages_send[i].message_size;
 
             if (sender != shamcomm::world_rank()) {
-                throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+                throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
                     "You are trying to send a message from a rank that does not posses it\n"
                     "    sender = {}, receiver = {}, world_rank = {}",
                     sender,
@@ -143,12 +143,11 @@ namespace shamalgs::collective {
                 // offset logic (& buffer selection)
                 if (sender == shamcomm::world_rank()) {
                     if (message_info.message_size > max_alloc_size) {
-                        throw shambase::make_except_with_loc<std::invalid_argument>(
-                            shambase::format(
-                                "Message size is greater than the max alloc size\n"
-                                "    message_size = {}, max_alloc_size = {}",
-                                message_info.message_size,
-                                max_alloc_size));
+                        throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
+                            "Message size is greater than the max alloc size\n"
+                            "    message_size = {}, max_alloc_size = {}",
+                            message_info.message_size,
+                            max_alloc_size));
                     }
 
                     if (send_buf_sizes.size() == 0) {
@@ -173,12 +172,11 @@ namespace shamalgs::collective {
                 if (receiver == shamcomm::world_rank()) {
 
                     if (message_info.message_size > max_alloc_size) {
-                        throw shambase::make_except_with_loc<std::invalid_argument>(
-                            shambase::format(
-                                "Message size is greater than the max alloc size\n"
-                                "    message_size = {}, max_alloc_size = {}",
-                                message_info.message_size,
-                                max_alloc_size));
+                        throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
+                            "Message size is greater than the max alloc size\n"
+                            "    message_size = {}, max_alloc_size = {}",
+                            message_info.message_size,
+                            max_alloc_size));
                     }
 
                     if (recv_buf_sizes.size() == 0) {
@@ -310,7 +308,7 @@ namespace shamalgs::collective {
         }
 
         if (comm_table.send_total_sizes.size() != bytebuffer_send.size()) {
-            throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+            throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
                 "The send total size is greater than the send buffer size\n"
                 "    send_total_sizes = {}, send_buffer_size = {}",
                 comm_table.send_total_sizes.size(),
@@ -318,7 +316,7 @@ namespace shamalgs::collective {
         }
 
         if (comm_table.recv_total_sizes.size() != bytebuffer_recv.size()) {
-            throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+            throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
                 "The recv total size is greater than the recv buffer size\n"
                 "    recv_total_sizes = {}, recv_buffer_size = {}",
                 comm_table.recv_total_sizes.size(),
@@ -327,7 +325,7 @@ namespace shamalgs::collective {
 
         for (size_t i = 0; i < comm_table.send_total_sizes.size(); i++) {
             if (comm_table.send_total_sizes[i] > bytebuffer_send[i]->get_size()) {
-                throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+                throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
                     "The send total size is greater than the send buffer size\n"
                     "    send_total_sizes = {}, send_buffer_size = {}, buf_id = {}",
                     comm_table.send_total_sizes[i],
@@ -338,7 +336,7 @@ namespace shamalgs::collective {
 
         for (size_t i = 0; i < comm_table.recv_total_sizes.size(); i++) {
             if (comm_table.recv_total_sizes[i] > bytebuffer_recv[i]->get_size()) {
-                throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+                throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
                     "The recv total size is greater than the recv buffer size\n"
                     "    recv_total_sizes = {}, recv_buffer_size = {}, buf_id = {}",
                     comm_table.recv_total_sizes[i],

--- a/src/shamalgs/src/details/numeric/streamCompactExclScan.cpp
+++ b/src/shamalgs/src/details/numeric/streamCompactExclScan.cpp
@@ -117,7 +117,7 @@ namespace shamalgs::numeric::details {
 
         if (new_len > 0) {
             // logger::raw_ln(
-            //     shambase::format("len = {}, new_len = {}, end_flag = {}", len, new_len,
+            //     sham::format("len = {}, new_len = {}, end_flag = {}", len, new_len,
             //     end_flag));
             sham::kernel_call(
                 sched->get_queue(),
@@ -132,7 +132,7 @@ namespace shamalgs::numeric::details {
                     bool should_write
                         = (_if1) ? (current_val < sum_vals[idx + 1]) : (bool(last_flag));
 
-                    // logger::raw_ln(shambase::format(
+                    // logger::raw_ln(sham::format(
                     //     "idx = {}, sum = {}, _if1 = {}, should_write = {}",
                     //     idx,
                     //     sum_vals[idx],

--- a/src/shamalgs/src/details/reduction/groupReduction_usm.cpp
+++ b/src/shamalgs/src/details/reduction/groupReduction_usm.cpp
@@ -89,7 +89,7 @@ namespace shamalgs::reduction::details {
         u32 work_group_size) {
 
         if (start_id >= end_id) {
-            shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+            shambase::throw_with_loc<std::invalid_argument>(sham::format(
                 "Empty range (or invalid range) not supported for max operation\n  start_id = {}, "
                 "end_id = {}",
                 start_id,
@@ -133,7 +133,7 @@ namespace shamalgs::reduction::details {
         u32 work_group_size) {
 
         if (start_id >= end_id) {
-            shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+            shambase::throw_with_loc<std::invalid_argument>(sham::format(
                 "Empty range (or invalid range) not supported for min operation\n  start_id = {}, "
                 "end_id = {}",
                 start_id,

--- a/src/shamalgs/src/primitives/dot_sum.cpp
+++ b/src/shamalgs/src/primitives/dot_sum.cpp
@@ -32,7 +32,7 @@ namespace shamalgs::primitives {
 
         if (start_id > end_id) {
             shambase::throw_with_loc<std::invalid_argument>(
-                shambase::format("start_id > end_id : {} > {}", start_id, end_id));
+                sham::format("start_id > end_id : {} > {}", start_id, end_id));
         }
 
         sham::DeviceBuffer<Tscal> ret_data_base(end_id - start_id, buf1.get_dev_scheduler_ptr());

--- a/src/shamalgs/src/primitives/gen_buffer_index.cpp
+++ b/src/shamalgs/src/primitives/gen_buffer_index.cpp
@@ -22,7 +22,7 @@ namespace shamalgs::primitives {
 
     void fill_buffer_index(sham::DeviceBuffer<u32> &buf, u32 len) {
         if (buf.get_size() < len) {
-            shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+            shambase::throw_with_loc<std::invalid_argument>(sham::format(
                 "buf.get_size() < len\n  buf.get_size() = {},\n  len = {}", buf.get_size(), len));
         }
 

--- a/src/shamalgs/src/primitives/is_all_true.cpp
+++ b/src/shamalgs/src/primitives/is_all_true.cpp
@@ -75,7 +75,7 @@ namespace shamalgs::primitives {
         } else if (impl == "sum_reduction") {
             return IS_ALL_TRUE_IMPL::SUM_REDUCTION;
         }
-        throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+        throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
             "invalid implementation : {}, possible implementations : {}",
             impl,
             impl::get_default_impl_list_is_all_true()));
@@ -88,7 +88,7 @@ namespace shamalgs::primitives {
             return {.impl_name = "sum_reduction", .params = ""};
         }
         throw shambase::make_except_with_loc<std::invalid_argument>(
-            shambase::format("unknown is_all_true implementation : {}", u32(impl)));
+            sham::format("unknown is_all_true implementation : {}", u32(impl)));
     }
 
     std::vector<shamalgs::impl_param> impl::get_default_impl_list_is_all_true() {
@@ -113,7 +113,7 @@ namespace shamalgs::primitives {
         case IS_ALL_TRUE_IMPL::SUM_REDUCTION: return is_all_true_sum_reduction(buf, cnt);
         default:
             shambase::throw_with_loc<std::invalid_argument>(
-                shambase::format("unimplemented case : {}", u32(is_all_true_impl)));
+                sham::format("unimplemented case : {}", u32(is_all_true_impl)));
         }
     }
 

--- a/src/shamalgs/src/primitives/reduction.cpp
+++ b/src/shamalgs/src/primitives/reduction.cpp
@@ -59,7 +59,7 @@ namespace shamalgs::primitives {
             return REDUCTION_IMPL::GROUP_REDUCTION256;
 #endif
         }
-        throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+        throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
             "invalid implementation : {}, possible implementations : {}",
             impl,
             impl::get_default_impl_list_reduction()));
@@ -78,7 +78,7 @@ namespace shamalgs::primitives {
 #endif
         }
         throw shambase::make_except_with_loc<std::invalid_argument>(
-            shambase::format("unknown reduction implementation : {}", u32(impl)));
+            sham::format("unknown reduction implementation : {}", u32(impl)));
     }
 
     std::vector<shamalgs::impl_param> impl::get_default_impl_list_reduction() {
@@ -122,7 +122,7 @@ namespace shamalgs::primitives {
 #endif
         default:
             shambase::throw_with_loc<std::invalid_argument>(
-                shambase::format("unimplemented case : {}", u32(reduction_impl)));
+                sham::format("unimplemented case : {}", u32(reduction_impl)));
         }
     }
 
@@ -147,7 +147,7 @@ namespace shamalgs::primitives {
 #endif
         default:
             shambase::throw_with_loc<std::invalid_argument>(
-                shambase::format("unimplemented case : {}", u32(reduction_impl)));
+                sham::format("unimplemented case : {}", u32(reduction_impl)));
         }
     }
 
@@ -172,7 +172,7 @@ namespace shamalgs::primitives {
 #endif
         default:
             shambase::throw_with_loc<std::invalid_argument>(
-                shambase::format("unimplemented case : {}", u32(reduction_impl)));
+                sham::format("unimplemented case : {}", u32(reduction_impl)));
         }
     }
 

--- a/src/shamalgs/src/primitives/scan_exclusive_sum_in_place.cpp
+++ b/src/shamalgs/src/primitives/scan_exclusive_sum_in_place.cpp
@@ -154,7 +154,7 @@ namespace shamalgs::primitives {
 #endif
         }
 
-        throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+        throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
             "invalid implementation : {}, possible implementations : {}",
             impl,
             impl::get_default_impl_list_scan_exclusive_sum_in_place()));
@@ -179,7 +179,7 @@ namespace shamalgs::primitives {
         }
 
         throw shambase::make_except_with_loc<std::invalid_argument>(
-            shambase::format("unknown scan_exclusive_sum_in_place implementation : {}", u32(impl)));
+            sham::format("unknown scan_exclusive_sum_in_place implementation : {}", u32(impl)));
     }
 
     std::vector<shamalgs::impl_param> impl::get_default_impl_list_scan_exclusive_sum_in_place() {
@@ -216,7 +216,7 @@ namespace shamalgs::primitives {
         }
 
         if (len > buf1.get_size()) {
-            shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+            shambase::throw_with_loc<std::invalid_argument>(sham::format(
                 "The buffer is smaller than the length of the scan\n"
                 "len > buf1.get_size(), len = {}, buf1.get_size() = {}",
                 len,
@@ -242,7 +242,7 @@ namespace shamalgs::primitives {
 #endif
         default:
             shambase::throw_with_loc<std::invalid_argument>(
-                shambase::format("unimplemented case : {}", u32(scan_exclusive_sum_in_place_impl)));
+                sham::format("unimplemented case : {}", u32(scan_exclusive_sum_in_place_impl)));
         }
     }
 

--- a/src/shamalgs/src/primitives/segmented_sort_in_place.cpp
+++ b/src/shamalgs/src/primitives/segmented_sort_in_place.cpp
@@ -125,7 +125,7 @@ namespace shamalgs::primitives {
             } else if (impl == "multi_std_sort") {
                 return SEGMENTED_SORT_IN_PLACE_IMPL::MULTI_STD_SORT;
             }
-            throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+            throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
                 "invalid implementation : {}, possible implementations : {}",
                 impl,
                 impl::get_default_impl_list_segmented_sort_in_place()));
@@ -139,7 +139,7 @@ namespace shamalgs::primitives {
                 return {.impl_name = "multi_std_sort", .params = ""};
             }
             throw shambase::make_except_with_loc<std::invalid_argument>(
-                shambase::format("unknown segmented sort in place implementation : {}", u32(impl)));
+                sham::format("unknown segmented sort in place implementation : {}", u32(impl)));
         }
 
         /// Get list of available segmented sort in place implementations
@@ -185,8 +185,8 @@ namespace shamalgs::primitives {
             details::segmented_sort_in_place_multi_std_sort(buf, offsets, comp);
             break;
         default:
-            shambase::throw_with_loc<std::invalid_argument>(shambase::format(
-                "unimplemented case : {}", u32(impl::segmented_sort_in_place_impl)));
+            shambase::throw_with_loc<std::invalid_argument>(
+                sham::format("unimplemented case : {}", u32(impl::segmented_sort_in_place_impl)));
         }
     }
 

--- a/src/shamalgs/src/serialize.cpp
+++ b/src/shamalgs/src/serialize.cpp
@@ -192,7 +192,7 @@ shamalgs::SerializeHelper::SerializeHelper(
 
     shamlog_debug_sycl_ln(
         "SerializeHelper",
-        shambase::format(
+        sham::format(
             "Init SerializeHelper from buffer\n    storage size : {},\n    header_size : {}",
             storage.get_size(),
             header_size));

--- a/src/shambackends/include/shambackends/DeviceBuffer.hpp
+++ b/src/shambackends/include/shambackends/DeviceBuffer.hpp
@@ -541,12 +541,12 @@ namespace sham {
             size_t begin, size_t end) const {
 
             if (end > size) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "copy_to_stdvec_idx_range: end > size\n  end = {},\n  size = {}", end, size));
             }
 
             if (begin > end) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "copy_to_stdvec_idx_range: begin >= end\n  begin = {},\n  end = {}",
                     begin,
                     end));
@@ -587,12 +587,12 @@ namespace sham {
             size_t dest_offset) const {
 
             if (begin > end) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "copy_range_offset: begin > end\n  begin = {},\n  end = {}", begin, end));
             }
 
             if (end > get_size()) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "copy_range_offset: end index is out of bounds\n  end = {},\n  source buffer "
                     "size = {}",
                     end,
@@ -600,7 +600,7 @@ namespace sham {
             }
 
             if (dest_offset > dest.get_size()) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "copy_range_offset: dest_offset > dest.get_size()\n  dest_offset = {},\n  "
                     "dest.get_size() = {}",
                     dest_offset,
@@ -608,7 +608,7 @@ namespace sham {
             }
 
             if (end - begin > (dest.get_size() - dest_offset)) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "copy_range_offset: end - begin > dest.get_size() - dest_offset\n  end - begin "
                     "= {},\n  "
                     "dest.get_size() - dest_offset = {},\n  dest_offset = {}",
@@ -666,7 +666,7 @@ namespace sham {
         inline void copy_from_stdvec(const std::vector<T> &vec) {
 
             if (size != vec.size()) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "copy_from_stdvec: size mismatch\n  size = {},\n  vec.size() = {}",
                     size,
                     vec.size()));
@@ -696,7 +696,7 @@ namespace sham {
         inline void copy_from_stdvec(const std::vector<T> &vec, size_t sz) {
 
             if (sz > vec.size() || sz > size) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "copy_from_stdvec: size mismatch (sz > vec.size() || sz > size)\n  size = "
                     "{},\n  vec.size() = {},\n  sz = {}",
                     size,
@@ -755,7 +755,7 @@ namespace sham {
         inline void copy_from_sycl_buffer(sycl::buffer<T> &buf) {
 
             if (size != buf.size()) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "copy_from_sycl_buffer: size mismatch\n  size = {},\n  buf.size() = {}",
                     size,
                     buf.size()));
@@ -788,7 +788,7 @@ namespace sham {
         inline void copy_from_sycl_buffer(sycl::buffer<T> &buf, size_t sz) {
 
             if (sz > buf.size() || sz > size) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "copy_from_sycl_buffer: size mismatch (sz > buf.size() || sz > size)\n  size = "
                     "{},\n  buf.size() = {},\n  sz = {}",
                     size,
@@ -797,7 +797,7 @@ namespace sham {
             }
 
             if (sz > u32_max) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "copy_from_sycl_buffer: size mismatch (sz > u32_max)\n  sz = {}", sz));
             }
 
@@ -859,7 +859,7 @@ namespace sham {
         inline void copy_from(const DeviceBuffer<T, new_target> &other, size_t copy_size) {
 
             if (!(copy_size <= get_size() && copy_size <= other.get_size())) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "The size of the copy must be smaller than the size of the buffer involved\n  "
                     "copy_size: {}\n  get_size(): {}\n  other.get_size(): {}",
                     copy_size,
@@ -892,7 +892,7 @@ namespace sham {
         inline void copy_from(const DeviceBuffer<T, new_target> &other) {
 
             if (get_size() != other.get_size()) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "The other field must be of the same size\n  get_size = {},\n  other.get_size "
                     "= {}",
                     get_size(),
@@ -954,7 +954,7 @@ namespace sham {
             size_t idx_count   = idx_range[1] - start_index;
 
             if (!(start_index + idx_count <= get_size())) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "!(start_index + idx_count <= get_size())\n  start_index = {},\n  idx_count = "
                     "{},\n  get_size() = {}",
                     start_index,
@@ -1033,7 +1033,7 @@ namespace sham {
             T ret;
 
             if (idx >= size) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "get_val_at_idx: idx >= size\n  idx = {},\n  size = {}", idx, size));
             }
 
@@ -1053,7 +1053,7 @@ namespace sham {
         void set_val_at_idx(size_t idx, T val) {
 
             if (idx >= size) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "set_val_at_idx: idx >= size\n  idx = {},\n  size = {}", idx, size));
             }
 
@@ -1126,7 +1126,7 @@ namespace sham {
                 }
 
                 if (new_storage_size > max_alloc_size) {
-                    shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                    shambase::throw_with_loc<std::runtime_error>(sham::format(
                         "new_storage_size > max_alloc_size\n"
                         "  new_storage_size      = {}\n"
                         "  max_alloc_size  = {}\n"
@@ -1203,7 +1203,7 @@ namespace sham {
          */
         inline void shrink(u32 sub_sz) {
             if (sub_sz > get_size()) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "shrink called with sub_sz > get_size()\n  sub_sz: {}\n  get_size(): {}",
                     sub_sz,
                     get_size()));

--- a/src/shambackends/include/shambackends/EventList.hpp
+++ b/src/shambackends/include/shambackends/EventList.hpp
@@ -128,7 +128,7 @@ namespace sham {
          * @return A string representation of the EventList's state.
          */
         inline std::string get_state() {
-            return shambase::format("events : {}, consumed : {}", events.size(), consumed);
+            return sham::format("events : {}, consumed : {}", events.size(), consumed);
         }
 
         /// Default constructor for EventList with source location

--- a/src/shambackends/include/shambackends/benchmarks/saxpy.hpp
+++ b/src/shambackends/include/shambackends/benchmarks/saxpy.hpp
@@ -87,13 +87,13 @@ namespace sham::benchmarks {
         y.fill(init_y);
 
         if (x.get_size() < N) {
-            shambase::make_except_with_loc<std::runtime_error>(shambase::format(
-                "x.get_size() < N\n  x.get_size() = {},\n  N = {}", x.get_size(), N));
+            shambase::make_except_with_loc<std::runtime_error>(
+                sham::format("x.get_size() < N\n  x.get_size() = {},\n  N = {}", x.get_size(), N));
         }
 
         if (y.get_size() < N) {
-            shambase::make_except_with_loc<std::runtime_error>(shambase::format(
-                "y.get_size() < N\n  y.get_size() = {},\n  N = {}", y.get_size(), N));
+            shambase::make_except_with_loc<std::runtime_error>(
+                sham::format("y.get_size() < N\n  y.get_size() = {},\n  N = {}", y.get_size(), N));
         }
 
         std::vector<T> y_res = {};

--- a/src/shambackends/include/shambackends/sycl_utils.hpp
+++ b/src/shambackends/include/shambackends/sycl_utils.hpp
@@ -105,7 +105,7 @@ namespace shambase {
         nvtxRangePush(name);
 #endif
 
-        shamlog_debug_sycl_ln("SYCL", shambase::format("parallel_for {} N={}", name, length));
+        shamlog_debug_sycl_ln("SYCL", sham::format("parallel_for {} N={}", name, length));
 
         if constexpr (mode == PARALLEL_FOR) {
 
@@ -156,7 +156,7 @@ namespace shambase {
 #endif
 
         shamlog_debug_sycl_ln(
-            "SYCL", shambase::format("parallel_for {} N={} {}", name, length_x, length_y));
+            "SYCL", sham::format("parallel_for {} N={} {}", name, length_x, length_y));
 
         if constexpr (mode == PARALLEL_FOR) {
 
@@ -217,8 +217,7 @@ namespace shambase {
 #endif
 
         shamlog_debug_sycl_ln(
-            "SYCL",
-            shambase::format("parallel_for {} N={} {} {}", name, length_x, length_y, length_z));
+            "SYCL", sham::format("parallel_for {} N={} {} {}", name, length_x, length_y, length_z));
 
         if constexpr (mode == PARALLEL_FOR) {
 

--- a/src/shambackends/src/Device.cpp
+++ b/src/shambackends/src/Device.cpp
@@ -316,7 +316,7 @@ namespace sham {
         // with acpp 8 bit is returned for most backends so we default to 8 bytes (64 bits)
         if (*mem_base_addr_align && mem_base_addr_align == 8) {
             warnings.push_back(
-                shambase::format(
+                sham::format(
                     "mem_base_addr_align for is {} bits. I will assume that this is an "
                     "issue and default to 64 bits (8 bytes) instead.",
                     *mem_base_addr_align));
@@ -328,7 +328,7 @@ namespace sham {
         if (!sub_group_sizes) {
             sub_group_sizes = std::vector<size_t>{default_work_group_size};
             warnings.push_back(
-                shambase::format(
+                sham::format(
                     "cannot fetch sub_group_sizes, defaulting to {}", default_work_group_size));
         }
         default_work_group_size = shambase::get_check_ref(sub_group_sizes)[0];
@@ -342,7 +342,7 @@ namespace sham {
                 max_alloc_host       = max_alloc;
             } catch (const std::exception &e) {
                 warnings.push_back(
-                    shambase::format(
+                    sham::format(
                         "Could not parse SHAM_MAX_ALLOC_SIZE value '{}'. Error: {}. "
                         "Ignoring override.",
                         SHAM_MAX_ALLOC_SIZE.value(),

--- a/src/shambackends/src/DeviceScheduler.cpp
+++ b/src/shambackends/src/DeviceScheduler.cpp
@@ -35,7 +35,7 @@ namespace {
         if (acc != expected_acc) {
             auto &ctx    = shambase::get_check_ref(q.ctx);
             auto &device = shambase::get_check_ref(ctx.device);
-            throw shambase::make_except_with_loc<std::runtime_error>(shambase::format(
+            throw shambase::make_except_with_loc<std::runtime_error>(sham::format(
                 "The chosen SYCL queue (name={}, device={}) cannot execute a basic kernel\n"
                 "  expected acc = {}\n"
                 "  actual acc = {}",
@@ -63,7 +63,7 @@ namespace sham {
         shamcomm::logs::raw_ln("  Queue list:");
         for (auto &q : queues) {
             std::string tmp
-                = shambase::format("   - name : {:20s} in order : {}", q->queue_name, q->in_order);
+                = sham::format("   - name : {:20s} in order : {}", q->queue_name, q->in_order);
             shamcomm::logs::raw_ln(tmp);
         }
     }

--- a/src/shambackends/src/EventList.cpp
+++ b/src/shambackends/src/EventList.cpp
@@ -18,7 +18,7 @@
 
 sham::EventList::~EventList() noexcept(false) {
     if (!consumed && !events.empty()) {
-        std::string log_str = shambase::format(
+        std::string log_str = sham::format(
             "EventList destroyed without being consumed :\n    -> creation : {}",
             loc_build.format_one_line());
 

--- a/src/shambackends/src/SyclMpiTypes.cpp
+++ b/src/shambackends/src/SyclMpiTypes.cpp
@@ -97,7 +97,7 @@ void check_offset_validity() {
     std::ptrdiff_t s0   = reinterpret_cast<std::ptrdiff_t>(&a.s0());
 
     if (s0 - base != 0) {
-        throw shambase::make_except_with_loc<std::runtime_error>(shambase::format(
+        throw shambase::make_except_with_loc<std::runtime_error>(sham::format(
             "Offset is not valid for type {}, base = {}, s0 = {}", typeid(T).name(), base, s0));
     }
 }

--- a/src/shambackends/src/details/BufferEventHandler.cpp
+++ b/src/shambackends/src/details/BufferEventHandler.cpp
@@ -51,7 +51,7 @@ namespace sham::details {
     void BufferEventHandler::read_access(sham::EventList &depends_list, SourceLocation src_loc) {
 
         if (!up_to_date_events) {
-            std::string err_msg = shambase::format(
+            std::string err_msg = sham::format(
                 "you have requested a read access on a buffer in an incomplete state\n"
                 "  read_access call location : {}\n"
                 "  last access location : {}\n",
@@ -76,7 +76,7 @@ namespace sham::details {
     void BufferEventHandler::write_access(sham::EventList &depends_list, SourceLocation src_loc) {
 
         if (!up_to_date_events) {
-            std::string err_msg = shambase::format(
+            std::string err_msg = sham::format(
                 "you have requested a write access on a buffer in an incomplete state\n"
                 "  write_access call location : {}\n"
                 "  last access location : {}\n",

--- a/src/shambackends/src/details/internal_alloc.cpp
+++ b/src/shambackends/src/details/internal_alloc.cpp
@@ -130,7 +130,7 @@ namespace sham::details {
 
     std::string log_mem_perf_info(const std::shared_ptr<DeviceScheduler> &dev_sched) {
 
-        return shambase::format(
+        return sham::format(
             R"log(
     World infos :
         World size = {}
@@ -209,7 +209,7 @@ namespace sham::details {
             try {
                 usm_ptr = alloc_lambda();
             } catch (std::exception &ex) {
-                std::string log = shambase::format(
+                std::string log = sham::format(
                     "Alloc failed with exception : {}\nShamrock mem infos : {}",
                     ex.what(),
                     log_mem_perf_info(dev_sched));
@@ -220,7 +220,7 @@ namespace sham::details {
         // check max alloc sizes
         if constexpr (target == device) {
             if (sz > ds.get_queue().get_device_prop().max_mem_alloc_size_dev) {
-                std::string err_log = shambase::format(
+                std::string err_log = sham::format(
                     "You are trying to allocate more than the maximum allocation size allowed by "
                     "the "
                     "device\n"
@@ -233,7 +233,7 @@ namespace sham::details {
             size_t max_alloc_size_dev  = ds.get_queue().get_device_prop().max_mem_alloc_size_dev;
             size_t max_alloc_size_host = ds.get_queue().get_device_prop().max_mem_alloc_size_host;
             if (sz > sycl::min(max_alloc_size_dev, max_alloc_size_host)) {
-                std::string err_log = shambase::format(
+                std::string err_log = sham::format(
                     "You are trying to allocate more than the maximum allocation size allowed by "
                     "the "
                     "device\n"
@@ -244,7 +244,7 @@ namespace sham::details {
             }
         } else if constexpr (target == host) {
             if (sz > ds.get_queue().get_device_prop().max_mem_alloc_size_host) {
-                std::string err_log = shambase::format(
+                std::string err_log = sham::format(
                     "You are trying to allocate more than the maximum allocation size allowed by "
                     "the "
                     "host\n"
@@ -260,7 +260,7 @@ namespace sham::details {
         if (alignment) {
 
             if (*alignment % ds.get_queue().get_device_prop().mem_base_addr_align != 0) {
-                shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                shambase::throw_with_loc<std::runtime_error>(sham::format(
                     "The alignment of the USM pointer is not aligned with minimum device "
                     "alignment\n"
                     "  alignment = {} | device alignment = {} | alignment % device alignment = {}",
@@ -270,7 +270,7 @@ namespace sham::details {
             }
 
             if (sz % *alignment != 0) {
-                shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                shambase::throw_with_loc<std::runtime_error>(sham::format(
                     "The size of the USM pointer is not aligned with the given alignment\n"
                     "  size = {} | alignment = {} | size % alignment = {}",
                     sz,
@@ -316,7 +316,7 @@ namespace sham::details {
         if (usm_ptr == nullptr) {
             std::string err_msg = "";
             if (alignment) {
-                err_msg = shambase::format(
+                err_msg = sham::format(
                     "USM allocation failed, details : sz={}, target={}, alignment={}, alloc "
                     "result = {}",
                     sz,
@@ -324,7 +324,7 @@ namespace sham::details {
                     *alignment,
                     usm_ptr);
             } else {
-                err_msg = shambase::format(
+                err_msg = sham::format(
                     "USM allocation failed, details : sz={}, target={}, alloc result = {}",
                     sz,
                     get_mode_name<target>(),

--- a/src/shambase/include/shambase/DistributedData.hpp
+++ b/src/shambase/include/shambase/DistributedData.hpp
@@ -153,7 +153,7 @@ namespace shambase {
                     id_list.push_back(id);
                 });
 
-                throw make_except_with_loc<std::runtime_error>(shambase::format(
+                throw make_except_with_loc<std::runtime_error>(sham::format(
                     "The querried id {} does not exist, current id list is {}", id, id_list));
             }
         }
@@ -170,7 +170,7 @@ namespace shambase {
                     id_list.push_back(id);
                 });
 
-                throw make_except_with_loc<std::runtime_error>(shambase::format(
+                throw make_except_with_loc<std::runtime_error>(sham::format(
                     "The querried id {} does not exist, current id list is {}", id, id_list));
             }
         }
@@ -219,8 +219,7 @@ namespace shambase {
         template<typename... Tf>
         inline void print_data(fmt::format_string<Tf...> fmt) const {
             for_each([&](u64 id_patch, const T &ref) {
-                shambase::println(
-                    shambase::format("{} -> {}", id_patch, shambase::format(fmt, ref)));
+                shambase::println(sham::format("{} -> {}", id_patch, sham::format(fmt, ref)));
             });
         }
 

--- a/src/shambase/include/shambase/exception_ctx.hpp
+++ b/src/shambase/include/shambase/exception_ctx.hpp
@@ -39,7 +39,7 @@ namespace shambase {
         template<class T>
         args_info(std::string name, const T &value) : name(std::move(name)) {
             try {
-                this->value = shambase::format("{}", value);
+                this->value = sham::format("{}", value);
             } catch (const std::exception &e) {
                 this->value = "format failed : " + std::string(e.what());
             }

--- a/src/shambase/include/shambase/logs/msgformat.hpp
+++ b/src/shambase/include/shambase/logs/msgformat.hpp
@@ -87,15 +87,14 @@ namespace shambase::logs {
         else if constexpr (std::is_pointer_v<T>) {
             // Convert the pointer to a void pointer, format it as a hexadecimal string, and
             // concatenate it with the formatted string from the remaining arguments
-            return shambase::format("{} ", static_cast<const void *>(var1))
-                   + format_message(var2...);
+            return sham::format("{} ", static_cast<const void *>(var1)) + format_message(var2...);
         }
 
         else {
             // General case for other types
             // Format the argument as a string and concatenate it with the formatted string from the
             // remaining arguments
-            return shambase::format("{} ", var1) + format_message(var2...);
+            return sham::format("{} ", var1) + format_message(var2...);
         }
     }
 

--- a/src/shambase/include/shambase/memory.hpp
+++ b/src/shambase/include/shambase/memory.hpp
@@ -247,7 +247,7 @@ namespace shambase {
     template<int n, class T>
     inline std::array<T, n> convert_to_array(std::vector<T> &in) {
         if (in.size() != n) {
-            throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+            throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
                 "you've input values with the wrong size, input size = {}, wanted = {}",
                 in.size(),
                 n));

--- a/src/shambase/include/shambase/narrowing.hpp
+++ b/src/shambase/include/shambase/narrowing.hpp
@@ -88,7 +88,7 @@ namespace shambase {
             return static_cast<U>(val);
         } else {
             using lim_U = std::numeric_limits<U>;
-            throw make_except_with_loc<std::runtime_error>(shambase::format(
+            throw make_except_with_loc<std::runtime_error>(sham::format(
                 "value {} cannot be narrowed to type U (see signature) static_cast<U>({}) = {} "
                 "(U::min() = {}, U::max() = {})",
                 val,

--- a/src/shambase/include/shambase/string.hpp
+++ b/src/shambase/include/shambase/string.hpp
@@ -56,13 +56,13 @@ namespace shambase {
 
             if (i % column_count == 0) {
                 if (i == 0) {
-                    accum += shambase::format("{:8} : ", i);
+                    accum += sham::format("{:8} : ", i);
                 } else {
-                    accum += shambase::format("\n{:8} : ", i);
+                    accum += sham::format("\n{:8} : ", i);
                 }
             }
 
-            accum += shambase::format(fmt, iter[i]);
+            accum += sham::format(fmt, iter[i]);
         }
 
         return accum;
@@ -198,7 +198,7 @@ namespace shambase {
             throw make_except_with_loc<std::invalid_argument>(
                 "the string is too short to be shortened"
                 "\n args : "
-                + shambase::format("{} : {} \n {} : {}", "str", str, "len", len));
+                + sham::format("{} : {} \n {} : {}", "str", str, "len", len));
         }
         return str.substr(0, str.size() - len);
     }

--- a/src/shambase/include/shambase/tabulate.hpp
+++ b/src/shambase/include/shambase/tabulate.hpp
@@ -53,7 +53,7 @@ namespace shambase {
         void add_double_rule() { table_lines.push_back(double_rule{}); }
         void add_rulled_data(const std::vector<std::string> &colnames) {
             if (colnames.size() != cols_count) {
-                throw make_except_with_loc<std::invalid_argument>(shambase::format(
+                throw make_except_with_loc<std::invalid_argument>(sham::format(
                     "the number of column does not match colnames.size() != cols_count ({} != {})",
                     colnames.size(),
                     cols_count));
@@ -62,7 +62,7 @@ namespace shambase {
         }
         void add_data(const std::vector<std::string> &cols, positionning position) {
             if (cols.size() != cols_count) {
-                throw make_except_with_loc<std::invalid_argument>(shambase::format(
+                throw make_except_with_loc<std::invalid_argument>(sham::format(
                     "the number of column does not match cols.size() != cols_count ({} != {})",
                     cols.size(),
                     cols_count));
@@ -96,18 +96,18 @@ namespace shambase {
                     print += "\n|";
                     for (u32 i = 0; i < cols_count; i++) {
                         if (data_line->position == left) {
-                            print += shambase::format(" {:<{}} |", data_line->cols[i], widths[i]);
+                            print += sham::format(" {:<{}} |", data_line->cols[i], widths[i]);
                         } else if (data_line->position == right) {
-                            print += shambase::format(" {:>{}} |", data_line->cols[i], widths[i]);
+                            print += sham::format(" {:>{}} |", data_line->cols[i], widths[i]);
                         } else if (data_line->position == center) {
-                            print += shambase::format(" {:^{}} |", data_line->cols[i], widths[i]);
+                            print += sham::format(" {:^{}} |", data_line->cols[i], widths[i]);
                         }
                     }
 
                 } else if (rulled_data *head_and_ruller_line = std::get_if<rulled_data>(&line)) {
                     std::string tmp = "+";
                     for (u32 i = 0; i < cols_count; i++) {
-                        tmp += shambase::format(
+                        tmp += sham::format(
                             " {:^{}} +", head_and_ruller_line->colnames[i], widths[i]);
                     }
 
@@ -133,14 +133,12 @@ namespace shambase {
                 } else if (rule *rule_line = std::get_if<rule>(&line)) {
                     print += "\n+";
                     for (u32 i = 0; i < cols_count; i++) {
-                        print += shambase::format(
-                            "-{:<{}}-+", std::string(widths[i], '-'), widths[i]);
+                        print += sham::format("-{:<{}}-+", std::string(widths[i], '-'), widths[i]);
                     }
                 } else if (double_rule *double_rule_line = std::get_if<double_rule>(&line)) {
                     print += "\n+";
                     for (u32 i = 0; i < cols_count; i++) {
-                        print += shambase::format(
-                            "={:<{}}=+", std::string(widths[i], '='), widths[i]);
+                        print += sham::format("={:<{}}=+", std::string(widths[i], '='), widths[i]);
                     }
                 }
             }

--- a/src/shambase/src/profiling/chrome.cpp
+++ b/src/shambase/src/profiling/chrome.cpp
@@ -46,7 +46,7 @@ namespace {
             u64 tid;
 
             std::string to_string() const {
-                return shambase::format(
+                return sham::format(
                     "{{\"name\": \"{}\", \"cat\": \"{}\", \"ph\": \"B\", \"ts\": {}, \"pid\": {}, "
                     "\"tid\": "
                     "{}}},\n",
@@ -66,7 +66,7 @@ namespace {
             u64 tid;
 
             std::string to_string() const {
-                return shambase::format(
+                return sham::format(
                     "{{\"name\": \"{}\", \"cat\": \"{}\", \"ph\": \"E\", \"ts\": {}, \"pid\": {}, "
                     "\"tid\": "
                     "{}}},\n",
@@ -87,7 +87,7 @@ namespace {
             u64 tid;
 
             std::string to_string() const {
-                return shambase::format(
+                return sham::format(
                     "{{\"name\": \"{}\", \"cat\": \"{}\", \"ph\": \"X\", \"ts\": {}, \"dur\": {}, "
                     "\"pid\": {}, "
                     "\"tid\": "
@@ -108,7 +108,7 @@ namespace {
             u64 pid;
 
             std::string to_string() const {
-                return shambase::format(
+                return sham::format(
                     "{{ \"pid\": {}, \"ph\": \"C\", \"ts\":  {}, \"args\": {{\"{}\": {:e} }} }},\n",
                     pid,
                     to_prof_time(t),

--- a/src/shambase/src/stacktrace.cpp
+++ b/src/shambase/src/stacktrace.cpp
@@ -40,7 +40,7 @@ namespace shambase::details {
 
     std::string ChromeProfileEntry::format(u32 world_rank) {
         if (is_start) {
-            return shambase::format_printf(
+            return sham::format_printf(
                 R"({
                 "cat": "%s",
                 "pid": %d,
@@ -58,7 +58,7 @@ namespace shambase::details {
                 name.c_str());
 
         } else {
-            return shambase::format_printf(
+            return sham::format_printf(
                 R"({
                 "cat": "%s",
                 "pid": %d,
@@ -164,7 +164,7 @@ namespace shambase::details {
          * @return std::string JSON string representation of the profile entry
          */
         std::string format() {
-            return shambase::format_printf(
+            return sham::format_printf(
                 R"({"tstart": %f, "tend": %f, "name": "%s"})", time_start, time_end, entry_name);
         }
     };
@@ -259,7 +259,7 @@ namespace shambase {
         }
 
         for (u32 i = 0; i < lines.size(); i++) {
-            ss << shambase::format(" {:2} : {}\n", i, lines[i]);
+            ss << sham::format(" {:2} : {}\n", i, lines[i]);
         }
 
         for (auto &generator : _callstack_gen_info_generators) {

--- a/src/shambindings/src/pybindings.cpp
+++ b/src/shambindings/src/pybindings.cpp
@@ -156,7 +156,7 @@ namespace shambindings {
     void expect_init_lib(SourceLocation loc) {
         if (init_state != Lib) {
             shambase::throw_with_loc<std::runtime_error>(
-                shambase::format(
+                sham::format(
                     "python bindings not initialized as lib mode, current mode = {}",
                     i32(init_state)),
                 loc);
@@ -166,7 +166,7 @@ namespace shambindings {
     void expect_init_embed(SourceLocation loc) {
         if (init_state != Embed) {
             shambase::throw_with_loc<std::runtime_error>(
-                shambase::format(
+                sham::format(
                     "python bindings not initialized as embed mode, current mode = {}",
                     i32(init_state)),
                 loc);

--- a/src/shamcmdopt/src/cmdopt.cpp
+++ b/src/shamcmdopt/src/cmdopt.cpp
@@ -167,7 +167,7 @@ namespace shamcmdopt {
         for (auto &[n, arg, desc] : registered_opts) {
             if (name == n) {
                 shambase::throw_with_loc<std::invalid_argument>(
-                    shambase::format("The option {} is already registered", name));
+                    sham::format("The option {} is already registered", name));
             }
         }
 
@@ -209,7 +209,7 @@ namespace shamcmdopt {
     }
 
     void print_help() {
-        shambase::println(shambase::format("executable : {}", executable_name));
+        shambase::println(sham::format("executable : {}", executable_name));
 
         fmt::println("\nUsage :");
 
@@ -223,7 +223,7 @@ namespace shamcmdopt {
             std::string arg_print = arg.value_or("");
 
             shambase::println(
-                shambase::format_printf(
+                sham::format_printf(
                     "%-15s %-15s : %s", n.c_str(), arg_print.c_str(), desc.c_str()));
         }
         print_help_env_var();

--- a/src/shamcmdopt/src/details/generic_opts.cpp
+++ b/src/shamcmdopt/src/details/generic_opts.cpp
@@ -124,7 +124,7 @@ namespace shamcmdopt {
             }
 
             shambase::println(
-                shambase::format(
+                sham::format(
                     "  tty size = {}x{}",
                     sham::term::get_tty_lines(),
                     sham::term::get_tty_columns()));

--- a/src/shamcmdopt/src/env.cpp
+++ b/src/shamcmdopt/src/env.cpp
@@ -45,7 +45,7 @@ void shamcmdopt::register_env_var_doc(std::string env_var, std::string desc) {
     for (auto &[_env_var, _desc] : env_var_reg) {
         if (_env_var == env_var) {
             shambase::throw_with_loc<std::invalid_argument>(
-                shambase::format("The env var {} is already registered", env_var));
+                sham::format("The env var {} is already registered", env_var));
         }
     }
 
@@ -60,7 +60,7 @@ void shamcmdopt::print_help_env_var() {
 
     auto stringify = [](std::optional<std::string> val) -> std::string {
         if (val) {
-            return shambase::format("= {}", *val);
+            return sham::format("= {}", *val);
         }
         return "";
     };
@@ -69,10 +69,10 @@ void shamcmdopt::print_help_env_var() {
     for (const auto &[var, desc] : env_var_reg) {
         auto val = getenv_str(var.c_str());
 
-        shambase::println(shambase::format("  {:<29} : {}", var, desc));
+        shambase::println(sham::format("  {:<29} : {}", var, desc));
 
         if (val) {
-            shambase::println(shambase::format("    = {}", *val));
+            shambase::println(sham::format("    = {}", *val));
         }
     }
 }

--- a/src/shamcomm/src/logs.cpp
+++ b/src/shamcomm/src/logs.cpp
@@ -36,7 +36,7 @@ namespace shamcomm::logs {
             raw_ln("If you've seen spam in your life i can garantee you, this is worst");
         }
 
-        raw_ln(shambase::format(" - Loglevel: {}, enabled log types :", u32(get_loglevel())));
+        raw_ln(sham::format(" - Loglevel: {}, enabled log types :", u32(get_loglevel())));
 
 // logger::raw_ln(terminal_effects::faint + "----------------------" + terminal_effects::reset);
 

--- a/src/shamcomm/src/worldInfo.cpp
+++ b/src/shamcomm/src/worldInfo.cpp
@@ -55,7 +55,7 @@ namespace shamcomm {
         std::optional<u32> local_rank = node_local_rank();
 
         shambase::set_callstack_process_identifier(
-            shambase::format(
+            sham::format(
                 "{} (world rank: {}, local rank: {})",
                 _mpi_process_name,
                 world_rank(),

--- a/src/shamcomm/src/wrapper.cpp
+++ b/src/shamcomm/src/wrapper.cpp
@@ -79,7 +79,7 @@ namespace shamcomm::mpi {
 
     void check_tag_value(i32 tag) {
         if (tag > mpi_max_tag_value()) {
-            shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+            shambase::throw_with_loc<std::invalid_argument>(sham::format(
                 "mpi_max_tag_value ({}) exceeded with tag {}", mpi_max_tag_value(), tag));
         }
     }

--- a/src/shammath/src/CoordRange.cpp
+++ b/src/shammath/src/CoordRange.cpp
@@ -24,7 +24,7 @@ namespace shammath {
     template<class T>
     void throw_ill_formed(
         T lower, T upper, SourceLocation call, SourceLocation loc = SourceLocation{}) {
-        throw shambase::make_except_with_loc<std::runtime_error>(shambase::format(
+        throw shambase::make_except_with_loc<std::runtime_error>(sham::format(
             "this range is ill formed normally upper > lower\n     lower = {}, upper = {}\n     "
             "call to check_throw = {}",
             lower,

--- a/src/shammodels/common/src/timestep_report.cpp
+++ b/src/shammodels/common/src/timestep_report.cpp
@@ -139,18 +139,18 @@ std::string shammodels::report_perf_timestep(
     table.add_double_rule();
     for (u32 i = 0; i < shamcomm::world_size(); i++) {
         std::vector<std::string> row = {
-            shambase::format("{:<4}", i),
-            shambase::format("{:.4e}", rate_all_ranks[i]),
-            shambase::format("{:}", nobj_all_ranks[i]),
-            shambase::format("{:}", npatch_all_ranks[i]),
-            shambase::format("{:.3e}", tcompute_all_ranks[i]),
-            shambase::format("{:.1f}%", 100 * (mpi_timer_all_ranks[i] / tcompute_all_ranks[i])),
-            shambase::format(
+            sham::format("{:<4}", i),
+            sham::format("{:.4e}", rate_all_ranks[i]),
+            sham::format("{:}", nobj_all_ranks[i]),
+            sham::format("{:}", npatch_all_ranks[i]),
+            sham::format("{:.3e}", tcompute_all_ranks[i]),
+            sham::format("{:.1f}%", 100 * (mpi_timer_all_ranks[i] / tcompute_all_ranks[i])),
+            sham::format(
                 "{:>.1f}% {:<.1f}%",
                 100 * (alloc_time_device_all_ranks[i] / tcompute_all_ranks[i]),
                 100 * (alloc_time_host_all_ranks[i] / tcompute_all_ranks[i])),
-            shambase::format("{}", shambase::readable_sizeof(max_mem_device_all_ranks[i])),
-            shambase::format("{}", shambase::readable_sizeof(max_mem_host_all_ranks[i])),
+            sham::format("{}", shambase::readable_sizeof(max_mem_device_all_ranks[i])),
+            sham::format("{}", shambase::readable_sizeof(max_mem_host_all_ranks[i])),
         };
         if (report_power_usage) {
             if (shamsys::support_rank_energy_consummed()) {
@@ -188,17 +188,17 @@ std::string shammodels::report_perf_timestep(
         table.add_rulled_data(ruled);
         std::vector<std::string> all_row = {
             "all",
-            shambase::format("{:.4e}", f64(obj_total) / max_t),
-            shambase::format("{:}", obj_total),
-            shambase::format("{:}", npatch_total),
-            shambase::format("{:.3e}", max_t),
-            shambase::format("{:.1f}%", 100 * (sum_mpi / sum_t)),
-            shambase::format(
+            sham::format("{:.4e}", f64(obj_total) / max_t),
+            sham::format("{:}", obj_total),
+            sham::format("{:}", npatch_total),
+            sham::format("{:.3e}", max_t),
+            sham::format("{:.1f}%", 100 * (sum_mpi / sum_t)),
+            sham::format(
                 "{:>.1f}% {:<.1f}%",
                 100 * (sum_alloc_device / sum_t),
                 100 * (sum_alloc_host / sum_t)),
-            shambase::format("{}", shambase::readable_sizeof(sum_mem_device_total)),
-            shambase::format("{}", shambase::readable_sizeof(sum_mem_host_total)),
+            sham::format("{}", shambase::readable_sizeof(sum_mem_device_total)),
+            sham::format("{}", shambase::readable_sizeof(sum_mem_host_total)),
         };
         if (report_power_usage) {
             if (shamsys::support_rank_energy_consummed()) {

--- a/src/shammodels/gsph/include/shammodels/gsph/Model.hpp
+++ b/src/shammodels/gsph/include/shammodels/gsph/Model.hpp
@@ -228,7 +228,7 @@ namespace shammodels::gsph {
 
                     // Validate ivar parameter to prevent out-of-bounds access
                     if (ivar >= nvar) {
-                        shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                        shambase::throw_with_loc<std::invalid_argument>(sham::format(
                             "set_field_in_box: ivar ({}) >= f.get_nvar ({}) for field {}",
                             ivar,
                             nvar,

--- a/src/shammodels/gsph/src/Model.cpp
+++ b/src/shammodels/gsph/src/Model.cpp
@@ -217,7 +217,7 @@ void shammodels::gsph::Model<Tvec, SPHKernel>::add_cube_fcc_3d(
                 return;
             }
 
-            log += shambase::format(
+            log += sham::format(
                 "\n  rank = {}  patch id={}, add N={} particles, coords = {} {}",
                 shamcomm::world_rank(),
                 p.id_patch,
@@ -322,7 +322,7 @@ void shammodels::gsph::Model<Tvec, SPHKernel>::add_cube_hcp_3d(
                 return;
             }
 
-            log += shambase::format(
+            log += sham::format(
                 "\n  rank = {}  patch id={}, add N={} particles, coords = {} {}",
                 shamcomm::world_rank(),
                 p.id_patch,

--- a/src/shammodels/gsph/src/Solver.cpp
+++ b/src/shammodels/gsph/src/Solver.cpp
@@ -670,7 +670,7 @@ void shammodels::gsph::Solver<Tvec, Kern>::gsph_prestep(Tscal time_val, Tscal dt
         Tscal max_eps_h;
 
         if (solver_config.gpart_mass == 0) {
-            shambase::throw_with_loc<std::runtime_error>(shambase::format(
+            shambase::throw_with_loc<std::runtime_error>(sham::format(
                 "invalid gpart_mass {}, this configuration can not converge.\n"
                 "Please set it using either model.set_particle_mass(pmass) or "
                 "cfg.set_particle_mass(pmass)",
@@ -795,7 +795,7 @@ void shammodels::gsph::Solver<Tvec, Kern>::gsph_prestep(Tscal time_val, Tscal dt
                         {
                             sycl::host_accessor acc{idx_err};
                             for (u32 i = 0; i < idx_err.size(); i++) {
-                                add_info += shambase::format(
+                                add_info += sham::format(
                                     "{} - pos : {}, hpart : {}\n", acc[i], pos[acc[i]], h[acc[i]]);
                             }
                         }
@@ -1813,8 +1813,7 @@ shammodels::gsph::TimestepLog shammodels::gsph::Solver<Tvec, Kern>::evolve_once(
 
     if (shamcomm::world_rank() == 0) {
         shamcomm::logs::raw_ln(
-            shambase::format(
-                "---------------- GSPH t = {}, dt = {} ----------------", t_current, dt));
+            sham::format("---------------- GSPH t = {}, dt = {} ----------------", t_current, dt));
     }
 
     shambase::Timer tstep;

--- a/src/shammodels/gsph/src/modules/GSPHGhostHandler.cpp
+++ b/src/shammodels/gsph/src/modules/GSPHGhostHandler.cpp
@@ -344,7 +344,7 @@ auto GSPHGhostHandler<vec>::gen_id_table_interfaces(GeneratorMap &&gen)
 
     for (auto &[k, v] : send_count_stats) {
         if (v > 0.2) {
-            warn_log += shambase::format("\n    patch {} high interf/patch volume: {}", k, v);
+            warn_log += sham::format("\n    patch {} high interf/patch volume: {}", k, v);
             has_warn = true;
         }
     }
@@ -371,13 +371,13 @@ void GSPHGhostHandler<vec>::gen_debug_patch_ghost(
 
     std::string loc_graph = "";
     interf_info.for_each([&loc_graph](u64 send, u64 recv, InterfaceIdTable &info) {
-        loc_graph += shambase::format("    p{} -> p{}\n", send, recv);
+        loc_graph += sham::format("    p{} -> p{}\n", send, recv);
     });
 
     sched.for_each_patch_data(
         [&](u64 id, shamrock::patch::Patch p, shamrock::patch::PatchDataLayer &pdat) {
             if (pdat.get_obj_cnt() > 0) {
-                loc_graph += shambase::format(
+                loc_graph += sham::format(
                     "    p{} [label= \"id={} N={}\"]\n", id, id, pdat.get_obj_cnt());
             }
         });
@@ -388,7 +388,7 @@ void GSPHGhostHandler<vec>::gen_debug_patch_ghost(
     dot_graph = "strict digraph {\n" + dot_graph + "}";
 
     if (shamcomm::world_rank() == 0) {
-        std::string fname = shambase::format("ghost_graph_{}.dot", cnt_dump_debug);
+        std::string fname = sham::format("ghost_graph_{}.dot", cnt_dump_debug);
         logger::info_ln("GSPH Ghost", "writing", fname);
         shambase::write_string_to_file(fname, dot_graph);
         cnt_dump_debug++;

--- a/src/shammodels/ramses/include/shammodels/ramses/SolverConfig.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/SolverConfig.hpp
@@ -268,8 +268,8 @@ struct shammodels::basegodunov::SolverConfig {
 
     inline void check_config() {
         if (grid_coord_to_pos_fact <= 0) {
-            shambase::throw_with_loc<std::runtime_error>(shambase::format(
-                "grid_coord_to_pos_fact must be > 0, got {}", grid_coord_to_pos_fact));
+            shambase::throw_with_loc<std::runtime_error>(
+                sham::format("grid_coord_to_pos_fact must be > 0, got {}", grid_coord_to_pos_fact));
         }
 
         if (is_dust_on()) {
@@ -281,7 +281,7 @@ struct shammodels::basegodunov::SolverConfig {
             u32 mode = gravity_config.gravity_mode;
 
             shamrock::experimental_feature_check(
-                shambase::format(
+                sham::format(
                     "self gravity mode is not enabled but gravity mode is set to {} (> 0 whith 0 "
                     "== "
                     "NoGravity mode)",
@@ -290,13 +290,13 @@ struct shammodels::basegodunov::SolverConfig {
 
         if (!(eos_gamma > 1.0)) {
             shambase::throw_with_loc<std::invalid_argument>(
-                shambase::format("Gamma must be > 1, currently Gamma = {}", eos_gamma));
+                sham::format("Gamma must be > 1, currently Gamma = {}", eos_gamma));
         }
 
         if (is_gas_passive_scalar_on()) {
             ON_RANK_0(logger::warn_ln("Ramses::SolverConfig", "Passive scalars are experimental"));
             shamrock::experimental_feature_check(
-                shambase::format(
+                sham::format(
                     "gas passive scalars mode is not enabled but gas passive scalars mode is set "
                     "to {}"
                     "> 0",

--- a/src/shammodels/ramses/include/shammodels/ramses/modules/ComputeCoordinates.hpp
+++ b/src/shammodels/ramses/include/shammodels/ramses/modules/ComputeCoordinates.hpp
@@ -58,7 +58,7 @@ namespace shammodels::basegodunov::modules {
 
             if (block_nside != 2) {
                 shambase::throw_with_loc<std::runtime_error>(
-                    shambase::format("this module assume block_nside=2, got {}", block_nside));
+                    sham::format("this module assume block_nside=2, got {}", block_nside));
             }
         }
 

--- a/src/shammodels/ramses/src/Model.cpp
+++ b/src/shammodels/ramses/src/Model.cpp
@@ -60,19 +60,19 @@ void shammodels::basegodunov::Model<Tvec, TgridVec>::make_base_grid(
     TgridVec bmin, TgridVec cell_size, u32_3 cell_count) {
 
     if (cell_size.x() < Solver::Config::AMRBlock::Nside) {
-        shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+        shambase::throw_with_loc<std::invalid_argument>(sham::format(
             "the x block size must be larger than {}, currently : cell_size = {}",
             Solver::Config::AMRBlock::Nside,
             cell_size));
     }
     if (cell_size.y() < Solver::Config::AMRBlock::Nside) {
-        shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+        shambase::throw_with_loc<std::invalid_argument>(sham::format(
             "the y block size must be larger than {}, currently : cell_size = {}",
             Solver::Config::AMRBlock::Nside,
             cell_size));
     }
     if (cell_size.z() < Solver::Config::AMRBlock::Nside) {
-        shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+        shambase::throw_with_loc<std::invalid_argument>(sham::format(
             "the z block size must be larger than {}, currently : cell_size = {}",
             Solver::Config::AMRBlock::Nside,
             cell_size));

--- a/src/shammodels/ramses/src/Solver.cpp
+++ b/src/shammodels/ramses/src/Solver.cpp
@@ -164,7 +164,7 @@ class PatchDataLayerToVtk : public shamrock::solvergraph::INode {
             using Block = shammodels::amr::AMRBlock<Tvec, TgridVec, 1>;
 
             if (Block::block_size != block_size) {
-                shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                shambase::throw_with_loc<std::runtime_error>(sham::format(
                     "block_size mismatch, got {} expected {}", Block::block_size, block_size));
             }
 
@@ -1532,7 +1532,7 @@ void shammodels::basegodunov::Solver<Tvec, TgridVec>::evolve_once() {
     Tscal dt_input  = get_dt();
 
     if (shamcomm::world_rank() == 0) {
-        logger::normal_ln("amr::Godunov", shambase::format("t = {}, dt = {}", t_current, dt_input));
+        logger::normal_ln("amr::Godunov", sham::format("t = {}, dt = {}", t_current, dt_input));
     }
 
     if (solver_config.face_half_time_interpolation) {

--- a/src/shammodels/ramses/src/modules/ComputeCellAABB.cpp
+++ b/src/shammodels/ramses/src/modules/ComputeCellAABB.cpp
@@ -121,9 +121,9 @@ namespace shammodels::basegodunov::modules {
         shambase::replace_all(tex, "{block_max}", block_max);
         shambase::replace_all(tex, "{block_cell_sizes}", block_cell_sizes);
         shambase::replace_all(tex, "{cell0block_aabb_lower}", cell0block_aabb_lower);
-        shambase::replace_all(tex, "{block_nside}", shambase::format("{}", block_nside));
+        shambase::replace_all(tex, "{block_nside}", sham::format("{}", block_nside));
         shambase::replace_all(
-            tex, "{grid_coord_to_pos_fact}", shambase::format("{}", grid_coord_to_pos_fact));
+            tex, "{grid_coord_to_pos_fact}", sham::format("{}", grid_coord_to_pos_fact));
 
         return tex;
     }

--- a/src/shammodels/ramses/src/modules/ComputeCoordinates.cpp
+++ b/src/shammodels/ramses/src/modules/ComputeCoordinates.cpp
@@ -107,9 +107,9 @@ namespace shammodels::basegodunov::modules {
         shambase::replace_all(tex, "{block_min}", block_min);
         shambase::replace_all(tex, "{block_max}", block_max);
         shambase::replace_all(tex, "{cell_coord}", cell_coord);
-        shambase::replace_all(tex, "{block_nside}", shambase::format("{}", block_nside));
+        shambase::replace_all(tex, "{block_nside}", sham::format("{}", block_nside));
         shambase::replace_all(
-            tex, "{grid_coord_to_pos_fact}", shambase::format("{}", grid_coord_to_pos_fact));
+            tex, "{grid_coord_to_pos_fact}", sham::format("{}", grid_coord_to_pos_fact));
 
         return tex;
     }

--- a/src/shammodels/ramses/src/modules/ComputeMass.cpp
+++ b/src/shammodels/ramses/src/modules/ComputeMass.cpp
@@ -101,7 +101,7 @@ namespace shammodels::basegodunov::modules {
         shambase::replace_all(tex, "{rho}", rho);
         shambase::replace_all(tex, "{mass}", mass);
         shambase::replace_all(tex, "{block_count}", block_count);
-        shambase::replace_all(tex, "{block_size}", shambase::format("{}", block_size));
+        shambase::replace_all(tex, "{block_size}", sham::format("{}", block_size));
 
         return tex;
     }

--- a/src/shammodels/ramses/src/modules/ComputeSumOverV.cpp
+++ b/src/shammodels/ramses/src/modules/ComputeSumOverV.cpp
@@ -64,7 +64,7 @@ namespace shammodels::basegodunov::modules {
         shambase::replace_all(tex, "{field}", field);
         shambase::replace_all(tex, "{mean}", mean);
         shambase::replace_all(tex, "{block_count}", block_count);
-        shambase::replace_all(tex, "{block_size}", shambase::format("{}", block_size));
+        shambase::replace_all(tex, "{block_size}", sham::format("{}", block_size));
 
         return tex;
     }

--- a/src/shammodels/ramses/src/modules/ConsToPrimDust.cpp
+++ b/src/shammodels/ramses/src/modules/ConsToPrimDust.cpp
@@ -106,8 +106,8 @@ namespace shammodels::basegodunov::modules {
         shambase::replace_all(tex, "{rho}", rho);
         shambase::replace_all(tex, "{rhov}", rhov);
         shambase::replace_all(tex, "{block_count}", block_count);
-        shambase::replace_all(tex, "{ndust}", shambase::format("{}", ndust));
-        shambase::replace_all(tex, "{block_size}", shambase::format("{}", block_size));
+        shambase::replace_all(tex, "{ndust}", sham::format("{}", ndust));
+        shambase::replace_all(tex, "{block_size}", sham::format("{}", block_size));
 
         return tex;
     }

--- a/src/shammodels/ramses/src/modules/ConsToPrimGas.cpp
+++ b/src/shammodels/ramses/src/modules/ConsToPrimGas.cpp
@@ -122,8 +122,8 @@ namespace shammodels::basegodunov::modules {
         shambase::replace_all(tex, "{rhov}", rhov);
         shambase::replace_all(tex, "{rhoe}", rhoe);
         shambase::replace_all(tex, "{block_count}", block_count);
-        shambase::replace_all(tex, "{gamma}", shambase::format("{}", gamma));
-        shambase::replace_all(tex, "{block_size}", shambase::format("{}", block_size));
+        shambase::replace_all(tex, "{gamma}", sham::format("{}", gamma));
+        shambase::replace_all(tex, "{block_size}", sham::format("{}", block_size));
 
         return tex;
     }

--- a/src/shammodels/ramses/src/modules/DragIntegrator.cpp
+++ b/src/shammodels/ramses/src/modules/DragIntegrator.cpp
@@ -573,7 +573,7 @@ void shammodels::basegodunov::modules::DragIntegrator<Tvec, TgridVec>::enable_ex
         } else {
 
             if (loc_mem_size > q.get_device_prop().local_mem_size) {
-                shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                shambase::throw_with_loc<std::runtime_error>(sham::format(
                     "not enough local memory for expo drag integrator:\n"
                     "loc_mem_size: {} > max_local_mem: {}\n"
                     "loc_acc_size: {}\n"
@@ -595,7 +595,7 @@ void shammodels::basegodunov::modules::DragIntegrator<Tvec, TgridVec>::enable_ex
                 sycl::local_accessor<Tscal> local_Id(loc_acc_size, cgh);
 
                 logger::debug_sycl_ln(
-                    "SYCL", shambase::format("parallel_for add_drag [expo-shared-mem]"));
+                    "SYCL", sham::format("parallel_for add_drag [expo-shared-mem]"));
                 cgh.parallel_for(
                     shambase::make_range(cell_count, group_size), [=](sycl::nd_item<1> id) {
                         u32 loc_id = id.get_local_id();

--- a/src/shammodels/ramses/src/modules/TransformGhostLayer.cpp
+++ b/src/shammodels/ramses/src/modules/TransformGhostLayer.cpp
@@ -56,7 +56,7 @@ void shammodels::basegodunov::modules::TransformGhostLayer<Tvec, TgridVec>::
 
     if (ghost_layer.patchdatas.get_element_count()
         != ghost_layers_candidates.values.get_element_count()) {
-        shambase::throw_with_loc<std::runtime_error>(shambase::format(
+        shambase::throw_with_loc<std::runtime_error>(sham::format(
             "ghost_layer.patchdatas.get_element_count() != "
             "ghost_layers_candidates.values.get_element_count()\n "
             "ghost_layer.patchdatas.get_element_count(): {}\n"
@@ -162,7 +162,7 @@ void shammodels::basegodunov::modules::TransformGhostLayer<Tvec, TgridVec>::
             } else if (nvar == 1) {
                 // do nothing
             } else {
-                throw shambase::make_except_with_loc<std::runtime_error>(shambase::format(
+                throw shambase::make_except_with_loc<std::runtime_error>(sham::format(
                     "the number of variables is not equal to the expected number of variables: {} "
                     "!= {}, field name: {}, layout: {}",
                     nvar,

--- a/src/shammodels/sph/include/shammodels/sph/Model.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/Model.hpp
@@ -217,7 +217,7 @@ namespace shammodels::sph {
 
                     auto f_nvar = f.get_nvar();
                     if (offset >= f_nvar) {
-                        shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                        shambase::throw_with_loc<std::invalid_argument>(sham::format(
                             "offset ({}) is out of bounds for field '{}' with nvar {}",
                             offset,
                             field_name,
@@ -254,7 +254,7 @@ namespace shammodels::sph {
 
                     auto f_nvar = f.get_nvar();
                     if (offset >= f_nvar) {
-                        shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                        shambase::throw_with_loc<std::invalid_argument>(sham::format(
                             "offset ({}) is out of bounds for field '{}' with nvar {}",
                             offset,
                             field_name,
@@ -264,7 +264,7 @@ namespace shammodels::sph {
                     auto result = field_compute(shamrock::pdat_to_dic(pdat));
 
                     if (result.size() != f.get_obj_cnt()) {
-                        throw shambase::make_except_with_loc<std::runtime_error>(shambase::format(
+                        throw shambase::make_except_with_loc<std::runtime_error>(sham::format(
                             "result.size() != f.get_obj_cnt() ({} != {})",
                             result.size(),
                             f.get_obj_cnt()));
@@ -399,7 +399,7 @@ namespace shammodels::sph {
                     vec_cs.push_back(o.cs);
                 }
 
-                log += shambase::format(
+                log += sham::format(
                     "\n    patch id={}, add N={} particles", ptch.id_patch, vec_pos.size());
 
                 PatchDataLayer tmp(sched.get_layout_ptr_old());
@@ -484,7 +484,7 @@ namespace shammodels::sph {
 
             log = "";
             sched.for_each_local_patchdata([&](const Patch &p, PatchDataLayer &pdat) {
-                log += shambase::format(
+                log += sham::format(
                     "\n    patch id={}, N={} particles", p.id_patch, pdat.get_obj_cnt());
             });
 
@@ -565,7 +565,7 @@ namespace shammodels::sph {
                         vec_u.push_back(U(cs));
                     });
 
-                log += shambase::format(
+                log += sham::format(
                     "\n    patch id={}, add N={} particles", ptch.id_patch, vec_acc.size());
 
                 PatchDataLayer tmp(sched.get_layout_ptr_old());
@@ -640,7 +640,7 @@ namespace shammodels::sph {
 
             log = "";
             sched.for_each_local_patchdata([&](const Patch &p, PatchDataLayer &pdat) {
-                log += shambase::format(
+                log += sham::format(
                     "\n    patch id={}, N={} particles", p.id_patch, pdat.get_obj_cnt());
             });
 
@@ -679,7 +679,7 @@ namespace shammodels::sph {
                         = pdat.template get_field<T>(sched.pdl_old().get_field_idx<T>(field_name));
 
                     if (ivar >= f.get_nvar()) {
-                        shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                        shambase::throw_with_loc<std::invalid_argument>(sham::format(
                             "You are trying to set value in a box for field ({}) with "
                             "ivar ({}) >= f.get_nvar ({})",
                             field_name,
@@ -883,7 +883,7 @@ namespace shammodels::sph {
 
         inline void change_htolerances(Tscal in_coarse, Tscal in_fine) {
             if (in_coarse < in_fine) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "in_coarse ({}) must be greater than in_fine ({})", in_coarse, in_fine));
             }
             solver.solver_config.htol_up_coarse_cycle = in_coarse;

--- a/src/shammodels/sph/include/shammodels/sph/Solver.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/Solver.hpp
@@ -311,7 +311,7 @@ namespace shammodels::sph {
             if (shamcomm::world_rank() == 0) {
                 logger::info_ln(
                     "SPH",
-                    shambase::format(
+                    sham::format(
                         "evolve_until (target_time = {:.2f}s, niter_max = {}, max_walltime = "
                         "{:.2f}s)",
                         target_time,
@@ -375,7 +375,7 @@ namespace shammodels::sph {
                         if (shamcomm::world_rank() == 0) {
                             logger::info_ln(
                                 "SPH",
-                                shambase::format(
+                                sham::format(
                                     "stopping evolve until because of "
                                     "max_walltime = {:.2f}s > {:.2f}s",
                                     global_walltime,
@@ -411,7 +411,7 @@ namespace shammodels::sph {
                     if (shamcomm::world_rank() == 0) {
                         logger::info_ln(
                             "SPH",
-                            shambase::format(
+                            sham::format(
                                 "next walltime check in {:.2f}s (niter = {}) global walltime = "
                                 "{:.2f}s (max_walltime = {:.2f}s)",
                                 iters_to_next_check * sec_per_iter,

--- a/src/shammodels/sph/include/shammodels/sph/io/PhantomDump.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/io/PhantomDump.hpp
@@ -60,7 +60,7 @@ namespace shammodels::sph {
          * @param val the value of the entry
          */
         void add(std::string s, T val) {
-            s = shambase::format("{:16s}", s);
+            s = sham::format("{:16s}", s);
             entries.push_back({s, val});
         }
 
@@ -306,7 +306,7 @@ namespace shammodels::sph {
         template<class T>
         void fill_vec(std::string field_name, std::vector<T> &vec) {
 
-            field_name = shambase::format("{:16s}", field_name);
+            field_name = sham::format("{:16s}", field_name);
 
             for (auto &tmp : blocks_fort_int) {
                 tmp.fill_vec(field_name, vec);
@@ -435,7 +435,7 @@ namespace shammodels::sph {
          */
         inline bool has_header_entry(std::string s) const {
 
-            s = shambase::format("{:16s}", s);
+            s = sham::format("{:16s}", s);
 
             if (auto tmp = table_header_fort_int.fetch(s); tmp) {
                 return true;
@@ -477,7 +477,7 @@ namespace shammodels::sph {
         template<class T>
         inline T read_header_float(std::string s) const {
 
-            s = shambase::format("{:16s}", s);
+            s = sham::format("{:16s}", s);
 
             if (auto tmp = table_header_fort_real.fetch(s); tmp) {
                 return *tmp;
@@ -506,7 +506,7 @@ namespace shammodels::sph {
         inline std::vector<T> read_header_floats(std::string s) {
             std::vector<T> vec{};
 
-            s = shambase::format("{:16s}", s);
+            s = sham::format("{:16s}", s);
 
             table_header_fort_real.fetch_multiple(vec, s);
             table_header_f32.fetch_multiple(vec, s);
@@ -527,7 +527,7 @@ namespace shammodels::sph {
         template<class T>
         inline T read_header_int(std::string s) const {
 
-            s = shambase::format("{:16s}", s);
+            s = sham::format("{:16s}", s);
 
             if (auto tmp = table_header_fort_int.fetch(s); tmp) {
                 return *tmp;
@@ -562,7 +562,7 @@ namespace shammodels::sph {
         inline std::vector<T> read_header_ints(std::string s) {
             std::vector<T> vec{};
 
-            s = shambase::format("{:16s}", s);
+            s = sham::format("{:16s}", s);
 
             table_header_fort_int.fetch_multiple(vec, s);
             table_header_i8.fetch_multiple(vec, s);

--- a/src/shammodels/sph/include/shammodels/sph/modules/BallabioTsLimiter.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/BallabioTsLimiter.hpp
@@ -101,7 +101,7 @@ namespace shammodels::sph::modules {
             )tex";
 
             shambase::replace_all(tex, "{part_counts}", part_counts);
-            shambase::replace_all(tex, "{ndust}", shambase::format("{}", ndust));
+            shambase::replace_all(tex, "{ndust}", sham::format("{}", ndust));
             shambase::replace_all(tex, "{hpart}", hpart);
             shambase::replace_all(tex, "{cs}", cs);
             shambase::replace_all(tex, "{t_j}", t_j);

--- a/src/shammodels/sph/include/shammodels/sph/modules/ComputeDustTtilde.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/ComputeDustTtilde.hpp
@@ -172,8 +172,8 @@ namespace shammodels::sph::modules {
             shambase::replace_all(tex, "{s_j}", s_j);
             shambase::replace_all(tex, "{t_j}", t_j);
             shambase::replace_all(tex, "{Ttilde_sj}", Ttilde_sj);
-            shambase::replace_all(tex, "{ndust}", shambase::format("{}", ndust));
-            shambase::replace_all(tex, "{hfact}", shambase::format("{}", Kernel::hfactd));
+            shambase::replace_all(tex, "{ndust}", sham::format("{}", ndust));
+            shambase::replace_all(tex, "{hfact}", sham::format("{}", Kernel::hfactd));
 
             return tex;
         };

--- a/src/shammodels/sph/include/shammodels/sph/modules/MonoFluidTVADeltav.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/MonoFluidTVADeltav.hpp
@@ -164,7 +164,7 @@ namespace shammodels::sph::modules {
 
             shambase::replace_all(tex, "{gpart_mass}", gpart_mass);
             shambase::replace_all(tex, "{part_counts}", part_counts);
-            shambase::replace_all(tex, "{ndust}", shambase::format("{}", ndust));
+            shambase::replace_all(tex, "{ndust}", sham::format("{}", ndust));
             shambase::replace_all(tex, "{hpart}", hpart);
             shambase::replace_all(tex, "{grad_p_on_rho}", grad_p_on_rho);
             shambase::replace_all(tex, "{s_j}", s_j);

--- a/src/shammodels/sph/include/shammodels/sph/modules/NodeMonofluidTVAAddSourceTerm.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/NodeMonofluidTVAAddSourceTerm.hpp
@@ -137,7 +137,7 @@ namespace shammodels::sph::modules {
             shambase::replace_all(tex, "{ds_j_dt}", ds_j_dt_edge);
             shambase::replace_all(tex, "{rhodust_eps}", rhodust_eps_edge);
             shambase::replace_all(tex, "{part_counts}", part_counts_edge);
-            shambase::replace_all(tex, "{nbins}", shambase::format("{}", nbins));
+            shambase::replace_all(tex, "{nbins}", sham::format("{}", nbins));
 
             return tex;
         }

--- a/src/shammodels/sph/include/shammodels/sph/modules/NodeMonofluidTVASmoothSPositivityLimiter.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/NodeMonofluidTVASmoothSPositivityLimiter.hpp
@@ -122,7 +122,7 @@ namespace shammodels::sph::modules {
             shambase::replace_all(tex, "{s_j}", s_j);
             shambase::replace_all(tex, "{Ttilde_sj}", Ttilde_sj);
             shambase::replace_all(tex, "{ds_j_dt}", ds_j_dt);
-            shambase::replace_all(tex, "{ndust}", shambase::format("{}", ndust));
+            shambase::replace_all(tex, "{ndust}", sham::format("{}", ndust));
 
             return tex;
         }

--- a/src/shammodels/sph/include/shammodels/sph/modules/SetDustStoppingTimeConstant.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/SetDustStoppingTimeConstant.hpp
@@ -112,7 +112,7 @@ namespace shammodels::sph::modules {
 
             shambase::replace_all(tex, "{t_j_0}", t_j_0);
             shambase::replace_all(tex, "{part_counts}", part_counts);
-            shambase::replace_all(tex, "{ndust}", shambase::format("{}", ndust));
+            shambase::replace_all(tex, "{ndust}", sham::format("{}", ndust));
             shambase::replace_all(tex, "{t_j}", t_j);
 
             return tex;

--- a/src/shammodels/sph/include/shammodels/sph/modules/SetDustStoppingTimeEpstein.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/SetDustStoppingTimeEpstein.hpp
@@ -167,11 +167,11 @@ namespace shammodels::sph::modules {
             shambase::replace_all(tex, "{sgrain_j}", sgrain_j);
             shambase::replace_all(tex, "{rho_grain_j}", rho_grain_j);
             shambase::replace_all(tex, "{part_counts}", part_counts);
-            shambase::replace_all(tex, "{ndust}", shambase::format("{}", ndust));
+            shambase::replace_all(tex, "{ndust}", sham::format("{}", ndust));
             shambase::replace_all(tex, "{hpart}", hpart);
             shambase::replace_all(tex, "{cs}", cs);
             shambase::replace_all(tex, "{t_j}", t_j);
-            shambase::replace_all(tex, "{hfact}", shambase::format("{}", Kernel::hfactd));
+            shambase::replace_all(tex, "{hfact}", sham::format("{}", Kernel::hfactd));
 
             return tex;
         };

--- a/src/shammodels/sph/src/BasicSPHGhosts.cpp
+++ b/src/shammodels/sph/src/BasicSPHGhosts.cpp
@@ -560,7 +560,7 @@ auto BasicSPHGhostHandler<vec>::gen_id_table_interfaces(GeneratorMap &&gen)
 
     for (auto &[k, v] : send_count_stats) {
         if (v > 0.2) {
-            warn_log += shambase::format("\n    patch {} high interf/patch volume: {}", k, v);
+            warn_log += sham::format("\n    patch {} high interf/patch volume: {}", k, v);
             has_warn = true;
         }
     }
@@ -587,13 +587,13 @@ void BasicSPHGhostHandler<vec>::gen_debug_patch_ghost(
 
     std::string loc_graph = "";
     interf_info.for_each([&loc_graph](u64 send, u64 recv, InterfaceIdTable &info) {
-        loc_graph += shambase::format("    p{} -> p{}\n", send, recv);
+        loc_graph += sham::format("    p{} -> p{}\n", send, recv);
     });
 
     sched.for_each_patch_data(
         [&](u64 id, shamrock::patch::Patch p, shamrock::patch::PatchDataLayer &pdat) {
             if (pdat.get_obj_cnt() > 0) {
-                loc_graph += shambase::format(
+                loc_graph += sham::format(
                     "    p{} [label= \"id={} N={}\"]\n", id, id, pdat.get_obj_cnt());
             }
         });
@@ -604,7 +604,7 @@ void BasicSPHGhostHandler<vec>::gen_debug_patch_ghost(
     dot_graph = "strict digraph {\n" + dot_graph + "}";
 
     if (shamcomm::world_rank() == 0) {
-        std::string fname = shambase::format("ghost_graph_{}.dot", cnt_dump_debug);
+        std::string fname = sham::format("ghost_graph_{}.dot", cnt_dump_debug);
         logger::info_ln("SPH Ghost", "writing", fname);
         shambase::write_string_to_file(fname, dot_graph);
         cnt_dump_debug++;

--- a/src/shammodels/sph/src/Model.cpp
+++ b/src/shammodels/sph/src/Model.cpp
@@ -263,7 +263,7 @@ inline void post_insert_data(PatchScheduler &sched) {
     }
 
     // sched.for_each_local_patchdata([&](const Patch p, PatchData &pdat) {
-    //     log += shambase::format(
+    //     log += sham::format(
     //         "\n    patch id={}, N={} particles", p.id_patch, pdat.get_obj_cnt());
     // });
     //
@@ -309,7 +309,7 @@ void shammodels::sph::Model<Tvec, SPHKernel>::push_particle(
             return;
         }
 
-        log += shambase::format(
+        log += sham::format(
             "\n  rank = {}  patch id={}, add N={} particles, coords = {} {}",
             shamcomm::world_rank(),
             p.id_patch,
@@ -405,7 +405,7 @@ void shammodels::sph::Model<Tvec, SPHKernel>::push_particle_mhd(
             return;
         }
 
-        log += shambase::format(
+        log += sham::format(
             "\n  rank = {}  patch id={}, add N={} particles, coords = {} {}",
             shamcomm::world_rank(),
             p.id_patch,
@@ -530,7 +530,7 @@ void shammodels::sph::Model<Tvec, SPHKernel>::add_cube_hcp_3d(
                     return;
                 }
 
-                log += shambase::format(
+                log += sham::format(
                     "\n  rank = {}  patch id={}, add N={} particles, coords = {} {}",
                     shamcomm::world_rank(),
                     p.id_patch,
@@ -976,7 +976,7 @@ void shammodels::sph::Model<Tvec, SPHKernel>::add_big_disc_3d(
                     return;
                 }
 
-                log += shambase::format(
+                log += sham::format(
                     "\n  rank = {}  patch id={}, add N={} particles, coords = {} {}",
                     shamcomm::world_rank(),
                     p.id_patch,
@@ -1154,7 +1154,7 @@ void shammodels::sph::Model<Tvec, SPHKernel>::add_cube_fcc_3d(
                 return;
             }
 
-            log += shambase::format(
+            log += sham::format(
                 "\n  rank = {}  patch id={}, add N={} particles, coords = {} {}",
                 shamcomm::world_rank(),
                 p.id_patch,
@@ -1335,7 +1335,7 @@ void shammodels::sph::Model<Tvec, SPHKernel>::init_from_phantom_dump(
                 return;
             }
 
-            log += shambase::format(
+            log += sham::format(
                 "\n  rank = {}  patch id={}, add N={} particles, coords = {} {}",
                 shamcomm::world_rank(),
                 p.id_patch,
@@ -1501,7 +1501,7 @@ shammodels::sph::PhantomDump shammodels::sph::Model<Tvec, SPHKernel>::make_phant
 
     dump.override_magic_number();
     dump.iversion = 1;
-    dump.fileid   = shambase::format("{:100s}", "FT:Phantom Shamrock writer");
+    dump.fileid   = sham::format("{:100s}", "FT:Phantom Shamrock writer");
 
     u32 Ntot = get_total_part_count();
     dump.table_header_fort_int.add("nparttot", Ntot);

--- a/src/shammodels/sph/src/SPHUtilities.cpp
+++ b/src/shammodels/sph/src/SPHUtilities.cpp
@@ -276,7 +276,7 @@ namespace shammodels::sph {
                 flt omega_a = 1 + (h_a / (3 * rho_ha)) * part_omega_sum;
                 omega[id_a] = omega_a;
 
-                // logger::raw(shambase::format("pmass {}, rho_a {}, omega_a {}\n",
+                // logger::raw(sham::format("pmass {}, rho_a {}, omega_a {}\n",
                 // part_mass,rho_ha, omega_a));
             });
         });

--- a/src/shammodels/sph/src/Solver.cpp
+++ b/src/shammodels/sph/src/Solver.cpp
@@ -714,7 +714,7 @@ namespace shammodels::sph {
 
         dump.override_magic_number();
         dump.iversion = 1;
-        dump.fileid   = shambase::format("{:100s}", "FT:Phantom Shamrock writer");
+        dump.fileid   = sham::format("{:100s}", "FT:Phantom Shamrock writer");
 
         u32 Ntot = info.nobj;
         dump.table_header_fort_int.add("nparttot", Ntot);
@@ -981,7 +981,7 @@ void shammodels::sph::Solver<Tvec, Kern>::sph_prestep(Tscal time_val, Tscal dt) 
         Tscal max_eps_h;
 
         if (solver_config.gpart_mass == 0) {
-            shambase::throw_with_loc<std::runtime_error>(shambase::format(
+            shambase::throw_with_loc<std::runtime_error>(sham::format(
                 "invalid gpart_mass {}, this configuration can not converge.\n"
                 "Please set it using either model.set_particle_mass(pmass) or "
                 "cfg.set_particle_mass(pmass)",
@@ -1106,7 +1106,7 @@ void shammodels::sph::Solver<Tvec, Kern>::sph_prestep(Tscal time_val, Tscal dt) 
                         {
                             sycl::host_accessor acc{idx_err};
                             for (u32 i = 0; i < idx_err.size(); i++) {
-                                add_info += shambase::format(
+                                add_info += sham::format(
                                     "{} - pos : {}, hpart : {}\n", acc[i], pos[acc[i]], h[acc[i]]);
                             }
                         }
@@ -1847,7 +1847,7 @@ shammodels::sph::TimestepLog shammodels::sph::Solver<Tvec, Kern>::evolve_once() 
 
     if (shamcomm::world_rank() == 0) {
         shamcomm::logs::raw_ln(
-            shambase::format("---------------- t = {}, dt = {} ----------------", t_current, dt));
+            sham::format("---------------- t = {}, dt = {} ----------------", t_current, dt));
     }
 
     shambase::Timer tstep;
@@ -2489,7 +2489,7 @@ shammodels::sph::TimestepLog shammodels::sph::Solver<Tvec, Kern>::evolve_once() 
             if (shamcomm::world_rank() == 0) {
                 logger::warn_ln(
                     "BasicGasSPH",
-                    shambase::format(
+                    sham::format(
                         "the corrector tolerance are broken the step will "
                         "be re rerunned\n    eps_v = {}",
                         eps_v));
@@ -2999,7 +2999,7 @@ shammodels::sph::TimestepLog shammodels::sph::Solver<Tvec, Kern>::evolve_once() 
                     table.add_double_rule();
                     for (auto &[key, value] : cfl_detail) {
                         table.add_data(
-                            {key, shambase::format("{:.2e}", value)}, shambase::table::right);
+                            {key, sham::format("{:.2e}", value)}, shambase::table::right);
                     }
                     table.add_rule();
                     logger::info_ln("sph::Model", "CFL detail :", table.render());

--- a/src/shammodels/sph/src/io/PhantomDump.cpp
+++ b/src/shammodels/sph/src/io/PhantomDump.cpp
@@ -218,7 +218,7 @@ void shammodels::sph::PhantomDumpBlock::write(
 
 u64 shammodels::sph::PhantomDumpBlock::get_ref_fort_real(std::string s) {
 
-    s            = shambase::format("{:16s}", s);
+    s            = sham::format("{:16s}", s);
     auto &blocks = blocks_fort_real;
 
     for (u32 i = 0; i < blocks_fort_real.size(); i++) {
@@ -242,7 +242,7 @@ u64 shammodels::sph::PhantomDumpBlock::get_ref_fort_real(std::string s) {
 
 u64 shammodels::sph::PhantomDumpBlock::get_ref_f32(std::string s) {
 
-    s = shambase::format("{:16s}", s);
+    s = sham::format("{:16s}", s);
 
     auto &blocks = blocks_f32;
 
@@ -444,7 +444,7 @@ bool shammodels::sph::compare_phantom_dumps(PhantomDump &dump_ref, PhantomDump &
         if (header_ref[matching_key] != header_comp[matching_key]) {
             logger::warn_ln(
                 "PhantomDump",
-                shambase::format(
+                sham::format(
                     "Mismatch in the header key {}, ref={}, comp={}",
                     matching_key,
                     header_ref[matching_key],

--- a/src/shammodels/sph/src/io/PhantomDumpEOSUtils.cpp
+++ b/src/shammodels/sph/src/io/PhantomDumpEOSUtils.cpp
@@ -78,18 +78,17 @@ namespace {
                 if (use_krome) {
                     logger::raw_ln("KROME eos: initial gamma = 1.666667");
                 } else {
-                    logger::raw_ln(shambase::format("adiabatic eos: gamma = {}", eos.gamma));
+                    logger::raw_ln(sham::format("adiabatic eos: gamma = {}", eos.gamma));
                 }
             } else {
                 logger::raw_ln(
-                    shambase::format(
+                    sham::format(
                         "setting isothermal sound speed^2 (polyk) = {}, gamma = {}",
                         eos.polyk,
                         eos.gamma));
                 if (eos.polyk <= std::numeric_limits<f64>::epsilon()) {
                     logger::raw_ln(
-                        shambase::format(
-                            "WARNING! sound speed zero in dump!, polyk = {}", eos.polyk));
+                        sham::format("WARNING! sound speed zero in dump!, polyk = {}", eos.polyk));
                 }
             }
         }
@@ -101,7 +100,7 @@ namespace {
 
         if (std::abs(eos.gamma - 1.0) > std::numeric_limits<f64>::epsilon() && maxvxyzu < 4) {
             logger::raw_ln(
-                shambase::format(
+                sham::format(
                     "WARNING! compiled for isothermal equation of state but gamma /= 1, gamma={}",
                     eos.gamma));
         }
@@ -109,10 +108,10 @@ namespace {
         if (ieos == 3 || ieos == 6 || ieos == 7) {
             if (eos.qfacdisc <= std::numeric_limits<f64>::epsilon()) {
                 if (shamcomm::world_rank() == 0)
-                    logger::raw_ln(shambase::format("ERROR: qfacdisc <= 0"));
+                    logger::raw_ln(sham::format("ERROR: qfacdisc <= 0"));
             } else {
                 if (shamcomm::world_rank() == 0)
-                    logger::raw_ln(shambase::format("qfacdisc = {}", eos.qfacdisc));
+                    logger::raw_ln(sham::format("qfacdisc = {}", eos.qfacdisc));
             }
         }
 
@@ -123,10 +122,10 @@ namespace {
             eos.z0      = hdr.read_header_float<f64>("z0");
             if (std::abs(eos.qfacdisc2) <= std::numeric_limits<f64>::epsilon()) {
                 if (shamcomm::world_rank() == 0)
-                    logger::raw_ln(shambase::format("ERROR: qfacdisc2 == 0"));
+                    logger::raw_ln(sham::format("ERROR: qfacdisc2 == 0"));
             } else {
                 if (shamcomm::world_rank() == 0)
-                    logger::raw_ln(shambase::format("qfacdisc2 = {}", eos.qfacdisc2));
+                    logger::raw_ln(sham::format("qfacdisc2 = {}", eos.qfacdisc2));
             }
         }
 
@@ -143,7 +142,7 @@ namespace shammodels::sph::phdump {
     inline void assert_ieos_val(const PhantomDump &dump, int ieos) {
         i64 ieos_dump = dump.read_header_int<i64>("ieos");
         if (ieos_dump != ieos) {
-            shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+            shambase::throw_with_loc<std::invalid_argument>(sham::format(
                 "You are querying phantom dump eos {} parameters, even though ieos is {}",
                 ieos,
                 ieos_dump));

--- a/src/shammodels/sph/src/modules/ConservativeCheck.cpp
+++ b/src/shammodels/sph/src/modules/ConservativeCheck.cpp
@@ -71,7 +71,7 @@ void shammodels::sph::modules::ConservativeCheck<Tvec, SPHKernel>::check_conserv
                 sum_p += mass[i] * vel[i];
             }
         }
-        cv_checks += shambase::format("    sum v = {}\n", sum_p);
+        cv_checks += sham::format("    sum v = {}\n", sum_p);
     }
 
     ///////////////////////////////////
@@ -94,7 +94,7 @@ void shammodels::sph::modules::ConservativeCheck<Tvec, SPHKernel>::check_conserv
                 sum_a += mass[i] * (acc_sph[i] + acc_ext[i]);
             }
         }
-        cv_checks += shambase::format("    sum a = {}\n", sum_a);
+        cv_checks += sham::format("    sum a = {}\n", sum_a);
     }
 
     ///////////////////////////////////
@@ -109,7 +109,7 @@ void shammodels::sph::modules::ConservativeCheck<Tvec, SPHKernel>::check_conserv
     Tscal sum_e = gpart_mass * shamalgs::collective::allreduce_sum(tmpe);
 
     if (shamcomm::world_rank() == 0) {
-        cv_checks += shambase::format("    sum e = {}\n", sum_e);
+        cv_checks += sham::format("    sum e = {}\n", sum_e);
     }
 
     Tscal pmass  = gpart_mass;
@@ -175,7 +175,7 @@ void shammodels::sph::modules::ConservativeCheck<Tvec, SPHKernel>::check_conserv
     Tscal de = shamalgs::collective::allreduce_sum(tmp_de);
 
     if (shamcomm::world_rank() == 0) {
-        cv_checks += shambase::format("    sum de = {}", de);
+        cv_checks += sham::format("    sum de = {}", de);
     }
 
     if (shamcomm::world_rank() == 0) {

--- a/src/shammodels/sph/src/modules/ExternalForces.cpp
+++ b/src/shammodels/sph/src/modules/ExternalForces.cpp
@@ -467,7 +467,7 @@ void shammodels::sph::modules::ExternalForces<Tvec, SPHKernel>::add_ext_forces()
 
         auto &var_force = solver_config.ext_force_config.ext_forces[i];
 
-        std::string prefix = shambase::format("ext_force_{}_", i);
+        std::string prefix = sham::format("ext_force_{}_", i);
 
         if (EF_PointMass *ext_force = std::get_if<EF_PointMass>(&var_force.val)) {
 

--- a/src/shammodels/sph/src/modules/GetParticlesOutsideSphere.cpp
+++ b/src/shammodels/sph/src/modules/GetParticlesOutsideSphere.cpp
@@ -59,8 +59,8 @@ namespace shammodels::sph::modules {
 
         shambase::replace_all(tex, "{pos}", pos);
         shambase::replace_all(tex, "{part_ids_outside_sphere}", part_ids_outside_sphere);
-        shambase::replace_all(tex, "{center}", shambase::format("{}", sphere_center));
-        shambase::replace_all(tex, "{radius}", shambase::format("{}", sphere_radius));
+        shambase::replace_all(tex, "{center}", sham::format("{}", sphere_center));
+        shambase::replace_all(tex, "{radius}", sham::format("{}", sphere_radius));
 
         return tex;
     }

--- a/src/shammodels/sph/src/modules/IterateSmoothingLengthDensity.cpp
+++ b/src/shammodels/sph/src/modules/IterateSmoothingLengthDensity.cpp
@@ -157,8 +157,8 @@ std::string IterateSmoothingLengthDensity<Tvec, SPHKernel>::_impl_get_tex() cons
     shambase::replace_all(tex, "{old_h}", old_h);
     shambase::replace_all(tex, "{new_h}", new_h);
     shambase::replace_all(tex, "{eps_h}", eps_h);
-    shambase::replace_all(tex, "{hfact}", shambase::format("{}", SPHKernel::hfactd));
-    shambase::replace_all(tex, "{Rkern}", shambase::format("{}", SPHKernel::Rkern));
+    shambase::replace_all(tex, "{hfact}", sham::format("{}", SPHKernel::hfactd));
+    shambase::replace_all(tex, "{Rkern}", sham::format("{}", SPHKernel::Rkern));
 
     return tex;
 }

--- a/src/shammodels/sph/src/modules/IterateSmoothingLengthDensityNeighLim.cpp
+++ b/src/shammodels/sph/src/modules/IterateSmoothingLengthDensityNeighLim.cpp
@@ -187,8 +187,8 @@ std::string IterateSmoothingLengthDensityNeighLim<Tvec, SPHKernel>::_impl_get_te
     shambase::replace_all(tex, "{old_h}", old_h);
     shambase::replace_all(tex, "{new_h}", new_h);
     shambase::replace_all(tex, "{eps_h}", eps_h);
-    shambase::replace_all(tex, "{hfact}", shambase::format("{}", SPHKernel::hfactd));
-    shambase::replace_all(tex, "{Rkern}", shambase::format("{}", SPHKernel::Rkern));
+    shambase::replace_all(tex, "{hfact}", sham::format("{}", SPHKernel::hfactd));
+    shambase::replace_all(tex, "{Rkern}", sham::format("{}", SPHKernel::Rkern));
 
     return tex;
 }

--- a/src/shammodels/sph/src/modules/LoopSmoothingLengthIter.cpp
+++ b/src/shammodels/sph/src/modules/LoopSmoothingLengthIter.cpp
@@ -71,7 +71,7 @@ namespace shammodels::sph::modules {
             if (shamcomm::world_rank() == 0) {
                 std::string log = "";
                 log += "smoothing length iteration converged\n";
-                log += shambase::format(
+                log += sham::format(
                     "  eps min = {}, max = {}\n  iterations = {}", min_eps_h, max_eps_h, iter_h);
 
                 logger::info_ln("Smoothinglength", log);

--- a/src/shammodels/sph/src/modules/NodeEvolveDustCOALASourceTerm.cpp
+++ b/src/shammodels/sph/src/modules/NodeEvolveDustCOALASourceTerm.cpp
@@ -220,7 +220,7 @@ namespace shammodels::sph::modules {
         shambase::replace_all(tex, "{s_j}", s_j);
         shambase::replace_all(tex, "{delta_v_j}", delta_v_j);
         shambase::replace_all(tex, "{S_coag}", S_coag);
-        shambase::replace_all(tex, "{nbins}", shambase::format("{}", nbins));
+        shambase::replace_all(tex, "{nbins}", sham::format("{}", nbins));
 
         return tex;
     }

--- a/src/shammodels/sph/src/modules/SPHSetup.cpp
+++ b/src/shammodels/sph/src/modules/SPHSetup.cpp
@@ -521,7 +521,7 @@ void shammodels::sph::modules::SPHSetup<Tvec, SPHKernel>::apply_setup_new(
             f64 part_per_sec = f64(sum_push) / f64(timer_gen.elapsed_sec());
             logger::normal_ln(
                 "SPH setup",
-                shambase::format(
+                sham::format(
                     "Nstep = {} ( {:.1e} ) Ntotal = {} ( {:.1e} rank min = {:.1e} max = {:.1e}) "
                     "rate = {:e} N.s^-1",
                     sum_push,
@@ -568,7 +568,7 @@ void shammodels::sph::modules::SPHSetup<Tvec, SPHKernel>::apply_setup_new(
         if (shamcomm::world_rank() == 0) {
             logger::normal_ln(
                 "SPH setup",
-                shambase::format(
+                sham::format(
                     "injected {:12} / {:} => {:5.1f}% | ranks with patchs = {:d} / {:d} {}",
                     injected_parts - sum_all,
                     injected_parts,
@@ -905,7 +905,7 @@ void shammodels::sph::modules::SPHSetup<Tvec, SPHKernel>::apply_setup_new(
         if (was_sync_limited) {
             log_suffix += " (sync limited)";
         }
-        log_suffix += shambase::format(" (msg count : {})", recv_msg.size());
+        log_suffix += sham::format(" (msg count : {})", recv_msg.size());
         log_inject_status(" <- global loop ->" + log_suffix);
 
         f64 worst_time_get_index_per_ranks
@@ -979,35 +979,35 @@ void shammodels::sph::modules::SPHSetup<Tvec, SPHKernel>::apply_setup_new(
             table.add_double_rule();
             for (u32 i = 0; i < shamcomm::world_size(); i++) {
                 table.add_data(
-                    {shambase::format("{:<4}", i),
-                     shambase::format(
+                    {sham::format("{:<4}", i),
+                     sham::format(
                          "{:.2f}s / {:.2f}s",
                          time_rank_getter_all_ranks[i],
                          max_time_rank_getter_all_ranks[i]),
-                     shambase::format("{:.2f}s", mpi_timer_all_ranks[i]),
-                     shambase::format(
+                     sham::format("{:.2f}s", mpi_timer_all_ranks[i]),
+                     sham::format(
                          "{:>.1f}% {:<.1f}%",
                          100 * (alloc_time_device_all_ranks[i] / time_part_inject_sec),
                          100 * (alloc_time_host_all_ranks[i] / time_part_inject_sec)),
-                     shambase::format("{}", shambase::readable_sizeof(max_mem_device_all_ranks[i])),
-                     shambase::format("{}", shambase::readable_sizeof(max_mem_host_all_ranks[i]))},
+                     sham::format("{}", shambase::readable_sizeof(max_mem_device_all_ranks[i])),
+                     sham::format("{}", shambase::readable_sizeof(max_mem_host_all_ranks[i]))},
                     Table::right);
             }
             if (shamcomm::world_size() > 1) {
                 table.add_rulled_data({"", "<avg> / <max>", "<avg>", "<avg>", "<sum>", "<sum>"});
                 table.add_data(
                     {"all",
-                     shambase::format(
+                     sham::format(
                          "{:.2f}s / {:.2f}s",
                          sum_time_rank_getter / shamcomm::world_size(),
                          max_time_rank_getter),
-                     shambase::format("{:.2f}s", sum_mpi / shamcomm::world_size()),
-                     shambase::format(
+                     sham::format("{:.2f}s", sum_mpi / shamcomm::world_size()),
+                     sham::format(
                          "{:>.1f}% {:<.1f}%",
                          100 * (sum_alloc_device / sum_t),
                          100 * (sum_alloc_host / sum_t)),
-                     shambase::format("{}", shambase::readable_sizeof(sum_mem_device_total)),
-                     shambase::format("{}", shambase::readable_sizeof(sum_mem_host_total))},
+                     sham::format("{}", shambase::readable_sizeof(sum_mem_device_total)),
+                     sham::format("{}", shambase::readable_sizeof(sum_mem_host_total))},
                     Table::right);
             }
             table.add_rule();

--- a/src/shammodels/sph/src/modules/SinkParticlesAccreteQuantities.cpp
+++ b/src/shammodels/sph/src/modules/SinkParticlesAccreteQuantities.cpp
@@ -174,7 +174,7 @@ namespace shammodels::sph::modules {
             sink_accelerations[i_sink] = new_acc;
 
             had_accretion = true;
-            log += shambase::format(
+            log += sham::format(
                 "\n    id {} deltas : mass={} r={} v={} l={}",
                 i_sink,
                 new_mass - old_mass,

--- a/src/shammodels/sph/src/modules/render/CartesianRender.cpp
+++ b/src/shammodels/sph/src/modules/render/CartesianRender.cpp
@@ -65,7 +65,7 @@ namespace shammodels::sph::modules {
         Tvec e_z  = sycl::cross(delta_x, delta_y);
         Tscal len = sycl::length(e_z);
         if (!(len > 0)) {
-            throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+            throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
                 "The cross product of delta_x and delta_y is zero\n"
                 "  args :"
                 "    center  = {}\n"
@@ -111,7 +111,7 @@ namespace shammodels::sph::modules {
         if (shamcomm::world_rank() == 0) {
             logger::info_ln(
                 "sph::CartesianRender",
-                shambase::format(
+                sham::format(
                     "compute_slice field_name: {}, positions count: {}",
                     field_name,
                     positions.get_size()));
@@ -131,8 +131,7 @@ namespace shammodels::sph::modules {
         t.stop();
         if (shamcomm::world_rank() == 0) {
             logger::info_ln(
-                "sph::CartesianRender",
-                shambase::format("compute_slice took {}", t.get_time_str()));
+                "sph::CartesianRender", sham::format("compute_slice took {}", t.get_time_str()));
         }
 
         return ret;
@@ -148,7 +147,7 @@ namespace shammodels::sph::modules {
         if (shamcomm::world_rank() == 0) {
             logger::info_ln(
                 "sph::CartesianRender",
-                shambase::format(
+                sham::format(
                     "compute_column_integ field_name: {}, rays count: {}",
                     field_name,
                     rays.get_size()));
@@ -169,7 +168,7 @@ namespace shammodels::sph::modules {
         if (shamcomm::world_rank() == 0) {
             logger::info_ln(
                 "sph::CartesianRender",
-                shambase::format("compute_column_integ took {}", t.get_time_str()));
+                sham::format("compute_column_integ took {}", t.get_time_str()));
         }
 
         return ret;
@@ -185,7 +184,7 @@ namespace shammodels::sph::modules {
         if (shamcomm::world_rank() == 0) {
             logger::info_ln(
                 "sph::CartesianRender",
-                shambase::format(
+                sham::format(
                     "compute_azymuthal_integ field_name: {}, ring_rays count: {}",
                     field_name,
                     ring_rays.get_size()));
@@ -206,7 +205,7 @@ namespace shammodels::sph::modules {
         if (shamcomm::world_rank() == 0) {
             logger::info_ln(
                 "sph::CartesianRender",
-                shambase::format("compute_azymuthal_integ took {}", t.get_time_str()));
+                sham::format("compute_azymuthal_integ took {}", t.get_time_str()));
         }
 
         return ret;

--- a/src/shammodels/sph/src/modules/self_gravity/SGSFMMPlummer.cpp
+++ b/src/shammodels/sph/src/modules/self_gravity/SGSFMMPlummer.cpp
@@ -337,7 +337,7 @@ namespace shammodels::sph::modules {
                                 throw shambase::make_except_with_loc<std::runtime_error>(
                                     "Potential race condition detected in part_calls for particle "
                                     + std::to_string(i) + " and cell " + std::to_string(icell)
-                                    + " current set: " + shambase::format("{}", a_acc_by_tid[i]));
+                                    + " current set: " + sham::format("{}", a_acc_by_tid[i]));
                             }
                         });
                     }

--- a/src/shammodels/sph/src/pySPHModel.cpp
+++ b/src/shammodels/sph/src/pySPHModel.cpp
@@ -1695,7 +1695,7 @@ ON_PYTHON_INIT {
         .def_readwrite("reach_max_walltime", &EvolveUntilResults::reach_max_walltime)
         .def_readwrite("iter_count", &EvolveUntilResults::iter_count)
         .def("__repr__", [](const EvolveUntilResults &self) {
-            return shambase::format(
+            return sham::format(
                 "EvolveUntilResults(reach_target_time={}, reach_niter_max={}, "
                 "reach_max_walltime={}, iter_count={})",
                 self.reach_target_time,

--- a/src/shammodels/zeus/include/shammodels/zeus/SolverConfig.hpp
+++ b/src/shammodels/zeus/include/shammodels/zeus/SolverConfig.hpp
@@ -48,7 +48,7 @@ namespace shammodels::zeus {
 
         inline void check_config() {
             if (grid_coord_to_pos_fact <= 0) {
-                shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                shambase::throw_with_loc<std::runtime_error>(sham::format(
                     "grid_coord_to_pos_fact must be > 0, got {}", grid_coord_to_pos_fact));
             }
         }

--- a/src/shammodels/zeus/src/Solver.cpp
+++ b/src/shammodels/zeus/src/Solver.cpp
@@ -39,7 +39,7 @@ auto shammodels::zeus::Solver<Tvec, TgridVec>::evolve_once(Tscal t_current, Tsca
     f64 mpi_timer_start                     = shamcomm::mpi::get_timer("total");
 
     if (shamcomm::world_rank() == 0) {
-        logger::normal_ln("amr::Zeus", shambase::format("t = {}, dt = {}", t_current, dt_input));
+        logger::normal_ln("amr::Zeus", sham::format("t = {}, dt = {}", t_current, dt_input));
     }
 
     shambase::Timer tstep;

--- a/src/shammodels/zeus/src/modules/GhostZones.cpp
+++ b/src/shammodels/zeus/src/modules/GhostZones.cpp
@@ -141,7 +141,7 @@ void shammodels::zeus::modules::GhostZones<Tvec, TgridVec>::build_ghost_cache() 
     gen_ghost.ghost_gen_infos.for_each([&](u64 sender, u64 receiver, InterfaceBuildInfos &build) {
         std::string log;
 
-        log = shambase::format(
+        log = sham::format(
             "{} -> {} : off = {}, {} -> {}",
             sender,
             receiver,
@@ -182,14 +182,14 @@ void shammodels::zeus::modules::GhostZones<Tvec, TgridVec>::build_ghost_cache() 
         auto resut = shamalgs::numeric::stream_compact(q.q, is_in_interf, src.get_obj_cnt());
         f64 ratio  = f64(std::get<1>(resut)) / f64(src.get_obj_cnt());
 
-        std::string s = shambase::format(
+        std::string s = sham::format(
             "{} -> {} : off = {}, test volume = {} -> {}",
             sender,
             receiver,
             build.offset,
             build.volume_target.lower,
             build.volume_target.upper);
-        s += shambase::format("\n    found N = {}, ratio = {} %", std::get<1>(resut), ratio);
+        s += sham::format("\n    found N = {}, ratio = {} %", std::get<1>(resut), ratio);
 
         shamlog_debug_ln("AMR interf", s);
 

--- a/src/shammodels/zeus/src/modules/ValueLoader.cpp
+++ b/src/shammodels/zeus/src/modules/ValueLoader.cpp
@@ -250,8 +250,8 @@ void shammodels::zeus::modules::ValueLoader<Tvec, TgridVec, T>::load_patch_inter
             load_patch_internal_block_zp(nobj, nvar, buf_src, buf_dest);
 
         } else {
-            throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
-                "offset : ({},{},{}) is invalid", offset[0], offset[1], offset[2]));
+            throw shambase::make_except_with_loc<std::invalid_argument>(
+                sham::format("offset : ({},{},{}) is invalid", offset[0], offset[1], offset[2]));
         }
     } else {
         shambase::throw_unimplemented();
@@ -738,8 +738,8 @@ void shammodels::zeus::modules::ValueLoader<Tvec, TgridVec, T>::load_patch_neigh
                 offset, buf_cell_min, buf_cell_max, face_lists, nobj, nvar, buf_src, buf_dest);
 
         } else {
-            throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
-                "offset : ({},{},{}) is invalid", offset[0], offset[1], offset[2]));
+            throw shambase::make_except_with_loc<std::invalid_argument>(
+                sham::format("offset : ({},{},{}) is invalid", offset[0], offset[1], offset[2]));
         }
     } else {
         shambase::throw_unimplemented();
@@ -798,8 +798,8 @@ void shammodels::zeus::modules::ValueLoader<Tvec, TgridVec, T>::load_patch_neigh
             OrientedNeighFaceList<Tvec> &face_zp = face_lists.zp();
 
         } else {
-            throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
-                "offset : ({},{},{}) is invalid", offset[0], offset[1], offset[2]));
+            throw shambase::make_except_with_loc<std::invalid_argument>(
+                sham::format("offset : ({},{},{}) is invalid", offset[0], offset[1], offset[2]));
         }
     } else {
         shambase::throw_unimplemented();
@@ -857,8 +857,8 @@ void shammodels::zeus::modules::ValueLoader<Tvec, TgridVec, T>::load_patch_neigh
             OrientedNeighFaceList<Tvec> &face_zp = face_lists.zp();
 
         } else {
-            throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
-                "offset : ({},{},{}) is invalid", offset[0], offset[1], offset[2]));
+            throw shambase::make_except_with_loc<std::invalid_argument>(
+                sham::format("offset : ({},{},{}) is invalid", offset[0], offset[1], offset[2]));
         }
     } else {
         shambase::throw_unimplemented();

--- a/src/shampylib/src/math/pyAABB.cpp
+++ b/src/shampylib/src/math/pyAABB.cpp
@@ -44,10 +44,10 @@ namespace shampylib {
             .def(
                 "__str__",
                 [](const shammath::AABB<T> &aabb) {
-                    return shambase::format("AABB(lower={}, upper={})", aabb.lower, aabb.upper);
+                    return sham::format("AABB(lower={}, upper={})", aabb.lower, aabb.upper);
                 })
             .def("__repr__", [](const shammath::AABB<T> &aabb) {
-                return shambase::format("AABB(lower={}, upper={})", aabb.lower, aabb.upper);
+                return sham::format("AABB(lower={}, upper={})", aabb.lower, aabb.upper);
             });
     }
 

--- a/src/shampylib/src/pyShamalgs.cpp
+++ b/src/shampylib/src/pyShamalgs.cpp
@@ -52,13 +52,13 @@ ON_PYTHON_INIT {
         .def(
             "__str__",
             [](const shamalgs::impl_param &impl_param) {
-                return shambase::format(
+                return sham::format(
                     "impl_param(impl_name=\"{}\", params=\"{}\")",
                     impl_param.impl_name,
                     impl_param.params);
             })
         .def("__repr__", [](const shamalgs::impl_param &impl_param) {
-            return shambase::format(
+            return sham::format(
                 "impl_param(impl_name=\"{}\", params=\"{}\")",
                 impl_param.impl_name,
                 impl_param.params);

--- a/src/shampylib/src/pyShambackends.cpp
+++ b/src/shampylib/src/pyShambackends.cpp
@@ -137,7 +137,7 @@ ON_PYTHON_INIT {
         .def(
             "__str__",
             [](const sham::MemPerfInfos &mem_perf_infos) {
-                return shambase::format(
+                return sham::format(
                     "MemPerfInfos(\n"
                     "    time_alloc_host=\"{0:}\",\n"
                     "    time_alloc_device=\"{1:}\",\n"
@@ -165,7 +165,7 @@ ON_PYTHON_INIT {
                     mem_perf_infos.max_allocated_byte_shared);
             })
         .def("__repr__", [](const sham::MemPerfInfos &mem_perf_infos) {
-            return shambase::format(
+            return sham::format(
                 "MemPerfInfos(\n"
                 "    time_alloc_host=\"{0:}\",\n"
                 "    time_alloc_device=\"{1:}\",\n"

--- a/src/shampylib/src/pySolverGraph.cpp
+++ b/src/shampylib/src/pySolverGraph.cpp
@@ -41,7 +41,7 @@ void register_field(py::module &m, const char *class_name) {
         .def(
             "__repr__",
             [=](Field<T> &self) {
-                return shambase::format(
+                return sham::format(
                     "{}(label={}, tex_symbol={}, nvar={})",
                     class_name,
                     self.get_label(),

--- a/src/shamrock/include/shamrock/io/AsciiSplitDump.hpp
+++ b/src/shamrock/include/shamrock/io/AsciiSplitDump.hpp
@@ -45,7 +45,7 @@ class AsciiSplitDump {
          */
         void open(u64 id_patch, std::string fileprefix) {
             const std::filesystem::path path{
-                fileprefix + "patch_" + shambase::format("{:04d}", id_patch) + ".txt"};
+                fileprefix + "patch_" + sham::format("{:04d}", id_patch) + ".txt"};
             if (std::filesystem::exists(path)) {
                 std::filesystem::remove(path);
             }

--- a/src/shamrock/include/shamrock/io/LegacyVtkWriter.hpp
+++ b/src/shamrock/include/shamrock/io/LegacyVtkWriter.hpp
@@ -426,7 +426,7 @@ namespace shamrock {
             if (len > 0) {
                 sycl::buffer<T> &buf_ref = shambase::get_check_ref(buf);
                 if (buf_ref.size() < len) {
-                    shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                    shambase::throw_with_loc<std::runtime_error>(sham::format(
                         "the buffer is smaller than expected write field size\n    buf size = {}, "
                         "cnt = {}",
                         buf_ref.size(),
@@ -446,7 +446,7 @@ namespace shamrock {
             if (shamcomm::world_rank() == 0) {
                 logger::info_ln(
                     "VTK Dump",
-                    shambase::format(
+                    sham::format(
                         "dump to {}\n              - took {}, bandwidth = {}/s",
                         fname,
                         timer.get_time_str(),

--- a/src/shamrock/include/shamrock/io/json_print_diff.hpp
+++ b/src/shamrock/include/shamrock/io/json_print_diff.hpp
@@ -58,20 +58,20 @@ namespace shamrock {
 
         while (it1 != v1.end() || it2 != v2.end()) {
             if (it1 == v1.end()) {
-                ss << shambase::format("{}+ | {}{}\n", green, *it2++, reset);
+                ss << sham::format("{}+ | {}{}\n", green, *it2++, reset);
             } else if (it2 == v2.end()) {
-                ss << shambase::format("{}- | {}{}\n", red, *it1++, reset);
+                ss << sham::format("{}- | {}{}\n", red, *it1++, reset);
             } else if (differ_by_trailing_char(*it1, *it2)) {
                 auto &longest = (*it1).length() > (*it2).length() ? *it1 : *it2;
-                ss << shambase::format("  | {}\n", longest); // unchanged
+                ss << sham::format("  | {}\n", longest); // unchanged
                 ++it1;
                 ++it2;
             } else if (*it1 < *it2) {
-                ss << shambase::format("{}- | {}{}\n", red, *it1++, reset);
+                ss << sham::format("{}- | {}{}\n", red, *it1++, reset);
             } else if (*it2 < *it1) {
-                ss << shambase::format("{}+ | {}{}\n", green, *it2++, reset);
+                ss << sham::format("{}+ | {}{}\n", green, *it2++, reset);
             } else {
-                ss << shambase::format("  | {}\n", *it1); // unchanged
+                ss << sham::format("  | {}\n", *it1); // unchanged
                 ++it1;
                 ++it2;
             }

--- a/src/shamrock/include/shamrock/io/json_variant.hpp
+++ b/src/shamrock/include/shamrock/io/json_variant.hpp
@@ -89,7 +89,7 @@ namespace shamrock {
                 },
                 var);
 
-            throw shambase::make_except_with_loc<std::runtime_error>(shambase::format(
+            throw shambase::make_except_with_loc<std::runtime_error>(sham::format(
                 "unknown type: {}\navailable types: {}\njson: {}",
                 type_id,
                 available_types,

--- a/src/shamrock/include/shamrock/patch/PatchDataField.hpp
+++ b/src/shamrock/include/shamrock/patch/PatchDataField.hpp
@@ -175,7 +175,7 @@ class PatchDataField {
     [[nodiscard]] inline u32 get_obj_cnt() const {
         size_t sz = buf.get_size();
         if (sz % nvar != 0) {
-            throw shambase::make_except_with_loc<std::runtime_error>(shambase::format(
+            throw shambase::make_except_with_loc<std::runtime_error>(sham::format(
                 "the size of the buffer ({}) is not a multiple of the number of variables ({})",
                 sz,
                 nvar));

--- a/src/shamrock/include/shamrock/patch/PatchDataFieldSpan.hpp
+++ b/src/shamrock/include/shamrock/patch/PatchDataFieldSpan.hpp
@@ -193,7 +193,7 @@ namespace shamrock {
             if (is_nvar_static()) {
                 if (field_ref.get_nvar() != nvar) {
                     shambase::throw_with_loc<std::invalid_argument>(
-                        shambase::format(
+                        sham::format(
                             "You are trying to bind a PatchDataFieldSpan with static nvar={} to a "
                             "PatchDataField with nvar={}",
                             nvar,
@@ -204,7 +204,7 @@ namespace shamrock {
 
             if (start + count > field_ref.get_obj_cnt()) {
                 shambase::throw_with_loc<std::invalid_argument>(
-                    shambase::format(
+                    sham::format(
                         "PatchDataFieldSpan out of bounds: {} + {} > {}",
                         start,
                         count,

--- a/src/shamrock/include/shamrock/patch/PatchDataLayerLayout.hpp
+++ b/src/shamrock/include/shamrock/patch/PatchDataLayerLayout.hpp
@@ -354,7 +354,7 @@ namespace shamrock::patch {
             }
         }
 
-        throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+        throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
             "the requested field does not exists\n    the function : {}\n    the field name : {}\n "
             "   current table : \n{}",
             __PRETTY_FUNCTION__,

--- a/src/shamrock/include/shamrock/scheduler/ComputeField.hpp
+++ b/src/shamrock/include/shamrock/scheduler/ComputeField.hpp
@@ -134,7 +134,7 @@ namespace shamrock {
 
                 if (nvar != loc_nvar) {
                     shambase::throw_with_loc<std::runtime_error>(
-                        shambase::format("mismatch in nvar excepted={} found={}", *nvar, loc_nvar));
+                        sham::format("mismatch in nvar excepted={} found={}", *nvar, loc_nvar));
                 }
             });
 

--- a/src/shamrock/include/shamrock/scheduler/loadbalance/LoadBalanceStrategy.hpp
+++ b/src/shamrock/include/shamrock/scheduler/loadbalance/LoadBalanceStrategy.hpp
@@ -297,7 +297,7 @@ namespace shamrock::scheduler {
         if (shamcomm::world_rank() == 0) {
             logger::info_ln(
                 "LoadBalance",
-                shambase::format(
+                sham::format(
                     R"=(Summary (strategy = {0:}):
  - strategy "psweep"      : max = {1:.1f} min = {2:.1f} factor = {3:}
  - strategy "round robin" : max = {4:.1f} min = {5:.1f} factor = {6:})=",

--- a/src/shamrock/include/shamrock/solvergraph/ExchangeGhostLayerDebugDotGraph.hpp
+++ b/src/shamrock/include/shamrock/solvergraph/ExchangeGhostLayerDebugDotGraph.hpp
@@ -112,16 +112,15 @@ namespace shamrock::solvergraph {
                 )graph";
 
                 u32 current_subgraph = 0;
-                log += shambase::format("subgraph cluster_{0} {{\n", current_subgraph);
+                log += sham::format("subgraph cluster_{0} {{\n", current_subgraph);
 
                 for (u64_3 &info : collected_object_counts) {
                     if (info.z() != current_subgraph) {
                         log += "}\n";
                         current_subgraph = info.z();
-                        log += shambase::format("subgraph cluster_{0} {{\n", current_subgraph);
+                        log += sham::format("subgraph cluster_{0} {{\n", current_subgraph);
                     }
-                    log += shambase::format(
-                        "p_{0} [label=\"Patch {0} N={1}\"];\n", info.x(), info.y());
+                    log += sham::format("p_{0} [label=\"Patch {0} N={1}\"];\n", info.x(), info.y());
                 }
                 log += "}\n";
 
@@ -137,7 +136,7 @@ namespace shamrock::solvergraph {
                         edge_color = "blue";
                     }
 
-                    log += shambase::format(
+                    log += sham::format(
                         "p_{0} -> p_{1} [xlabel={2}, color={3}, fontcolor={3}];\n",
                         info.x(),
                         info.y(),

--- a/src/shamrock/include/shamrock/solvergraph/Field.hpp
+++ b/src/shamrock/include/shamrock/solvergraph/Field.hpp
@@ -66,7 +66,7 @@ namespace shamrock::solvergraph {
                 field.field_data,
                 sizes,
                 [&](u64 id) {
-                    shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                    shambase::throw_with_loc<std::runtime_error>(sham::format(
                         "Missing field ref in distributed data at id {}\n"
                         "Field name: {}\n"
                         "Field texsymbol: {}",
@@ -78,7 +78,7 @@ namespace shamrock::solvergraph {
                     // TODO
                 },
                 [&](u64 id) {
-                    shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                    shambase::throw_with_loc<std::runtime_error>(sham::format(
                         "Extra field ref in distributed data at id {}\n"
                         "Field name: {}\n"
                         "Field texsymbol: {}",

--- a/src/shamrock/include/shamrock/solvergraph/FieldRefs.hpp
+++ b/src/shamrock/include/shamrock/solvergraph/FieldRefs.hpp
@@ -55,7 +55,7 @@ namespace shamrock::solvergraph {
                 field_refs,
                 sizes,
                 [&](u64 id) {
-                    shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                    shambase::throw_with_loc<std::runtime_error>(sham::format(
                         "Missing field ref in distributed data at id {}\n"
                         "Field name: {}\n"
                         "Field texsymbol: {}",
@@ -67,7 +67,7 @@ namespace shamrock::solvergraph {
                     // TODO
                 },
                 [&](u64 id) {
-                    shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                    shambase::throw_with_loc<std::runtime_error>(sham::format(
                         "Extra field ref in distributed data at id {}\n"
                         "Field name: {}\n"
                         "Field texsymbol: {}",

--- a/src/shamrock/include/shamrock/solvergraph/FieldSpan.hpp
+++ b/src/shamrock/include/shamrock/solvergraph/FieldSpan.hpp
@@ -44,7 +44,7 @@ namespace shamrock::solvergraph {
                     spans.for_each([&](u64 id, const PatchDataFieldSpan<T> &span) {
                         ids.push_back(id);
                     });
-                    shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                    shambase::throw_with_loc<std::runtime_error>(sham::format(
                         "Missing field span in distributed data at id {}\n"
                         "Field name: {}\n"
                         "Field texsymbol: {}",
@@ -56,7 +56,7 @@ namespace shamrock::solvergraph {
                     // TODO
                 },
                 [&](u64 id) {
-                    shambase::throw_with_loc<std::runtime_error>(shambase::format(
+                    shambase::throw_with_loc<std::runtime_error>(sham::format(
                         "Extra field span in distributed data at id {}\n"
                         "Field name: {}\n"
                         "Field texsymbol: {}",

--- a/src/shamrock/src/io/AsciiSplitDump.cpp
+++ b/src/shamrock/src/io/AsciiSplitDump.cpp
@@ -21,15 +21,15 @@ void AsciiSplitDump::PatchDump::write_val(T val) {
     if constexpr (
         std::is_same_v<T, u32> || std::is_same_v<T, i32> || std::is_same_v<T, u64>
         || std::is_same_v<T, i64>) {
-        file << shambase::format("{:}\n", val);
+        file << sham::format("{:}\n", val);
     } else if constexpr (std::is_same_v<T, i64_3> || std::is_same_v<T, i32_3>) {
-        file << shambase::format("{:} {:} {:}\n", val.x(), val.y(), val.z());
+        file << sham::format("{:} {:} {:}\n", val.x(), val.y(), val.z());
     } else if constexpr (std::is_same_v<T, f64> || std::is_same_v<T, f32>) {
-        file << shambase::format("{:0.9f}\n", val);
+        file << sham::format("{:0.9f}\n", val);
     } else if constexpr (std::is_same_v<T, f64_3> || std::is_same_v<T, f32_3>) {
-        file << shambase::format("{:0.9f} {:0.9f} {:0.9f}\n", val.x(), val.y(), val.z());
+        file << sham::format("{:0.9f} {:0.9f} {:0.9f}\n", val.x(), val.y(), val.z());
     } else if constexpr (std::is_same_v<T, f64_8> || std::is_same_v<T, f32_8>) {
-        file << shambase::format(
+        file << sham::format(
             "{:0.9f} {:0.9f} {:0.9f} {:0.9f} {:0.9f} {:0.9f} {:0.9f} {:0.9f}\n",
             val.s0(),
             val.s1(),

--- a/src/shamrock/src/io/ShamrockDump.cpp
+++ b/src/shamrock/src/io/ShamrockDump.cpp
@@ -94,7 +94,7 @@ namespace shamrock {
 
         shamlog_debug_ln(
             "ShamrockDump",
-            shambase::format(
+            sham::format(
                 "table sizes {} {} {}", metadata_patch.size(), metadata_user.size(), sout.size()));
 
         if (/*do check*/ true) {
@@ -103,7 +103,7 @@ namespace shamrock {
                 if (out != s.size() * shamcomm::world_size()) {
                     logger::err_ln(
                         "ShamrockDump",
-                        shambase::format(
+                        sham::format(
                             "string size mismatch between all processes,\n    size : {}\nthe "
                             "string : {}\n",
                             s.size(),
@@ -152,7 +152,7 @@ namespace shamrock {
             size_t max_head = all_offsets[plist_len - 1] + all_bytecounts[plist_len - 1] + head_ptr;
             logger::info_ln(
                 "Shamrock Dump",
-                shambase::format(
+                sham::format(
                     "dump to {}\n              - took {}, bandwidth = {}/s",
                     fname,
                     timer.get_time_str(),
@@ -263,7 +263,7 @@ namespace shamrock {
             size_t max_head = all_offsets[plist_len - 1] + all_bytecounts[plist_len - 1] + head_ptr;
             logger::info_ln(
                 "Shamrock Dump",
-                shambase::format(
+                sham::format(
                     "load dump from {}\n              - took {}, bandwidth = {}/s",
                     fname,
                     timer.get_time_str(),

--- a/src/shamrock/src/io/json_utils.cpp
+++ b/src/shamrock/src/io/json_utils.cpp
@@ -34,7 +34,7 @@ namespace shamrock {
 
         int dash_count = 50;
 
-        std::string faint_line = shambase::format(
+        std::string faint_line = sham::format(
             "{}{:-^{}}{}\n",
             shambase::term_colors::faint(),
             "",         // empty string
@@ -46,11 +46,11 @@ namespace shamrock {
         auto red   = shambase::term_colors::col8b_red();
 
         std::string newold_text
-            = shambase::format("[{}+ | added{}] [{}- | removed{}]", green, reset, red, reset);
-        std::string nice_plus  = shambase::format("{}+{}", green, reset);
-        std::string nice_minus = shambase::format("{}-{}", red, reset);
+            = sham::format("[{}+ | added{}] [{}- | removed{}]", green, reset, red, reset);
+        std::string nice_plus  = sham::format("{}+{}", green, reset);
+        std::string nice_minus = sham::format("{}-{}", red, reset);
 
-        std::string log = shambase::format(
+        std::string log = sham::format(
             "Used config parameters are listed below;\n      "
             "Possible cases for highlighted entries:\n      "
             "  - ({})   default-added\n      "

--- a/src/shamrock/src/patch/PatchDataField.cpp
+++ b/src/shamrock/src/patch/PatchDataField.cpp
@@ -253,7 +253,7 @@ template<class T>
 void PatchDataField<T>::index_remap(sham::DeviceBuffer<u32> &index_map, u32 len) {
 
     if (len != get_obj_cnt()) {
-        throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+        throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
             "the match of the new index map does not match with the patchdatafield obj count: {} "
             "!= {}",
             len,
@@ -266,7 +266,7 @@ void PatchDataField<T>::index_remap(sham::DeviceBuffer<u32> &index_map, u32 len)
 template<class T>
 void PatchDataField<T>::permut_vars(const std::vector<u32> &permut) {
     if (permut.size() != get_nvar()) {
-        throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+        throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
             "the number of permut is not equal to the patchdatafield nvar: {} != {}",
             permut.size(),
             get_nvar()));
@@ -303,7 +303,7 @@ void PatchDataField<T>::remove_ids(const sham::DeviceBuffer<u32> &ids_to_rem, u3
     auto &q        = dev_sched->get_queue();
 
     if (len > get_obj_cnt()) {
-        throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+        throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
             "the number of ids to remove is greater than the patchdatafield obj count: {} > {}",
             len,
             get_obj_cnt()));
@@ -349,7 +349,7 @@ void PatchDataField<T>::remove_ids(const sham::DeviceBuffer<u32> &ids_to_rem, u3
         // compute keep flags sum
         u32 keep_flags_sum = std::accumulate(keep_flags_vec.begin(), keep_flags_vec.end(), u32(0));
 
-        std::string log = shambase::format(
+        std::string log = sham::format(
             "the number of remaining ids {} is different from the expected {}",
             keep_ids.get_size(),
             remaining);
@@ -360,7 +360,7 @@ void PatchDataField<T>::remove_ids(const sham::DeviceBuffer<u32> &ids_to_rem, u3
         } else {
             log += "  ids_to_rem has duplicates = false\n";
         }
-        log += shambase::format("  keep flags sum = {}\n", keep_flags_sum);
+        log += sham::format("  keep flags sum = {}\n", keep_flags_sum);
 
         throw shambase::make_except_with_loc<std::invalid_argument>(log);
     }

--- a/src/shamrock/src/patch/PatchDataLayer.cpp
+++ b/src/shamrock/src/patch/PatchDataLayer.cpp
@@ -281,11 +281,10 @@ namespace shamrock::patch {
                     if constexpr (std::is_same<t1, t2>::value) {
                         field.append_subset_to(idxs_buf, sz, out_field);
                     } else {
-                        throw shambase::make_except_with_loc<std::invalid_argument>(
-                            shambase::format(
-                                "Mismatch in layout\n source layout = {}\n dest layout = {}",
-                                pdl().get_description_str(),
-                                pdat.pdl().get_description_str()));
+                        throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
+                            "Mismatch in layout\n source layout = {}\n dest layout = {}",
+                            pdl().get_description_str(),
+                            pdat.pdl().get_description_str()));
                     }
                 },
                 fields[idx].value,

--- a/src/shamrock/src/scheduler/HilbertLoadBalance.cpp
+++ b/src/shamrock/src/scheduler/HilbertLoadBalance.cpp
@@ -142,14 +142,14 @@ namespace shamrock::scheduler {
 
             if (shamcomm::world_rank() == 0) {
                 std::string str = "Loadbalance stats : \n";
-                str += shambase::format("    npatch = {}\n", global_patch_list.size());
-                str += shambase::format("    min = {}\n", min);
-                str += shambase::format("    max = {}\n", max);
-                str += shambase::format("    avg = {}\n", avg);
+                str += sham::format("    npatch = {}\n", global_patch_list.size());
+                str += sham::format("    min = {}\n", min);
+                str += sham::format("    max = {}\n", max);
+                str += sham::format("    avg = {}\n", avg);
                 if (max == 0) {
                     str += "    efficiency = ???%";
                 } else {
-                    str += shambase::format(
+                    str += sham::format(
                         "    efficiency = {:.2f}%", 100 - (100 * (max - min) / max));
                 }
                 logger::info_ln("LoadBalance", str);

--- a/src/shamrock/src/scheduler/PatchScheduler.cpp
+++ b/src/shamrock/src/scheduler/PatchScheduler.cpp
@@ -334,46 +334,45 @@ void PatchScheduler::scheduler_step(bool do_split_merge, bool do_load_balancing)
                 f64 total       = global_timer.nanosec;
                 std::string str = "";
                 str += "Scheduler step timings : ";
-                str += shambase::format(
+                str += sham::format(
                     "\n   metadata sync     : {:<10} ({:2.1f}%)",
                     metadata_sync.get_time_str(),
                     f64(100 * (metadata_sync.nanosec / total)));
                 if (patch_tree_count_reduce) {
-                    str += shambase::format(
+                    str += sham::format(
                         "\n   patch tree reduce : {:<10} ({:2.1f}%)",
                         patch_tree_count_reduce->get_time_str(),
                         100 * (patch_tree_count_reduce->nanosec / total));
                 }
                 if (gen_merge_split_rq) {
-                    str += shambase::format(
+                    str += sham::format(
                         "\n   gen split merge   : {:<10} ({:2.1f}%)",
                         gen_merge_split_rq->get_time_str(),
                         100 * (gen_merge_split_rq->nanosec / total));
                 }
                 if (split_merge_cnt) {
-                    str += shambase::format(
+                    str += sham::format(
                         "\n   split / merge op  : {}/{}",
                         split_merge_cnt->x(),
                         split_merge_cnt->y());
                 }
                 if (apply_splits) {
-                    str += shambase::format(
+                    str += sham::format(
                         "\n   apply split merge : {:<10} ({:2.1f}%)",
                         apply_splits->get_time_str(),
                         100 * (apply_splits->nanosec / total));
                 }
                 if (load_balance_compute) {
-                    str += shambase::format(
+                    str += sham::format(
                         "\n   LB compute        : {:<10} ({:2.1f}%)",
                         load_balance_compute->get_time_str(),
                         100 * (load_balance_compute->nanosec / total));
                 }
                 if (load_balance_move_op_cnt) {
-                    str += shambase::format(
-                        "\n   LB move op cnt    : {}", *load_balance_move_op_cnt);
+                    str += sham::format("\n   LB move op cnt    : {}", *load_balance_move_op_cnt);
                 }
                 if (load_balance_apply) {
-                    str += shambase::format(
+                    str += sham::format(
                         "\n   LB apply          : {:<10} ({:2.1f}%)",
                         load_balance_apply->get_time_str(),
                         100 * (load_balance_apply->nanosec / total));
@@ -597,9 +596,9 @@ std::string PatchScheduler::dump_status() {
            << " [" << p.coord_min[2] << "," << p.coord_max[2] << "] )\n";
     }
 
-    ss << shambase::format(
+    ss << sham::format(
         "patch_list.id_patch_to_global_idx :\n{}\n", patch_list.id_patch_to_global_idx);
-    ss << shambase::format(
+    ss << sham::format(
         "patch_list.id_patch_to_local_idx :\n{}\n", patch_list.id_patch_to_local_idx);
 
     ss << " -> SchedulerPatchData\n";
@@ -622,7 +621,7 @@ std::string PatchScheduler::dump_status() {
     ss << " -> SchedulerPatchTree\n";
 
     for (auto &[k, pnode] : patch_tree.tree) {
-        ss << shambase::format(
+        ss << sham::format(
             "      -> id : {} -> ({}) <=> {} [{}, {}] (cl={} il={} l={} pid={})\n",
             k,
             pnode.tree_node.childs_nid,
@@ -642,16 +641,16 @@ std::string PatchScheduler::format_patch_coord(shamrock::patch::Patch p) {
     std::string ret;
     if (pdl_old().check_main_field_type<f32_3>()) {
         auto [bmin, bmax] = patch_data.sim_box.patch_coord_to_domain<f32_3>(p);
-        ret               = shambase::format("coord = {} {}", bmin, bmax);
+        ret               = sham::format("coord = {} {}", bmin, bmax);
     } else if (pdl_old().check_main_field_type<f64_3>()) {
         auto [bmin, bmax] = patch_data.sim_box.patch_coord_to_domain<f64_3>(p);
-        ret               = shambase::format("coord = {} {}", bmin, bmax);
+        ret               = sham::format("coord = {} {}", bmin, bmax);
     } else if (pdl_old().check_main_field_type<u32_3>()) {
         auto [bmin, bmax] = patch_data.sim_box.patch_coord_to_domain<u32_3>(p);
-        ret               = shambase::format("coord = {} {}", bmin, bmax);
+        ret               = sham::format("coord = {} {}", bmin, bmax);
     } else if (pdl_old().check_main_field_type<u64_3>()) {
         auto [bmin, bmax] = patch_data.sim_box.patch_coord_to_domain<u64_3>(p);
-        ret               = shambase::format("coord = {} {}", bmin, bmax);
+        ret               = sham::format("coord = {} {}", bmin, bmax);
     } else {
         throw shambase::make_except_with_loc<std::runtime_error>(
             "the main field does not match any");
@@ -675,7 +674,7 @@ void check_locality_t(PatchScheduler &sched) {
             },
             bmin_p0,
             bmax_p0,
-            shambase::format("patch id = {}", pid));
+            sham::format("patch id = {}", pid));
     });
 }
 

--- a/src/shamrock/src/scheduler/SchedulerPatchData.cpp
+++ b/src/shamrock/src/scheduler/SchedulerPatchData.cpp
@@ -369,36 +369,36 @@ namespace shamrock::scheduler {
         auto search7 = owned_data.find(old_keys[7]);
 
         if (search0 == owned_data.not_found()) {
-            throw shambase::make_except_with_loc<std::runtime_error>(shambase::format_printf(
-                "patchdata for key=%d was not owned by the node", old_keys[0]));
+            throw shambase::make_except_with_loc<std::runtime_error>(
+                sham::format_printf("patchdata for key=%d was not owned by the node", old_keys[0]));
         }
         if (search1 == owned_data.not_found()) {
-            throw shambase::make_except_with_loc<std::runtime_error>(shambase::format_printf(
-                "patchdata for key=%d was not owned by the node", old_keys[1]));
+            throw shambase::make_except_with_loc<std::runtime_error>(
+                sham::format_printf("patchdata for key=%d was not owned by the node", old_keys[1]));
         }
         if (search2 == owned_data.not_found()) {
-            throw shambase::make_except_with_loc<std::runtime_error>(shambase::format_printf(
-                "patchdata for key=%d was not owned by the node", old_keys[2]));
+            throw shambase::make_except_with_loc<std::runtime_error>(
+                sham::format_printf("patchdata for key=%d was not owned by the node", old_keys[2]));
         }
         if (search3 == owned_data.not_found()) {
-            throw shambase::make_except_with_loc<std::runtime_error>(shambase::format_printf(
-                "patchdata for key=%d was not owned by the node", old_keys[3]));
+            throw shambase::make_except_with_loc<std::runtime_error>(
+                sham::format_printf("patchdata for key=%d was not owned by the node", old_keys[3]));
         }
         if (search4 == owned_data.not_found()) {
-            throw shambase::make_except_with_loc<std::runtime_error>(shambase::format_printf(
-                "patchdata for key=%d was not owned by the node", old_keys[4]));
+            throw shambase::make_except_with_loc<std::runtime_error>(
+                sham::format_printf("patchdata for key=%d was not owned by the node", old_keys[4]));
         }
         if (search5 == owned_data.not_found()) {
-            throw shambase::make_except_with_loc<std::runtime_error>(shambase::format_printf(
-                "patchdata for key=%d was not owned by the node", old_keys[5]));
+            throw shambase::make_except_with_loc<std::runtime_error>(
+                sham::format_printf("patchdata for key=%d was not owned by the node", old_keys[5]));
         }
         if (search6 == owned_data.not_found()) {
-            throw shambase::make_except_with_loc<std::runtime_error>(shambase::format_printf(
-                "patchdata for key=%d was not owned by the node", old_keys[6]));
+            throw shambase::make_except_with_loc<std::runtime_error>(
+                sham::format_printf("patchdata for key=%d was not owned by the node", old_keys[6]));
         }
         if (search7 == owned_data.not_found()) {
-            throw shambase::make_except_with_loc<std::runtime_error>(shambase::format_printf(
-                "patchdata for key=%d was not owned by the node", old_keys[7]));
+            throw shambase::make_except_with_loc<std::runtime_error>(
+                sham::format_printf("patchdata for key=%d was not owned by the node", old_keys[7]));
         }
 
         shamrock::patch::PatchDataLayer new_pdat(pdl_ptr);

--- a/src/shamsolvergraph/include/shamsolvergraph/JsonSerializable.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/JsonSerializable.hpp
@@ -171,7 +171,7 @@ namespace shamrock::solvergraph {
             // if the type is already registered, throw an error
             if (!inserted) {
                 throw std::runtime_error(
-                    shambase::format(
+                    sham::format(
                         "Type {} already registered (called from {})",
                         name,
                         shambase::format_one_line_func(loc)));

--- a/src/shamsolvergraph/include/shamsolvergraph/SolverGraph.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/SolverGraph.hpp
@@ -46,7 +46,7 @@ namespace shamrock::solvergraph {
 
         inline bool check_node(const std::shared_ptr<INode> &node) const {
             if (!bool(node)) {
-                throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+                throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
                     "node == nullptr is not allowed, please pass a shared pointer with a valid "
                     "node"));
             }
@@ -58,7 +58,7 @@ namespace shamrock::solvergraph {
 
         inline bool check_edge(const std::shared_ptr<IEdge> &edge) const {
             if (!bool(edge)) {
-                throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+                throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
                     "edge == nullptr is not allowed, please pass a shared pointer with a valid "
                     "edge"));
             }
@@ -148,7 +148,7 @@ namespace shamrock::solvergraph {
             const std::string &name, std::shared_ptr<INode> node) {
 
             if (!constraint.check_node(node)) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "Solvergraph constraint '{}' rejected node '{}' (label='{}', uuid={})",
                     constraint.name,
                     name,
@@ -159,7 +159,7 @@ namespace shamrock::solvergraph {
             const auto [it, inserted] = nodes.try_emplace(name, std::move(node));
             if (!inserted) {
                 shambase::throw_with_loc<std::invalid_argument>(
-                    shambase::format("Node already exists: {}", name));
+                    sham::format("Node already exists: {}", name));
             }
             return it->second;
         }
@@ -176,7 +176,7 @@ namespace shamrock::solvergraph {
             const std::string &name, std::shared_ptr<IEdge> edge) {
 
             if (!constraint.check_edge(edge)) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "Solvergraph constraint '{}' rejected edge '{}' (label='{}', uuid={})",
                     constraint.name,
                     name,
@@ -187,7 +187,7 @@ namespace shamrock::solvergraph {
             const auto [it, inserted] = edges.try_emplace(name, std::move(edge));
             if (!inserted) {
                 shambase::throw_with_loc<std::invalid_argument>(
-                    shambase::format("Edge already exists: {}", name));
+                    sham::format("Edge already exists: {}", name));
             }
             return it->second;
         }
@@ -203,7 +203,7 @@ namespace shamrock::solvergraph {
             auto it = nodes.find(name);
             if (it == nodes.end()) {
                 shambase::throw_with_loc<std::invalid_argument>(
-                    shambase::format("Node does not exist: {}", name));
+                    sham::format("Node does not exist: {}", name));
             }
             return it->second;
         }
@@ -213,7 +213,7 @@ namespace shamrock::solvergraph {
             auto it = nodes.find(name);
             if (it == nodes.end()) {
                 shambase::throw_with_loc<std::invalid_argument>(
-                    shambase::format("Node does not exist: {}", name));
+                    sham::format("Node does not exist: {}", name));
             }
             return it->second;
         }
@@ -229,7 +229,7 @@ namespace shamrock::solvergraph {
             auto it = edges.find(name);
             if (it == edges.end()) {
                 shambase::throw_with_loc<std::invalid_argument>(
-                    shambase::format("Edge does not exist: {}", name));
+                    sham::format("Edge does not exist: {}", name));
             }
             return it->second;
         }
@@ -239,7 +239,7 @@ namespace shamrock::solvergraph {
             auto it = edges.find(name);
             if (it == edges.end()) {
                 shambase::throw_with_loc<std::invalid_argument>(
-                    shambase::format("Edge does not exist: {}", name));
+                    sham::format("Edge does not exist: {}", name));
             }
             return it->second;
         }
@@ -360,7 +360,7 @@ namespace shamrock::solvergraph {
             auto tmp = std::dynamic_pointer_cast<T>(get_node_ptr_base(name));
             if (!bool(tmp)) {
                 shambase::throw_with_loc<std::invalid_argument>(
-                    shambase::format("Node exists but is not from the requested type: {}", name));
+                    sham::format("Node exists but is not from the requested type: {}", name));
             }
             return tmp;
         }
@@ -371,7 +371,7 @@ namespace shamrock::solvergraph {
             auto tmp = std::dynamic_pointer_cast<T>(get_node_ptr_base(name));
             if (!bool(tmp)) {
                 shambase::throw_with_loc<std::invalid_argument>(
-                    shambase::format("Node exists but is not from the requested type: {}", name));
+                    sham::format("Node exists but is not from the requested type: {}", name));
             }
             return tmp;
         }
@@ -392,7 +392,7 @@ namespace shamrock::solvergraph {
             auto tmp = std::dynamic_pointer_cast<T>(get_edge_ptr_base(name));
             if (!bool(tmp)) {
                 shambase::throw_with_loc<std::invalid_argument>(
-                    shambase::format("Edge exists but is not from the requested type: {}", name));
+                    sham::format("Edge exists but is not from the requested type: {}", name));
             }
             return tmp;
         }
@@ -403,7 +403,7 @@ namespace shamrock::solvergraph {
             auto tmp = std::dynamic_pointer_cast<T>(get_edge_ptr_base(name));
             if (!bool(tmp)) {
                 shambase::throw_with_loc<std::invalid_argument>(
-                    shambase::format("Edge exists but is not from the requested type: {}", name));
+                    sham::format("Edge exists but is not from the requested type: {}", name));
             }
             return tmp;
         }

--- a/src/shamsolvergraph/include/shamsolvergraph/SolverGraphSerializable.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/SolverGraphSerializable.hpp
@@ -55,7 +55,7 @@ namespace shamrock::solvergraph {
             // we use raw pointer to avoir the cost of creating a new shared pointer
             auto *serializable = dynamic_cast<const JsonSerializable *>(edge_ptr.get());
             if (serializable == nullptr) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "Edge '{}' is registered in SolverGraphSerializable but is not "
                     "JsonSerializable",
                     name));
@@ -94,7 +94,7 @@ namespace shamrock::solvergraph {
             std::shared_ptr<JsonSerializable> serializable = JsonSerializable::from_json(edge_json);
             auto edge = std::dynamic_pointer_cast<IEdge>(serializable);
             if (!bool(edge)) {
-                shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+                shambase::throw_with_loc<std::invalid_argument>(sham::format(
                     "Deserialized type for edge '{}' does not inherit from IEdge", name));
             }
 

--- a/src/shamsolvergraph/include/shamsolvergraph/node/INode.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/node/INode.hpp
@@ -103,7 +103,7 @@ namespace shamrock::solvergraph {
             }
 
             throw shambase::make_except_with_loc<std::invalid_argument>(
-                shambase::format("Edge is not from the requested type: {}", slot));
+                sham::format("Edge is not from the requested type: {}", slot));
         }
 
         /// Get a read write edge and cast it to the type T, return an optional
@@ -121,7 +121,7 @@ namespace shamrock::solvergraph {
             }
 
             throw shambase::make_except_with_loc<std::invalid_argument>(
-                shambase::format("Edge is not from the requested type: {}", slot));
+                sham::format("Edge is not from the requested type: {}", slot));
         }
 
         /// Get a reference to a read only edge
@@ -165,16 +165,16 @@ namespace shamrock::solvergraph {
 
         /// print the node info
         inline virtual std::string print_node_info() const {
-            std::string node_info = shambase::format("Node info :\n");
-            node_info += shambase::format(" - Node type : {}\n", typeid(*this).name());
-            node_info += shambase::format(" - Node UUID : {}\n", get_uuid());
-            node_info += shambase::format(" - Node label : {}\n", _impl_get_label());
+            std::string node_info = sham::format("Node info :\n");
+            node_info += sham::format(" - Node type : {}\n", typeid(*this).name());
+            node_info += sham::format(" - Node UUID : {}\n", get_uuid());
+            node_info += sham::format(" - Node label : {}\n", _impl_get_label());
 
             auto append_edges_info = [&](const char *title, const auto &edges) {
-                node_info += shambase::format(" - {}: {}\n", title, edges.size());
+                node_info += sham::format(" - {}: {}\n", title, edges.size());
                 for (const auto &edge : edges) {
                     const auto &e = *edge; // necessary to avoid -Wpotentially-evaluated-expression
-                    node_info += shambase::format(
+                    node_info += sham::format(
                         "     - Edge ptr = {}, uuid = {}, label = {},\n          type = {} \n",
                         static_cast<void *>(edge.get()),
                         edge->get_uuid(),
@@ -243,34 +243,34 @@ namespace shamrock::solvergraph {
 
     inline std::string INode::_impl_get_dot_graph_partial() const {
         std::string node_str
-            = shambase::format("n_{} [label=\"{}\"];\n", this->get_uuid(), _impl_get_label());
+            = sham::format("n_{} [label=\"{}\"];\n", this->get_uuid(), _impl_get_label());
 
         std::string edge_str = "";
         for (auto &in : ro_edges) {
-            edge_str += shambase::format(
+            edge_str += sham::format(
                 "e_{} -> n_{} [style=\"dashed\", color=green];\n",
                 in->get_uuid(),
                 this->get_uuid());
-            edge_str += shambase::format(
+            edge_str += sham::format(
                 "e_{} [label=\"{}\",shape=rect, style=filled];\n", in->get_uuid(), in->get_label());
         }
         for (auto &out : rw_edges) {
-            edge_str += shambase::format(
+            edge_str += sham::format(
                 "n_{} -> e_{} [style=\"dashed\", color=red];\n", this->get_uuid(), out->get_uuid());
-            edge_str += shambase::format(
+            edge_str += sham::format(
                 "e_{} [label=\"{}\",shape=rect, style=filled];\n",
                 out->get_uuid(),
                 out->get_label());
         }
 
-        return shambase::format("{}{}", node_str, edge_str);
+        return sham::format("{}{}", node_str, edge_str);
     };
 
     inline std::string INode::_impl_get_dot_graph_node_start() const {
-        return shambase::format("n_{}", this->get_uuid());
+        return sham::format("n_{}", this->get_uuid());
     }
     inline std::string INode::_impl_get_dot_graph_node_end() const {
-        return shambase::format("n_{}", this->get_uuid());
+        return sham::format("n_{}", this->get_uuid());
     }
 
 } // namespace shamrock::solvergraph

--- a/src/shamsolvergraph/include/shamsolvergraph/node/OperationIf.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/node/OperationIf.hpp
@@ -58,10 +58,10 @@ namespace shamrock::solvergraph {
         std::string _impl_get_dot_graph_partial() const;
 
         inline virtual std::string _impl_get_dot_graph_node_start() const {
-            return shambase::format("n_{}", get_uuid());
+            return sham::format("n_{}", get_uuid());
         }
         inline virtual std::string _impl_get_dot_graph_node_end() const {
-            return shambase::format("n_{}_end", get_uuid());
+            return sham::format("n_{}_end", get_uuid());
         }
 
         std::string _impl_get_tex() const;

--- a/src/shamsolvergraph/src/OperationIf.cpp
+++ b/src/shamsolvergraph/src/OperationIf.cpp
@@ -34,43 +34,42 @@ namespace shamrock::solvergraph {
         std::stringstream ss;
 
         ss << "subgraph cluster_" + std::to_string(get_uuid()) + " {\n";
-        ss << shambase::format(
-            "n_{} [label=\"{}\", shape=diamond];\n", get_uuid(), _impl_get_label());
+        ss << sham::format("n_{} [label=\"{}\", shape=diamond];\n", get_uuid(), _impl_get_label());
 
         if (then_node) {
             ss << then_node->get_dot_graph_partial();
-            ss << shambase::format(
+            ss << sham::format(
                 "n_{} -> {} [label=\"true\"];\n",
                 get_uuid(),
                 then_node->get_dot_graph_node_start());
             ss << then_node->get_dot_graph_node_end() << " -> "
-               << shambase::format("n_{}_end", get_uuid()) << ";\n";
+               << sham::format("n_{}_end", get_uuid()) << ";\n";
         } else {
-            ss << shambase::format(
+            ss << sham::format(
                 "n_{} -> n_{}_end [label=\"true\", style=dashed];\n", get_uuid(), get_uuid());
         }
 
         if (else_node) {
             ss << else_node->get_dot_graph_partial();
-            ss << shambase::format(
+            ss << sham::format(
                 "n_{} -> {} [label=\"false\"];\n",
                 get_uuid(),
                 else_node->get_dot_graph_node_start());
             ss << else_node->get_dot_graph_node_end() << " -> "
-               << shambase::format("n_{}_end", get_uuid()) << ";\n";
+               << sham::format("n_{}_end", get_uuid()) << ";\n";
         } else {
-            ss << shambase::format(
+            ss << sham::format(
                 "n_{} -> n_{}_end [label=\"false\", style=dashed];\n", get_uuid(), get_uuid());
         }
 
-        ss << shambase::format("n_{}_end [label=\"\", shape=point, width=0.15];\n", get_uuid());
-        ss << shambase::format("label = \"{}\";\n", _impl_get_label());
+        ss << sham::format("n_{}_end [label=\"\", shape=point, width=0.15];\n", get_uuid());
+        ss << sham::format("label = \"{}\";\n", _impl_get_label());
         ss << "}\n";
 
         auto &cond = get_ro_edge_base(0);
-        ss << shambase::format(
+        ss << sham::format(
             "e_{} -> n_{} [style=\"dashed\", color=green];\n", cond.get_uuid(), get_uuid());
-        ss << shambase::format(
+        ss << sham::format(
             "e_{} [label=\"{}\",shape=rect, style=filled];\n", cond.get_uuid(), cond.get_label());
 
         return ss.str();

--- a/src/shamsolvergraph/src/OperationSequence.cpp
+++ b/src/shamsolvergraph/src/OperationSequence.cpp
@@ -39,7 +39,7 @@ namespace shamrock::solvergraph {
                << nodes[i + 1]->get_dot_graph_node_start() << " [weight=3];\n";
         }
 
-        ss << shambase::format("label = \"{}\";\n", _impl_get_label());
+        ss << sham::format("label = \"{}\";\n", _impl_get_label());
         ss << "}\n";
 
         return ss.str();

--- a/src/shamsys/src/MicroBenchmark.cpp
+++ b/src/shamsys/src/MicroBenchmark.cpp
@@ -152,7 +152,7 @@ void shamsys::microbench::p2p_bandwidth(u32 wr_sender, u32 wr_receiv) {
     if (shamcomm::world_rank() == 0) {
         auto hr_bw = sham::to_human_readable<false>(bw);
         logger::raw_ln(
-            shambase::format(
+            sham::format(
                 " - p2p bandwidth    : {:.2f} {}B.s^-1 (ranks : {} -> {}) (loops : {})",
                 hr_bw.value,
                 hr_bw.prefix,
@@ -217,7 +217,7 @@ void shamsys::microbench::p2p_latency(u32 wr1, u32 wr2) {
 
     if (shamcomm::world_rank() == 0) {
         logger::raw_ln(
-            shambase::format(
+            sham::format(
                 " - p2p latency     : {:.4e} s (ranks : {} <-> {}) (loops : {})",
                 latency,
                 wr1,
@@ -325,7 +325,7 @@ void shamsys::microbench::saxpy() {
     if (shamcomm::world_rank() == 0) {
         auto hr_bw = sham::to_human_readable<false>(sum_bw);
         logger::raw_ln(
-            shambase::format(
+            sham::format(
                 " - saxpy ({})   : {:.2f} {}B.s^-1 (min = {:.1e}, max = {:.1e}, avg = {:.1e}) "
                 "({:.1e} ms, {})",
                 type_name,
@@ -386,7 +386,7 @@ void shamsys::microbench::fma_chains_rotation() {
     if (shamcomm::world_rank() == 0) {
         auto hr_flop = sham::to_human_readable<false>(sum_flop * flops_multiplier);
         logger::raw_ln(
-            shambase::format(
+            sham::format(
                 " - fma_chains ({}) : {:.2f} {}flops (min = {:.1e}, max = {:.1e}, avg = {:.1e}) "
                 "({:.1e} ms, rotations = {})",
                 type_name,
@@ -434,7 +434,7 @@ void shamsys::microbench::vector_allgather(u32 el_per_rank) {
 
     if (shamcomm::world_rank() == 0) {
         logger::raw_ln(
-            shambase::format(
+            sham::format(
                 " - vector_allgather (u64, n={:4}) : {:.3e} s (min = {:.2e}, max = {:.2e}, loops = "
                 "{})",
                 el_per_rank,

--- a/src/shamsys/src/NodeInstance.cpp
+++ b/src/shamsys/src/NodeInstance.cpp
@@ -63,7 +63,7 @@ namespace shamsys::instance::details {
             std::string platname = shambase::trunc_str(PlatformName, 24);
             std::string devtype  = shambase::trunc_str(shambase::getDevice_type(dev), 6);
 
-            print_buf += shambase::format(
+            print_buf += sham::format(
                              "| {:>4} | {:>2} | {:>29.29} | {:>24.24} | {:>6} |",
                              rank,
                              key_global,
@@ -173,14 +173,14 @@ namespace shamsys::instance {
 
         std::optional<u32> loc = shamcomm::node_local_rank();
         if (loc) {
-            print_buf = shambase::format(
+            print_buf = sham::format(
                 "| {:>4} | {:>8} | {:>12} | {:>16} |\n",
                 rank,
                 *loc,
                 shambase::get_check_ref(syclinit::device_alt).device_id,
                 shambase::get_check_ref(syclinit::device_compute).device_id);
         } else {
-            print_buf = shambase::format(
+            print_buf = sham::format(
                 "| {:>4} | {:>8} | {:>12} | {:>16} |\n",
                 rank,
                 "???",
@@ -271,7 +271,7 @@ namespace shamsys::instance {
 
         shamlog_debug_ln(
             "Sys",
-            shambase::format(
+            sham::format(
                 "[{:03}]: \x1B[32mMPI_Init : node n {:03} | world size : {} | name = {}\033[0m",
                 shamcomm::world_rank(),
                 shamcomm::world_rank(),
@@ -410,18 +410,17 @@ namespace shamsys::instance {
         if (shamcomm::world_rank() == 0) {
             if (num_dgpu_use == shamcomm::world_size()) {
                 logger::raw_ln(
-                    shambase::format(
-                        " - MPI use Direct Comm : {}", col8b_green() + "Yes" + reset()));
+                    sham::format(" - MPI use Direct Comm : {}", col8b_green() + "Yes" + reset()));
             } else if (num_dgpu_use > 0) {
                 logger::raw_ln(
-                    shambase::format(
+                    sham::format(
                         " - MPI use Direct Comm : {} ({} of {})",
                         col8b_yellow() + "Partial" + reset(),
                         num_dgpu_use,
                         shamcomm::world_size()));
             } else {
                 logger::raw_ln(
-                    shambase::format(" - MPI use Direct Comm : {}", col8b_red() + "No" + reset()));
+                    sham::format(" - MPI use Direct Comm : {}", col8b_red() + "No" + reset()));
             }
         }
     }

--- a/src/shamsys/src/SignalCatch.cpp
+++ b/src/shamsys/src/SignalCatch.cpp
@@ -97,7 +97,7 @@ namespace shamsys::details {
             outfile << report << std::endl;
             outfile << log_end << std::endl;
             outfile.close();
-            std::cout << shambase::format(
+            std::cout << sham::format(
                 "{}"
                 "Crash report written to {}",
                 log_start,

--- a/src/shamsys/src/change_log_format.cpp
+++ b/src/shamsys/src/change_log_format.cpp
@@ -58,7 +58,7 @@ namespace logformatter {
      * @return std::string The formatted log
      */
     std::string style1_formatter_full(const logger::ReformatArgs &args) {
-        return shambase::format(
+        return sham::format(
             "{5:}rank={6:<4}{2:} {5:}({3:^20}){2:} {0:}{1:}{2:}: {4:}",
             args.color,
             args.level_name,
@@ -76,7 +76,7 @@ namespace logformatter {
      * @return std::string The formatted log
      */
     std::string style1_formatter_simple(const logger::ReformatArgs &args) {
-        return shambase::format(
+        return sham::format(
             "{5:}({3:}){2:} : {4:}",
             args.color,
             args.level_name,
@@ -94,7 +94,7 @@ namespace logformatter {
 
     std::string style2_formatter_full(const logger::ReformatArgs &args) {
 
-        return shambase::format(
+        return sham::format(
             "{0:}{1:}{2:}: {4:}{5:} | ({3:}) rank={6:<4}{2:}",
             args.color,
             args.level_name,
@@ -112,7 +112,7 @@ namespace logformatter {
      * @return std::string The formatted log
      */
     std::string style2_formatter_simple(const logger::ReformatArgs &args) {
-        return shambase::format(
+        return sham::format(
             "{5:}({3:}){2:} : {4:}",
             args.color,
             args.level_name,
@@ -135,7 +135,7 @@ namespace logformatter {
         std::string ansi_reset = shambase::term_colors::reset();
         std::string ansi_faint = shambase::term_colors::faint();
 
-        std::string lineend = shambase::format(
+        std::string lineend = sham::format(
             "{5:} [{3:}][rank={6:}]{2:}",
             args.color,
             args.level_name,
@@ -145,7 +145,7 @@ namespace logformatter {
             ansi_faint,
             shamcomm::world_rank());
 
-        std::string log = shambase::format(
+        std::string log = sham::format(
             "{0:}{1:}{2:}: {4:}",
             args.color,
             args.level_name,
@@ -167,7 +167,7 @@ namespace logformatter {
 
         u32 ansi_count = ansi_reset.size() * 2 + ansi_faint.size() + args.color.size();
 
-        return shambase::format("{:<{}}", log_line1, tty_width - lineend.size() + ansi_count - 1)
+        return sham::format("{:<{}}", log_line1, tty_width - lineend.size() + ansi_count - 1)
                + lineend + log_line2;
     }
 
@@ -178,7 +178,7 @@ namespace logformatter {
      * @return std::string The formatted log
      */
     std::string style3_formatter_simple(const logger::ReformatArgs &args) {
-        return shambase::format(
+        return sham::format(
             "{5:}{3:}{2:}: {4:}",
             args.color,
             args.level_name,
@@ -201,7 +201,7 @@ namespace logformatter {
         std::string ansi_reset = shambase::term_colors::reset();
         std::string ansi_faint = shambase::term_colors::faint();
 
-        std::string lineend = shambase::format(
+        std::string lineend = sham::format(
             "{5:} [{3:}][rank={6:}][{7:.2f}s]{2:}",
             args.color,
             args.level_name,
@@ -212,7 +212,7 @@ namespace logformatter {
             shamcomm::world_rank(),
             shambase::details::get_wtime());
 
-        std::string log = shambase::format(
+        std::string log = sham::format(
             "{0:}{1:}{2:}: {4:}",
             args.color,
             args.level_name,
@@ -234,7 +234,7 @@ namespace logformatter {
 
         u32 ansi_count = ansi_reset.size() * 2 + ansi_faint.size() + args.color.size();
 
-        return shambase::format("{:<{}}", log_line1, tty_width - lineend.size() + ansi_count - 1)
+        return sham::format("{:<{}}", log_line1, tty_width - lineend.size() + ansi_count - 1)
                + lineend + log_line2;
     }
 
@@ -245,7 +245,7 @@ namespace logformatter {
      * @return std::string The formatted log
      */
     std::string style4_formatter_simple(const logger::ReformatArgs &args) {
-        return shambase::format(
+        return sham::format(
             "{5:}{3:}{2:}: {4:}",
             args.color,
             args.level_name,

--- a/src/shamsys/src/legacy/sycl_handler.cpp
+++ b/src/shamsys/src/legacy/sycl_handler.cpp
@@ -199,7 +199,7 @@ namespace sycl_handler {
                     std::string devtype  = shambase::trunc_str(getDeviceTypeName(Device), 6);
 
                     logger::raw_ln(
-                        shambase::format_printf(
+                        sham::format_printf(
                             "| %-3s | %02d | %-29s | %-24s | %-6s |",
                             selected.c_str(),
                             key_global,

--- a/src/shamsys/src/legacy/sysinfo.cpp
+++ b/src/shamsys/src/legacy/sysinfo.cpp
@@ -28,5 +28,5 @@ inline std::string get_cpu_name() {
     __get_cpuid(0x80000002, brand + 0x0, brand + 0x1, brand + 0x2, brand + 0x3);
     __get_cpuid(0x80000003, brand + 0x4, brand + 0x5, brand + 0x6, brand + 0x7);
     __get_cpuid(0x80000004, brand + 0x8, brand + 0x9, brand + 0xa, brand + 0xb);
-    return shambase::format_printf("Brand: %s\n", brand);
+    return sham::format_printf("Brand: %s\n", brand);
 }

--- a/src/shamsys/src/shamrock_smi.cpp
+++ b/src/shamsys/src/shamrock_smi.cpp
@@ -80,7 +80,7 @@ namespace shamsys {
             f64 mem            = device.prop.global_mem_size;
             std::string memstr = shambase::readable_sizeof(mem);
 
-            nodeconfig += shambase::format(
+            nodeconfig += sham::format(
                               "| {:>2} | {:>25.25} | {:>22.22} | {:>6} | {:>12} | {:>5} | ",
                               key_global,
                               devname,
@@ -98,8 +98,8 @@ namespace shamsys {
             std::string print = "Available devices :\n";
             for (auto &[node_conf, count] : nodeconfig_histogram) {
                 std::string arr = "";
-                add_array(arr, shambase::format("{} x Shamrock process: ", count), node_conf);
-                print += shambase::format("\n{}\n", arr);
+                add_array(arr, sham::format("{} x Shamrock process: ", count), node_conf);
+                print += sham::format("\n{}\n", arr);
             }
             printf("%s", print.data());
         }
@@ -128,7 +128,7 @@ namespace shamsys {
             f64 mem            = device.prop.global_mem_size;
             std::string memstr = shambase::readable_sizeof(mem);
 
-            print_buf += shambase::format(
+            print_buf += sham::format(
                              "| {:>4} | {:>2} | {:>25.25} | {:>22.22} | {:>6} | {:>12} | {:>5} | ",
                              rank,
                              key_global,
@@ -182,7 +182,7 @@ namespace shamsys {
                 }
             };
 
-            std::string dev_with_id = shambase::format(
+            std::string dev_with_id = sham::format(
                 R"({} (id={})
           - default_work_group_size = {}
           - global_mem_size = {}
@@ -204,7 +204,7 @@ namespace shamsys {
             if (!dev.prop.warnings.empty()) {
                 dev_with_id += "\n      - Warnings:";
                 for (auto &warning : dev.prop.warnings) {
-                    dev_with_id += shambase::format("\n          - {}", warning);
+                    dev_with_id += sham::format("\n          - {}", warning);
                 }
             }
 
@@ -224,7 +224,7 @@ namespace shamsys {
                                     "ranks per device)\n";
 
                 for (auto &[key, value] : devicename_histogram) {
-                    print += shambase::format("  - {} x {}", value, key) + "\n";
+                    print += sham::format("  - {} x {}", value, key) + "\n";
                 }
                 print += "  Total memory : " + shambase::readable_sizeof(total_mem) + "\n";
                 print += "  Total compute units : " + std::to_string(n_compute_units) + "\n";

--- a/src/shamsys/src/system_metrics.cpp
+++ b/src/shamsys/src/system_metrics.cpp
@@ -165,7 +165,7 @@ namespace shamsys {
         } else if (reporter_name == "noop" || reporter_name == "none" || reporter_name == "") {
             return std::make_unique<NoopSystemMetricReporter>();
         } else {
-            throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+            throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
                 "Unknown system metrics reporter: {}, valid reporters are: aurora, aurora-linked, "
                 "intel-rapl, noop",
                 reporter_name));
@@ -303,8 +303,8 @@ namespace shamsys {
                 if (wall_time > 0._f64 && energy.value() > 0._f64) {
                     f64 consumed_energy = energy.value();
                     f64 power           = consumed_energy / wall_time;
-                    out_power           = shambase::format("{:.1f} W", power);
-                    out_energy          = shambase::format("{:.1f} J", consumed_energy);
+                    out_power           = sham::format("{:.1f} W", power);
+                    out_energy          = sham::format("{:.1f} J", consumed_energy);
                 } else {
                     out_power  = "N/A";
                     out_energy = "N/A";
@@ -313,7 +313,7 @@ namespace shamsys {
         };
 
         FormattedSystemMetrics ret{
-            .wall_time             = shambase::format("{:.1f} s", input.wall_time),
+            .wall_time             = sham::format("{:.1f} s", input.wall_time),
             .rank_energy_consummed = std::nullopt,
             .gpu_energy_consummed  = std::nullopt,
             .cpu_energy_consummed  = std::nullopt,

--- a/src/shamtest/details/DataNode.cpp
+++ b/src/shamtest/details/DataNode.cpp
@@ -23,7 +23,7 @@ namespace shamtest::details {
         std::string acc = "\n[\n";
 
         for (u32 i = 0; i < vec.size(); i++) {
-            acc += shambase::format_printf("%e", vec[i]);
+            acc += sham::format_printf("%e", vec[i]);
             if (i < vec.size() - 1) {
                 acc += ", ";
             }

--- a/src/shamtest/details/reporters/texTestReport.cpp
+++ b/src/shamtest/details/reporters/texTestReport.cpp
@@ -159,7 +159,7 @@ namespace shamtest::details {
                 output << R"(\FAIL & )";
             }
 
-            output << shambase::format(R"({}/{} \\)", cnt_suc, cnt);
+            output << sham::format(R"({}/{} \\)", cnt_suc, cnt);
             output << "\n";
 
             table_cnt++;
@@ -175,7 +175,7 @@ namespace shamtest::details {
 
                 for (unsigned int j = 0; j < res.asserts.asserts.size(); j++) {
 
-                    output << shambase::format_printf(
+                    output << sham::format_printf(
                         "     - Assert [%d/%zu] \n\n", j + 1, res.asserts.asserts.size());
 
                     output << R"(\verb|)" << res.asserts.asserts[j].name << "| : ";

--- a/src/shamtest/shamtest.cpp
+++ b/src/shamtest/shamtest.cpp
@@ -61,14 +61,14 @@ namespace shamtest {
         if (is_run_only) {
             output += ("- : ");
         } else {
-            output += shambase::format("- [{}/{}] :", test_num + 1, test_count);
+            output += sham::format("- [{}/{}] :", test_num + 1, test_count);
         }
 
         bool any_node_cnt = test.world_size == -1;
         if (any_node_cnt) {
             output += (" [any] ");
         } else {
-            output += shambase::format(" [{:03}] ", test.world_size);
+            output += sham::format(" [{:03}] ", test.world_size);
         }
 
         output += "\033[;34m" + test.name + "\033[0m\n";
@@ -123,13 +123,13 @@ namespace shamtest {
             std::cout << "   -> Result : \033[1;31m Fail \033[0m";
         }
 
-        std::string s_assert = shambase::format(" [{}/{}] ", success_cnt, assert_count);
+        std::string s_assert = sham::format(" [{}/{}] ", success_cnt, assert_count);
         printf("%-15s", s_assert.c_str());
         std::cout << " (" << timer.get_time_str() << ")" << std::endl;
 
         if (shamcmdopt::is_ci_github_actions()) {
             if (success_cnt != assert_count) {
-                logger::raw_ln(shambase::format("##[error]Test {} failed", rank_results[0].name));
+                logger::raw_ln(sham::format("##[error]Test {} failed", rank_results[0].name));
             }
         }
 
@@ -171,8 +171,8 @@ namespace shamtest {
 
         for (unsigned int j = 0; j < res.asserts.asserts.size(); j++) {
 
-            out += shambase::format_printf("     - [%d/%zu] ", j + 1, res.asserts.asserts.size());
-            out += shambase::format_printf("%-20s", res.asserts.asserts[j].name.c_str());
+            out += sham::format_printf("     - [%d/%zu] ", j + 1, res.asserts.asserts.size());
+            out += sham::format_printf("%-20s", res.asserts.asserts[j].name.c_str());
 
             if (res.asserts.asserts[j].value) {
                 out += "  (\033[;32mSuccess\033[0m)\n";
@@ -409,7 +409,7 @@ namespace shamtest {
                 if (any_node_cnt) {
                     output += (" - [\033[;32many\033[0m] ");
                 } else {
-                    output += shambase::format(" - [\033[;32m{:03}\033[0m] ", t.world_size);
+                    output += sham::format(" - [\033[;32m{:03}\033[0m] ", t.world_size);
                 }
                 output += "\033[;32m" + t.name + "\033[0m\n";
 
@@ -417,7 +417,7 @@ namespace shamtest {
                 if (any_node_cnt) {
                     output += (" - [\033[;31many\033[0m] ");
                 } else {
-                    output += shambase::format(" - [\033[;31m{:03}\033[0m] ", t.world_size);
+                    output += sham::format(" - [\033[;31m{:03}\033[0m] ", t.world_size);
                 }
                 output += "\033[;31m" + t.name + "\033[0m\n";
             }
@@ -614,7 +614,7 @@ namespace shamtest {
 
         auto get_test_name = [&](Test t, int ranks) -> std::string {
             std::string name = get_pref_type(t.type) + "/" + t.name
-                               + shambase::format(
+                               + sham::format(
                                    "(ranks={})"
                                    //"{}"
                                    ,

--- a/src/shamtest/shamtest.hpp
+++ b/src/shamtest/shamtest.hpp
@@ -232,8 +232,8 @@ namespace shamtest::details {
                 assert_name,                                                                       \
                 eval,                                                                              \
                 assert_name + " evaluated to false\n\n" + " -> " #_a                               \
-                    + shambase::format(" = {}", _______a) + "\n" + " -> " #_b                      \
-                    + shambase::format(" = {}", _______b) + "\n"                                   \
+                    + sham::format(" = {}", _______a) + "\n" + " -> " #_b                          \
+                    + sham::format(" = {}", _______b) + "\n"                                       \
                     + " -> location : " + SourceLocation{}.format_one_line());                     \
         }                                                                                          \
     } while (0)
@@ -275,9 +275,9 @@ namespace shamtest::details {
             shamtest::asserts().assert_bool_with_log(                                              \
                 assert_name,                                                                       \
                 eval,                                                                              \
-                assert_name + " evaluated to false\n\n" + shambase::format(" -> " #_a " = {}", a)  \
-                    + "\n" + shambase::format(" -> " #_b " = {}", b) + "\n"                        \
-                    + shambase::format(" -> " #prec " = {}", prec) + "\n"                          \
+                assert_name + " evaluated to false\n\n" + sham::format(" -> " #_a " = {}", a)      \
+                    + "\n" + sham::format(" -> " #_b " = {}", b) + "\n"                            \
+                    + sham::format(" -> " #prec " = {}", prec) + "\n"                              \
                     + " -> location : " + SourceLocation{}.format_one_line());                     \
         }                                                                                          \
     } while (0)

--- a/src/shamtree/src/CLBVHDualTreeTraversal.cpp
+++ b/src/shamtree/src/CLBVHDualTreeTraversal.cpp
@@ -31,7 +31,7 @@ namespace shamtree {
         } else if (impl == "scan_multipass") {
             return DTTImpl::SCAN_MULTIPASS;
         }
-        throw shambase::make_except_with_loc<std::invalid_argument>(shambase::format(
+        throw shambase::make_except_with_loc<std::invalid_argument>(sham::format(
             "invalid implementation : {}, possible implementations : {}",
             impl,
             impl::get_default_impl_list_clbvh_dual_tree_traversal()));
@@ -46,7 +46,7 @@ namespace shamtree {
             return {.impl_name = "scan_multipass", .params = ""};
         }
         throw shambase::make_except_with_loc<std::invalid_argument>(
-            shambase::format("unknown dtt implementation : {}", u32(impl)));
+            sham::format("unknown dtt implementation : {}", u32(impl)));
     }
 
     std::vector<shamalgs::impl_param> impl::get_default_impl_list_clbvh_dual_tree_traversal() {

--- a/src/shamtree/src/MortonCodeSet.cpp
+++ b/src/shamtree/src/MortonCodeSet.cpp
@@ -74,7 +74,7 @@ namespace shamtree {
         morton_codes.resize(morton_count);
 
         if (morton_count < cnt_obj) {
-            shambase::throw_with_loc<std::invalid_argument>(shambase::format(
+            shambase::throw_with_loc<std::invalid_argument>(sham::format(
                 "MortonCodeSet: morton_count < cnt_obj\n morton_count: {}, cnt_obj: {}",
                 morton_count,
                 cnt_obj));

--- a/src/shamtree/src/MortonReducedSet.cpp
+++ b/src/shamtree/src/MortonReducedSet.cpp
@@ -44,7 +44,7 @@ namespace shamtree {
             " | after :",
             res.morton_leaf_count,
             ") ratio :",
-            shambase::format_printf(
+            sham::format_printf(
                 "%2.2f", f32(morton_codes_set.cnt_obj) / f32(res.morton_leaf_count)));
 
         if (res.morton_leaf_count == 0) {

--- a/src/shamtree/src/RadixTree.cpp
+++ b/src/shamtree/src/RadixTree.cpp
@@ -310,12 +310,12 @@ std::string print_member(const T &a);
 
 template<>
 std::string print_member(const u8 &a) {
-    return shambase::format_printf("%d", u32(a));
+    return sham::format_printf("%d", u32(a));
 }
 
 template<>
 std::string print_member(const u32 &a) {
-    return shambase::format_printf("%d", a);
+    return sham::format_printf("%d", a);
 }
 
 template<class u_morton, class vec3>

--- a/src/shamtree/src/TreeReducedMortonCodes.cpp
+++ b/src/shamtree/src/TreeReducedMortonCodes.cpp
@@ -50,7 +50,7 @@ namespace shamrock::tree {
             " | after :",
             tree_leaf_count,
             ") ratio :",
-            shambase::format_printf("%2.2f", f32(obj_cnt) / f32(tree_leaf_count)));
+            sham::format_printf("%2.2f", f32(obj_cnt) / f32(tree_leaf_count)));
 
         if (tree_leaf_count > 1) {
 

--- a/src/shamtree/src/kernels/reduction_alg.cpp
+++ b/src/shamtree/src/kernels/reduction_alg.cpp
@@ -343,7 +343,7 @@ void make_indexmap(
 
             for (unsigned int i = 0; i < morton_leaf_count + 2; i++) {
                 if (dest[i] != reduc_index_map[i]) {
-                    throw shambase::make_except_with_loc<std::runtime_error>(shambase::format(
+                    throw shambase::make_except_with_loc<std::runtime_error>(sham::format(
                         "difference i = {}, {} != {}", i, dest[i], reduc_index_map[i]));
                 }
             }

--- a/src/tests/fmmTests.cpp
+++ b/src/tests/fmmTests.cpp
@@ -1130,7 +1130,7 @@ Result_nompi_fmm_testing<flt, morton_mode, fmm_order> nompi_fmm_testing(
             if (i < 10) {
                 logger::raw_ln(
                     "local relative error : ",
-                    shambase::format_printf(
+                    sham::format_printf(
                         "%e (%e %e %e) (%e %e %e)",
                         err,
                         force[i].x(),
@@ -1147,7 +1147,7 @@ Result_nompi_fmm_testing<flt, morton_mode, fmm_order> nompi_fmm_testing(
 
         logger::raw_ln(
             "global relative error :",
-            shambase::format_printf("avg = %e max = %e", err_sum / npart, err_max));
+            sham::format_printf("avg = %e max = %e", err_sum / npart, err_max));
 
         prec = err_sum / npart;
     }

--- a/src/tests/shamalgs/collective/sparseXchgTests.cpp
+++ b/src/tests/shamalgs/collective/sparseXchgTests.cpp
@@ -108,7 +108,7 @@ void sparse_comm_test(std::string prefix, std::shared_ptr<sham::DeviceScheduler>
     logger::raw_ln("ref data : ");
     for (RefBuff &ref : tests.elements) {
         logger::raw_ln(
-            shambase::format(
+            sham::format(
                 "[{:2}] {} -> {} ({})",
                 wrank,
                 ref.sender_rank,
@@ -119,7 +119,7 @@ void sparse_comm_test(std::string prefix, std::shared_ptr<sham::DeviceScheduler>
     logger::raw_ln("recv data : ");
     for (RefBuff &ref : recv_data) {
         logger::raw_ln(
-            shambase::format(
+            sham::format(
                 "[{:2}] {} -> {} ({})",
                 wrank,
                 ref.sender_rank,

--- a/src/tests/shamalgs/collective/sparse_exchange_tests.cpp
+++ b/src/tests/shamalgs/collective/sparse_exchange_tests.cpp
@@ -186,16 +186,16 @@ struct fmt::formatter<shamalgs::collective::CommMessageInfo> {
 
 void print_comm_table(const shamalgs::collective::CommTable &comm_table) {
     std::stringstream ss;
-    ss << shambase::format(
+    ss << sham::format(
         "messages_send : [\n    {}\n]\n", fmt::join(comm_table.messages_send, "\n    "));
-    ss << shambase::format(
+    ss << sham::format(
         "messages_recv : [\n    {}\n]\n", fmt::join(comm_table.messages_recv, "\n    "));
-    ss << shambase::format(
+    ss << sham::format(
         "message_all : [\n    {}\n]\n", fmt::join(comm_table.message_all, "\n    "));
-    ss << shambase::format("send_message_global_ids : {}\n", comm_table.send_message_global_ids);
-    ss << shambase::format("recv_message_global_ids : {}\n", comm_table.recv_message_global_ids);
-    ss << shambase::format("send_total_sizes : {}\n", comm_table.send_total_sizes);
-    ss << shambase::format("recv_total_sizes : {}\n", comm_table.recv_total_sizes);
+    ss << sham::format("send_message_global_ids : {}\n", comm_table.send_message_global_ids);
+    ss << sham::format("recv_message_global_ids : {}\n", comm_table.recv_message_global_ids);
+    ss << sham::format("send_total_sizes : {}\n", comm_table.send_total_sizes);
+    ss << sham::format("recv_total_sizes : {}\n", comm_table.recv_total_sizes);
     logger::info_ln(
         "sparse exchange test", "rank :", shamcomm::world_rank(), "comm table :", "\n" + ss.str());
 }
@@ -293,12 +293,12 @@ void test_sparse_exchange(std::vector<TestElement> test_elements, size_t max_all
         std::stringstream ss;
         ss << "send bufs :\n";
         for (size_t i = 0; i < send_bufs.size(); i++) {
-            ss << "buf " << i << " : " << shambase::format("{}", send_bufs[i]->copy_to_stdvec())
+            ss << "buf " << i << " : " << sham::format("{}", send_bufs[i]->copy_to_stdvec())
                << "\n";
         }
         ss << "recv bufs :\n";
         for (size_t i = 0; i < recv_bufs.size(); i++) {
-            ss << "buf " << i << " : " << shambase::format("{}", recv_bufs[i]->copy_to_stdvec())
+            ss << "buf " << i << " : " << sham::format("{}", recv_bufs[i]->copy_to_stdvec())
                << "\n";
         }
         logger::info_ln("sparse exchange test", "rank :", shamcomm::world_rank(), ss.str());

--- a/src/tests/shamalgs/primitives/binary_range_searchTests.cpp
+++ b/src/tests/shamalgs/primitives/binary_range_searchTests.cpp
@@ -52,7 +52,7 @@ void test_binary_range_search(const std::vector<Tkey> &data, Tkey value_min, Tke
         }
     }
 
-    // shamcomm::logs::raw_ln(shambase::format(
+    // shamcomm::logs::raw_ln(sham::format(
     //    "--------\ndata = {}\nvalue_min = {}\nvalue_max = {}\ninf = {}\nsup = {}\nexpected_inf = "
     //    "{}\nexpected_sup = {}\nvalid_inf = {}\nvalid_sup = {}",
     //    data,

--- a/src/tests/shammath/crystalLatticeTests.cpp
+++ b/src/tests/shammath/crystalLatticeTests.cpp
@@ -115,7 +115,7 @@ NEW_TEST(Unittest, "shammath/crystalLattice/LatticeHCP/get_periodic_box", 1) {
         i32 zmax = shamalgs::primitives::mock_value(eng, 0, 7);
 
         REQUIRE_NAMED(
-            shambase::format(
+            sham::format(
                 "check periodicity : ({} {} {}) ({} {} {}) ({} {} {}) ",
                 xmin,
                 ymin,
@@ -151,7 +151,7 @@ NEW_TEST(Unittest, "shammath/crystalLattice/LatticeHCP/nearest_periodic_box_indi
                 {xmin, ymin, zmin}, {xmax, ymax, zmax});
 
         REQUIRE_NAMED(
-            shambase::format(
+            sham::format(
                 "check periodicity : ({} {} {}) ({} {} {}) ({} {} {})",
                 xmin,
                 ymin,

--- a/src/tests/shammath/matrixExpoTests.cpp
+++ b/src/tests/shammath/matrixExpoTests.cpp
@@ -44,7 +44,7 @@ NEW_TEST(Unittest, "shammath/matrix_exp", 1) {
 
     for (size_t i = 0; i < A.data.size(); i++) {
         logger::raw_ln(
-            shambase::format(
+            sham::format(
                 "A[{}] = {} != ex_res[{}] = {} delta: {}",
                 i,
                 A.data[i],

--- a/src/tests/shamrock/tree/key_pair_sortTests.cpp
+++ b/src/tests/shamrock/tree/key_pair_sortTests.cpp
@@ -47,7 +47,7 @@ void unit_test_key_pair() {
 
     for (u32 i = 0; i < size_test; i++) {
         REQUIRE_EQUAL_NAMED(
-            "index [" + shambase::format_printf("%d", i) + "]", unsorted[i], morton_list[i]);
+            "index [" + sham::format_printf("%d", i) + "]", unsorted[i], morton_list[i]);
     }
 }
 

--- a/src/tests/shamrock/tree/radix_treeTests.cpp
+++ b/src/tests/shamrock/tree/radix_treeTests.cpp
@@ -657,7 +657,7 @@ void test_inclusion(u32 Npart, u32 reduc_level) {
 
             if (!(l_ok && r_ok)) {
                 inclusion_valid = false;
-                comment += shambase::format(
+                comment += sham::format(
                     "fail : current : ({} {}) r:({} {}) l:({} {}) lid:{} rid:{}\n",
                     cur_pos_min_cell_a,
                     cur_pos_max_cell_a,
@@ -678,7 +678,7 @@ void test_inclusion(u32 Npart, u32 reduc_level) {
             "inclusion ok",
             false,
             comment
-                + shambase::format(
+                + sham::format(
                     "\n leaf count : {}, internal count : {}",
                     rtree.tree_reduced_morton_codes.tree_leaf_count,
                     rtree.tree_struct.internal_cell_count));

--- a/src/tests/shamrock_article_1Tests.cpp
+++ b/src/tests/shamrock_article_1Tests.cpp
@@ -348,7 +348,7 @@ void test_sph_iter_overhead(std::string dset_name) {
 
             shamlog_debug_ln(
                 "TestTreePerf",
-                shambase::format(
+                sham::format(
                     "dataset : {}, len={:e} seed={:10} len_p_obj={:e} rpart={:e}",
                     dset_name,
                     f32(len_pos),
@@ -674,7 +674,7 @@ f64 amr_walk_perf(
                 = tree_cell_bound.get_intersect(current_values.cell_bound);
 
             // logger::raw(
-            //     shambase::format("{} {} | {} {} -> {} {} -> {}\n",
+            //     sham::format("{} {} | {} {} -> {} {} -> {}\n",
             //     tree_cell_bound.lower,
             //     tree_cell_bound.upper,
             //     current_values.cell_bound.lower,
@@ -980,8 +980,7 @@ void test_fmm_nbody_iter_overhead(std::string dset_name, flt crit_theta) {
 
             shamlog_debug_ln(
                 "TestTreePerf",
-                shambase::format(
-                    "dataset : {}, len={:e} seed={:10}", dset_name, f32(len_pos), seed));
+                sham::format("dataset : {}, len={:e} seed={:10}", dset_name, f32(len_pos), seed));
 
             auto pos = shamalgs::random::mock_buffer_ptr<vec>(
                 seed, len_pos, coord_range.lower, coord_range.upper);

--- a/src/tests/shamsys/LogTests.cpp
+++ b/src/tests/shamsys/LogTests.cpp
@@ -14,5 +14,5 @@
 
 NEW_TEST(Unittest, "shamsys/Log", 1) {
 
-    std::cout << shambase::format("{} 1", f64_3{0, 1, 2}) << std::endl;
+    std::cout << sham::format("{} 1", f64_3{0, 1, 2}) << std::endl;
 }

--- a/src/tests/shamtree/DTTTesting_tests.cpp
+++ b/src/tests/shamtree/DTTTesting_tests.cpp
@@ -343,7 +343,7 @@ void dtt_test(
     __shamrock_stack_entry();
 
     logger::raw_ln(
-        shambase::format(
+        sham::format(
             "dtt test --- Npart : {}, reduction_level : {}, theta_crit : {}, ordered_result : {}, "
             "allow_leaf_lowering : {}",
             Npart,


### PR DESCRIPTION
sham/format/format.hpp re-exports format/vformat/format_printf into shambase only for backwards compatibility. Update all remaining callers across the codebase to call sham::format, sham::vformat, and sham::format_printf directly instead of the shambase alias, then re-run clang-format since the shorter sham:: prefix let several argument lists collapse back onto one line.

Assisted-by: Claude Code