### PR TITLE
[SPH] Convert ComputeCFL* ScalarEdges to IDataEdges

### DIFF
--- a/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLCourant.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLCourant.hpp
@@ -19,13 +19,13 @@
 #include "shambackends/kernel_call_distrib.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include "shamsys/NodeInstance.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, C_cour)                                         \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, C_cour)                                          \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, hpart)                                          \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, vsig)                                           \
     X_RW(shamrock::solvergraph::IFieldSpan<Tscal>, cfl_dt)
@@ -43,7 +43,7 @@ class ComputeCFLCourant : public shamrock::solvergraph::INode {
 
         auto dev_sched = shamsys::instance::get_compute_scheduler_ptr();
 
-        Tscal C_cour = edges.C_cour.value;
+        Tscal C_cour = edges.C_cour.data;
 
         sham::distributed_data_kernel_call(
             dev_sched,

--- a/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLDivBCleaning.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLDivBCleaning.hpp
@@ -19,13 +19,13 @@
 #include "shambackends/kernel_call_distrib.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include "shamsys/NodeInstance.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, C_cour)                                         \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, C_cour)                                          \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, hpart)                                          \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, vclean)                                         \
     X_RW(shamrock::solvergraph::IFieldSpan<Tscal>, cfl_dt)
@@ -43,7 +43,7 @@ class ComputeCFLDivBCleaning : public shamrock::solvergraph::INode {
 
         auto dev_sched = shamsys::instance::get_compute_scheduler_ptr();
 
-        Tscal C_cour = edges.C_cour.value;
+        Tscal C_cour = edges.C_cour.data;
 
         sham::distributed_data_kernel_call(
             dev_sched,

--- a/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLDust1Fluid.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLDust1Fluid.hpp
@@ -20,16 +20,15 @@
 #include "shammodels/sph/math/density.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
 #include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include "shamsys/NodeInstance.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, C_1_fluid)                                      \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, C_1_fluid)                                       \
     X_RO(shamrock::solvergraph::IDataEdge<Tscal>, pmass)                                           \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, hfactd)                                         \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, hfactd)                                          \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, hpart)                                          \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, soundspeed)                                     \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, s_j)                                            \
@@ -53,9 +52,9 @@ class ComputeCFLDust1Fluid : public shamrock::solvergraph::INode {
 
         auto dev_sched = shamsys::instance::get_compute_scheduler_ptr();
 
-        Tscal C_1_fluid = edges.C_1_fluid.value;
+        Tscal C_1_fluid = edges.C_1_fluid.data;
         Tscal pmass     = edges.pmass.data;
-        Tscal hfactd    = edges.hfactd.value;
+        Tscal hfactd    = edges.hfactd.data;
 
         sham::distributed_data_kernel_call(
             dev_sched,

--- a/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLDustDrift.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLDustDrift.hpp
@@ -20,17 +20,16 @@
 #include "shammodels/sph/math/density.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
 #include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include "shamsys/NodeInstance.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, C_drift)                                        \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, cfl_density_threshold)                          \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, C_drift)                                         \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, cfl_density_threshold)                           \
     X_RO(shamrock::solvergraph::IDataEdge<Tscal>, pmass)                                           \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, hfactd)                                         \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, hfactd)                                          \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, hpart)                                          \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, s_j)                                            \
     X_RO(shamrock::solvergraph::IFieldSpan<Tvec>, delta_v)                                         \
