### PR TITLE
[SPH] Convert dust COALA/monofluid TVA source term ScalarEdges to IDataEdges

### DIFF
--- a/src/shammodels/sph/include/shammodels/sph/modules/NodeEvolveDustCOALASourceTerm.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/NodeEvolveDustCOALASourceTerm.hpp
@@ -19,17 +19,17 @@
 #include "shambackends/vec.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include <experimental/mdspan>
 #include <vector>
 
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     /* scalars */                                                                                  \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, rhodust_eps)                                    \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, dv_max)                                         \
-    X_RO(shamrock::solvergraph::ScalarEdge<std::vector<Tscal>>, massgrid)                          \
-    X_RO(shamrock::solvergraph::ScalarEdge<std::vector<Tscal>>, tensor_tabflux_coag)               \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, rhodust_eps)                                     \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, dv_max)                                          \
+    X_RO(shamrock::solvergraph::IDataEdge<std::vector<Tscal>>, massgrid)                           \
+    X_RO(shamrock::solvergraph::IDataEdge<std::vector<Tscal>>, tensor_tabflux_coag)                \
                                                                                                    \
     /* counts */                                                                                   \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \

--- a/src/shammodels/sph/include/shammodels/sph/modules/NodeMonofluidTVAAddSourceTerm.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/NodeMonofluidTVAAddSourceTerm.hpp
@@ -21,7 +21,7 @@
 #include "shambackends/vec.hpp"
 #include "shamrock/solvergraph/IFieldSpan.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include "shamsys/NodeInstance.hpp"
 #include <experimental/mdspan>
@@ -29,8 +29,8 @@
 #define NODE_EDGES(X_RO, X_RW)                                                                     \
     /* counts */                                                                                   \
     X_RO(shamrock::solvergraph::Indexes<u32>, part_counts)                                         \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, rhodust_eps)                                    \
-    X_RO(shamrock::solvergraph::ScalarEdge<Tscal>, dt_hydro)                                       \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, rhodust_eps)                                     \
+    X_RO(shamrock::solvergraph::IDataEdge<Tscal>, dt_hydro)                                        \
                                                                                                    \
     /* fields */                                                                                   \
     X_RO(shamrock::solvergraph::IFieldSpan<Tscal>, S)                                              \
@@ -63,7 +63,7 @@ namespace shammodels::sph::modules {
             edges.s_j.check_sizes(edges.part_counts.indexes);
             edges.ds_j_dt.check_sizes(edges.part_counts.indexes);
 
-            auto rhodust_eps = edges.rhodust_eps.value;
+            auto rhodust_eps = edges.rhodust_eps.data;
 
             shambase::DistributedData<u32> counts = edges.part_counts.indexes.template map<u32>(
                 [nbins = this->nbins](u64 /**/, u32 count) -> u32 {
@@ -71,7 +71,7 @@ namespace shammodels::sph::modules {
                 });
 
             auto epsilon  = sycl::sqrt(rhodust_eps);
-            auto dt_hydro = edges.dt_hydro.value;
+            auto dt_hydro = edges.dt_hydro.data;
 
             sham::distributed_data_kernel_call(
                 shamsys::instance::get_compute_scheduler_ptr(),

--- a/src/shammodels/sph/src/modules/NodeEvolveDustCOALASourceTerm.cpp
+++ b/src/shammodels/sph/src/modules/NodeEvolveDustCOALASourceTerm.cpp
@@ -139,10 +139,10 @@ namespace shammodels::sph::modules {
         edges.S_coag.ensure_sizes(counts);
         auto S_coag_spans = edges.S_coag.get_spans();
 
-        Tscal rho_eps                                 = edges.rhodust_eps.value;
-        Tscal dv_max                                  = edges.dv_max.value;
-        const std::vector<Tscal> &massgrid            = edges.massgrid.value;
-        const std::vector<Tscal> &tensor_tabflux_coag = edges.tensor_tabflux_coag.value;
+        Tscal rho_eps                                 = edges.rhodust_eps.data;
+        Tscal dv_max                                  = edges.dv_max.data;
+        const std::vector<Tscal> &massgrid            = edges.massgrid.data;
+        const std::vector<Tscal> &tensor_tabflux_coag = edges.tensor_tabflux_coag.data;
 
         auto dev_sched = shamsys::instance::get_compute_scheduler_ptr();
         auto &q        = shambase::get_check_ref(dev_sched).get_queue();


### PR DESCRIPTION
Migrates NodeEvolveDustCOALASourceTerm (rhodust_eps, dv_max, massgrid, tensor_tabflux_coag) and NodeMonofluidTVAAddSourceTerm (rhodust_eps, dt_hydro) from shamrock::solvergraph::ScalarEdge to shamsolvergraph::edge::IDataEdge, completing the ScalarEdge -> IDataEdge migration in the SPH solver. Neither node is currently instantiated anywhere in the codebase, so this is a self-contained header/impl change.

Assisted-by: Claude