### PR TITLE
[SPH] Convert alpha_u/beta_AV ScalarEdges to IDataEdges

### DIFF
--- a/src/shammodels/sph/include/shammodels/sph/modules/NodeUpdateDerivsVaryingAlphaAV.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/NodeUpdateDerivsVaryingAlphaAV.hpp
@@ -20,15 +20,14 @@
 #include "shammodels/sph/solvergraph/NeighCache.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
 #include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     /* scalars */                                                                                  \
     X_RO(shamrock::solvergraph::IDataEdge<Tscal>, gpart_mass)                                      \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, alpha_u)                                        \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, beta_AV)                                        \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, alpha_u)                                         \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, beta_AV)                                         \
                                                                                                    \
     /* counts */                                                                                   \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \

--- a/src/shammodels/sph/include/shammodels/sph/modules/NodeUpdateDerivsVaryingAlphaAVDustTVA.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/NodeUpdateDerivsVaryingAlphaAVDustTVA.hpp
@@ -20,15 +20,14 @@
 #include "shammodels/sph/solvergraph/NeighCache.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
 #include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     /* scalars */                                                                                  \
     X_RO(shamrock::solvergraph::IDataEdge<Tscal>, gpart_mass)                                      \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, alpha_u)                                        \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, beta_AV)                                        \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, alpha_u)                                         \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, beta_AV)                                         \
                                                                                                    \
     /* counts */                                                                                   \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \

--- a/src/shammodels/sph/src/modules/NodeUpdateDerivsVaryingAlphaAV.cpp
+++ b/src/shammodels/sph/src/modules/NodeUpdateDerivsVaryingAlphaAV.cpp
@@ -164,8 +164,8 @@ void shammodels::sph::modules::NodeUpdateDerivsVaryingAlphaAV<Tvec, SPHKernel>::
     edges.duint.ensure_sizes(part_counts);
 
     const Tscal pmass   = edges.gpart_mass.data;
-    const Tscal alpha_u = edges.alpha_u.value;
-    const Tscal beta_AV = edges.beta_AV.value;
+    const Tscal alpha_u = edges.alpha_u.data;
+    const Tscal beta_AV = edges.beta_AV.data;
 
     using ComputeKernel = KernelUpdateDerivsVaryingAlphaAV<Tvec, SPHKernel>;
 

--- a/src/shammodels/sph/src/modules/NodeUpdateDerivsVaryingAlphaAVDustTVA.cpp
+++ b/src/shammodels/sph/src/modules/NodeUpdateDerivsVaryingAlphaAVDustTVA.cpp
@@ -179,8 +179,8 @@ void shammodels::sph::modules::NodeUpdateDerivsVaryingAlphaAVDustTVA<Tvec, SPHKe
     edges.duint.ensure_sizes(part_counts);
 
     const Tscal pmass   = edges.gpart_mass.data;
-    const Tscal alpha_u = edges.alpha_u.value;
-    const Tscal beta_AV = edges.beta_AV.value;
+    const Tscal alpha_u = edges.alpha_u.data;
+    const Tscal beta_AV = edges.beta_AV.data;
 
     using ComputeKernel = KernelUpdateDerivsVaryingAlphaAVDustTVA<Tvec, SPHKernel>;
 

--- a/src/shammodels/sph/src/modules/UpdateDerivs.cpp
+++ b/src/shammodels/sph/src/modules/UpdateDerivs.cpp
@@ -44,7 +44,6 @@
 #include "shamrock/solvergraph/FieldRefs.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
 #include "shamsolvergraph/edge/IDataEdge.hpp"
 #include <memory>
 #include <vector>
@@ -377,15 +376,15 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_mm97
     auto gpart_mass
         = solver_graph.get_edge_ptr<shamrock::solvergraph::IDataEdge<Tscal>>("gpart_mass");
 
-    std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> alpha_u
-        = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>("alpha_u", "alpha_u");
+    std::shared_ptr<shamrock::solvergraph::IDataEdge<Tscal>> alpha_u
+        = std::make_shared<shamrock::solvergraph::IDataEdge<Tscal>>("alpha_u", "alpha_u");
     {
-        shambase::get_check_ref(alpha_u).value = cfg.alpha_u;
+        shambase::get_check_ref(alpha_u).data = cfg.alpha_u;
     }
-    std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> beta_AV
-        = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>("beta_AV", "beta_AV");
+    std::shared_ptr<shamrock::solvergraph::IDataEdge<Tscal>> beta_AV
+        = std::make_shared<shamrock::solvergraph::IDataEdge<Tscal>>("beta_AV", "beta_AV");
     {
-        shambase::get_check_ref(beta_AV).value = cfg.beta_AV;
+        shambase::get_check_ref(beta_AV).data = cfg.beta_AV;
     }
 
     std::shared_ptr<NodeUpdateDerivsVaryingAlphaAV<Tvec, SPHKernel>> node
@@ -502,15 +501,15 @@ void shammodels::sph::modules::UpdateDerivs<Tvec, SPHKernel>::update_derivs_cd10
     auto gpart_mass
         = solver_graph.get_edge_ptr<shamrock::solvergraph::IDataEdge<Tscal>>("gpart_mass");
 
-    std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> alpha_u
-        = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>("alpha_u", "alpha_u");
+    std::shared_ptr<shamrock::solvergraph::IDataEdge<Tscal>> alpha_u
+        = std::make_shared<shamrock::solvergraph::IDataEdge<Tscal>>("alpha_u", "alpha_u");
     {
-        shambase::get_check_ref(alpha_u).value = cfg.alpha_u;
+        shambase::get_check_ref(alpha_u).data = cfg.alpha_u;
     }
-    std::shared_ptr<shamrock::solvergraph::ScalarEdge<Tscal>> beta_AV
-        = std::make_shared<shamrock::solvergraph::ScalarEdge<Tscal>>("beta_AV", "beta_AV");
+    std::shared_ptr<shamrock::solvergraph::IDataEdge<Tscal>> beta_AV
+        = std::make_shared<shamrock::solvergraph::IDataEdge<Tscal>>("beta_AV", "beta_AV");
     {
-        shambase::get_check_ref(beta_AV).value = cfg.beta_AV;
+        shambase::get_check_ref(beta_AV).data = cfg.beta_AV;
     }
 
     if (solver_config.dust_config.should_use_dust_av()) {


### PR DESCRIPTION
Continues the ScalarEdge -> IDataEdge migration for the varying-AV derivative update nodes (with and without dust TVA), matching the gpart_mass, dust stopping-time, and CFL conversions already done.

Assisted-by: Claude Code