@@ -53,11 +52,11 @@ class ComputeCFLDustDrift : public shamrock::solvergraph::INode {
 
         auto dev_sched = shamsys::instance::get_compute_scheduler_ptr();
 
-        Tscal C_drift               = edges.C_drift.value;
-        Tscal cfl_density_threshold = edges.cfl_density_threshold.value;
+        Tscal C_drift               = edges.C_drift.data;
+        Tscal cfl_density_threshold = edges.cfl_density_threshold.data;
 
         Tscal pmass  = edges.pmass.data;
-        Tscal hfactd = edges.hfactd.value;
+        Tscal hfactd = edges.hfactd.data;
 
         sham::distributed_data_kernel_call(
             dev_sched,

--- a/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLForce.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/ComputeCFLForce.hpp
@@ -19,13 +19,13 @@
 #include "shambackends/kernel_call_distrib.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include "shamsys/NodeInstance.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, C_force)                                        \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, C_force)                                         \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, hpart)                                          \
     X_RO(shamrock::solvergraph::IFieldSpan<Tvec>, axyz)                                            \
     X_RW(shamrock::solvergraph::IFieldSpan<Tscal>, cfl_dt)
@@ -45,7 +45,7 @@ class ComputeCFLForce : public shamrock::solvergraph::INode {
 
         auto dev_sched = shamsys::instance::get_compute_scheduler_ptr();
 
-        Tscal C_force = edges.C_force.value;
+        Tscal C_force = edges.C_force.data;
 
         sham::distributed_data_kernel_call(
             dev_sched,

--- a/src/shammodels/sph/src/Solver.cpp
+++ b/src/shammodels/sph/src/Solver.cpp
@@ -2783,17 +2783,15 @@ shammodels::sph::TimestepLog shammodels::sph::Solver<Tvec, Kern>::evolve_once() 
             Tscal C_force = solver_config.cfl_config.cfl_force * get_cfl_multipler();
             Tscal eta_phi = solver_config.cfl_config.eta_sink;
 
-            std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> C_cour_edge
-                = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>("C_cour", "C_{cour}");
-            C_cour_edge->value = C_cour;
-            std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> C_force_edge
-                = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>(
-                    "C_force", "C_{force}");
-            C_force_edge->value = C_force;
-            std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> eta_phi_edge
-                = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>(
-                    "eta_phi", "\\eta_{\\phi}");
-            eta_phi_edge->value = eta_phi;
+            std::shared_ptr<shamrock::solvergraph::IDataEdge<Tscal>> C_cour_edge
+                = shamrock::solvergraph::IDataEdge<Tscal>::make_shared("C_cour", "C_{cour}");
+            C_cour_edge->data = C_cour;
+            std::shared_ptr<shamrock::solvergraph::IDataEdge<Tscal>> C_force_edge
+                = shamrock::solvergraph::IDataEdge<Tscal>::make_shared("C_force", "C_{force}");
+            C_force_edge->data = C_force;
+            std::shared_ptr<shamrock::solvergraph::IDataEdge<Tscal>> eta_phi_edge
+                = shamrock::solvergraph::IDataEdge<Tscal>::make_shared("eta_phi", "\\eta_{\\phi}");
+            eta_phi_edge->data = eta_phi;
 
             std::shared_ptr<ComputeCFLCourant<Tscal>> compute_cfl_courant
                 = std::make_shared<ComputeCFLCourant<Tscal>>();
@@ -2814,7 +2812,7 @@ shammodels::sph::TimestepLog shammodels::sph::Solver<Tvec, Kern>::evolve_once() 
 
             std::shared_ptr<ComputeCFLDust1Fluid<Tvec>> compute_cfl_dust1_fluid;
             std::shared_ptr<shamrock::solvergraph::FieldRefs<Tscal>> s_j_refs;
-            std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> hfactd_edge;
+            std::shared_ptr<shamrock::solvergraph::IDataEdge<Tscal>> hfactd_edge;
 
             if (solver_config.dust_config.has_s_j_field()) {
                 u32 ndust = solver_config.dust_config.get_dust_nvar();
@@ -2832,16 +2830,16 @@ shammodels::sph::TimestepLog shammodels::sph::Solver<Tvec, Kern>::evolve_once() 
 
                 s_j_refs = std::make_shared<shamrock::solvergraph::FieldRefs<Tscal>>("s_j", "s_j");
 
-                hfactd_edge = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>(
-                    "hfactd", "hfactd");
-                hfactd_edge->value = Kernel::hfactd;
+                hfactd_edge
+                    = shamrock::solvergraph::IDataEdge<Tscal>::make_shared("hfactd", "hfactd");
+                hfactd_edge->data = Kernel::hfactd;
 
                 map_field_refs(scheduler(), is_j, *s_j_refs);
 
-                std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> C_1fluid_edge
-                    = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>(
+                std::shared_ptr<shamrock::solvergraph::IDataEdge<Tscal>> C_1fluid_edge
+                    = shamrock::solvergraph::IDataEdge<Tscal>::make_shared(
                         "C_1fluid", "C_{1fluid}");
-                C_1fluid_edge->value
+                C_1fluid_edge->data
                     = solver_config.dust_config.get_monofluid_tva().C_1_fluid * get_cfl_multipler();
 
                 compute_cfl_dust1_fluid->set_edges(
@@ -2857,8 +2855,8 @@ shammodels::sph::TimestepLog shammodels::sph::Solver<Tvec, Kern>::evolve_once() 
             }
 
             std::shared_ptr<ComputeCFLDustDrift<Tvec>> compute_cfl_dust_drift;
-            std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> C_drift_edge;
-            std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> cfl_density_threshold_edge;
+            std::shared_ptr<shamrock::solvergraph::IDataEdge<Tscal>> C_drift_edge;
+            std::shared_ptr<shamrock::solvergraph::IDataEdge<Tscal>> cfl_density_threshold_edge;
             std::shared_ptr<shamrock::solvergraph::FieldRefs<Tvec>> delta_v_refs;
 
             if (solver_config.dust_config.has_s_j_field()) {
@@ -2873,14 +2871,13 @@ shammodels::sph::TimestepLog shammodels::sph::Solver<Tvec, Kern>::evolve_once() 
 
                 auto &cfg_monofluid_tva = solver_config.dust_config.get_monofluid_tva();
 
-                C_drift_edge = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>(
-                    "C_drift", "C_{drift}");
-                C_drift_edge->value = cfg_monofluid_tva.C_drift * get_cfl_multipler();
+                C_drift_edge
+                    = shamrock::solvergraph::IDataEdge<Tscal>::make_shared("C_drift", "C_{drift}");
+                C_drift_edge->data = cfg_monofluid_tva.C_drift * get_cfl_multipler();
 
-                cfl_density_threshold_edge
-                    = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>(
-                        "cfl_density_threshold", "cfl_density_threshold");
-                cfl_density_threshold_edge->value = cfg_monofluid_tva.cfl_density_threshold;
+                cfl_density_threshold_edge = shamrock::solvergraph::IDataEdge<Tscal>::make_shared(
+                    "cfl_density_threshold", "cfl_density_threshold");
+                cfl_density_threshold_edge->data = cfg_monofluid_tva.cfl_density_threshold;
 
                 auto pmass_edge
                     = storage.solver_graph


### PR DESCRIPTION
Finish converting the CFL node family (Courant, Force, DivBCleaning, Dust1Fluid, DustDrift) to IDataEdge, continuing the migration from the gpart_mass and dust stopping-time conversions.