### PR TITLE
[SPH] Convert LoopSmoothingLengthIter's is_converged ScalarEdge to IDataEdge

### DIFF
--- a/src/shammodels/gsph/src/Solver.cpp
+++ b/src/shammodels/gsph/src/Solver.cpp
@@ -60,6 +60,7 @@
 #include "shamrock/solvergraph/Field.hpp"
 #include "shamrock/solvergraph/FieldRefs.hpp"
 #include "shamrock/solvergraph/Indexes.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsys/NodeInstance.hpp"
 #include "shamsys/legacy/log.hpp"
 #include "shamtree/KarrasRadixTreeField.hpp"
@@ -754,8 +755,8 @@ void shammodels::gsph::Solver<Tvec, Kern>::gsph_prestep(Tscal time_val, Tscal dt
         }
         // iterate smoothing length
 
-        std::shared_ptr<shamrock::solvergraph::ScalarEdge<bool>> is_converged
-            = std::make_shared<shamrock::solvergraph::ScalarEdge<bool>>("", "");
+        std::shared_ptr<shamrock::solvergraph::IDataEdge<bool>> is_converged
+            = shamrock::solvergraph::IDataEdge<bool>::make_shared("", "");
 
         shammodels::sph::modules::LoopSmoothingLengthIter<Tvec> loop_smth_h_iter(
             smth_h_iter_ptr, solver_config.epsilon_h, solver_config.h_iter_per_subcycles, false);
@@ -763,7 +764,7 @@ void shammodels::gsph::Solver<Tvec, Kern>::gsph_prestep(Tscal time_val, Tscal dt
 
         loop_smth_h_iter.evaluate();
 
-        if (!is_converged->value) {
+        if (!is_converged->data) {
 
             Tscal largest_h = 0;
 

--- a/src/shammodels/sph/include/shammodels/sph/modules/LoopSmoothingLengthIter.hpp
+++ b/src/shammodels/sph/include/shammodels/sph/modules/LoopSmoothingLengthIter.hpp
@@ -18,7 +18,7 @@
 
 #include "shambackends/vec.hpp"
 #include "shamrock/solvergraph/IFieldRefs.hpp"
-#include "shamrock/solvergraph/ScalarEdge.hpp"
+#include "shamsolvergraph/edge/IDataEdge.hpp"
 #include "shamsolvergraph/node/INode.hpp"
 #include <memory>
 
@@ -47,12 +47,12 @@ namespace shammodels::sph::modules {
 
         struct Edges {
             const shamrock::solvergraph::IFieldRefs<Tscal> &eps_h;
-            shamrock::solvergraph::ScalarEdge<bool> &is_converged;
+            shamrock::solvergraph::IDataEdge<bool> &is_converged;
         };
 
         inline void set_edges(
             std::shared_ptr<shamrock::solvergraph::IFieldRefs<Tscal>> eps_h,
-            std::shared_ptr<shamrock::solvergraph::ScalarEdge<bool>> is_converged) {
+            std::shared_ptr<shamrock::solvergraph::IDataEdge<bool>> is_converged) {
             __internal_set_ro_edges({eps_h});
             __internal_set_rw_edges({is_converged});
         }
@@ -60,7 +60,7 @@ namespace shammodels::sph::modules {
         inline Edges get_edges() {
             return Edges{
                 get_ro_edge<shamrock::solvergraph::IFieldRefs<Tscal>>(0),
-                get_rw_edge<shamrock::solvergraph::ScalarEdge<bool>>(0),
+                get_rw_edge<shamrock::solvergraph::IDataEdge<bool>>(0),
             };
         }
 

--- a/src/shammodels/sph/src/Solver.cpp
+++ b/src/shammodels/sph/src/Solver.cpp
@@ -1178,8 +1178,8 @@ void shammodels::sph::Solver<Tvec, Kern>::sph_prestep(Tscal time_val, Tscal dt) 
         }
         // iterate smoothing length
 
-        std::shared_ptr<shamrock::solvergraph::ScalarEdge<bool>> is_converged
-            = std::make_shared<shamrock::solvergraph::ScalarEdge<bool>>("", "");
+        std::shared_ptr<shamrock::solvergraph::IDataEdge<bool>> is_converged
+            = shamrock::solvergraph::IDataEdge<bool>::make_shared("", "");
 
         shammodels::sph::modules::LoopSmoothingLengthIter<Tvec> loop_smth_h_iter(
             smth_h_iter_ptr, solver_config.epsilon_h, solver_config.h_iter_per_subcycles, false);
@@ -1187,7 +1187,7 @@ void shammodels::sph::Solver<Tvec, Kern>::sph_prestep(Tscal time_val, Tscal dt) 
 
         loop_smth_h_iter.evaluate();
 
-        if (!is_converged->value) {
+        if (!is_converged->data) {
 
             Tscal largest_h = 0;
 

--- a/src/shammodels/sph/src/modules/LoopSmoothingLengthIter.cpp
+++ b/src/shammodels/sph/src/modules/LoopSmoothingLengthIter.cpp
@@ -60,10 +60,10 @@ namespace shammodels::sph::modules {
 
         bool local_is_converged = local_is_h_below_tol && (!local_should_rerun_gz);
 
-        is_converged.value
+        is_converged.data
             = shamalgs::collective::are_all_rank_true(local_is_converged, MPI_COMM_WORLD);
 
-        if (is_converged.value && print_info) {
+        if (is_converged.data && print_info) {
 
             Tscal min_eps_h = shamalgs::collective::allreduce_min(local_min_eps_h);
             Tscal max_eps_h = shamalgs::collective::allreduce_max(local_max_eps_h);


### PR DESCRIPTION
Continue the ScalarEdge to IDataEdge migration. LoopSmoothingLengthIter is shared by the SPH and GSPH solvers, so both callsites are converted together.

Assisted-by: Claude