### PR TITLE
[Solvergraph] Add INode::get_subgraph() structured introspection API

### DIFF
--- a/src/shamsolvergraph/include/shamsolvergraph/node/INode.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/node/INode.hpp
@@ -21,6 +21,7 @@
 #include "shambase/stacktrace.hpp"
 #include "shamsolvergraph/edge/IEdge.hpp"
 #include "shamsolvergraph/edge/INullOptEdge.hpp"
+#include "shamsolvergraph/node/NodeSubgraph.hpp"
 #include <memory>
 #include <vector>
 
@@ -56,6 +57,11 @@ namespace shamrock::solvergraph {
         inline std::vector<std::shared_ptr<IEdge>> &get_ro_edges() { return ro_edges; }
         /// Get the read write edges
         inline std::vector<std::shared_ptr<IEdge>> &get_rw_edges() { return rw_edges; }
+
+        /// Get the read only edges (const)
+        inline const std::vector<std::shared_ptr<IEdge>> &get_ro_edges() const { return ro_edges; }
+        /// Get the read write edges (const)
+        inline const std::vector<std::shared_ptr<IEdge>> &get_rw_edges() const { return rw_edges; }
 
         /// Set the read only edges
         inline void __internal_set_ro_edges(std::vector<std::shared_ptr<IEdge>> new_ro_edges);
@@ -145,16 +151,17 @@ namespace shamrock::solvergraph {
         /// Evaluate the node
         inline void evaluate() { _impl_evaluate_internal(); }
 
+        /// Get a structured description of the node, and (if it is a meta node) everything
+        /// nested under it
+        inline NodeSubgraph get_subgraph() const { return _impl_get_subgraph(); }
+
         /// Get the dot graph of the node (Currently only an alias to get_dot_graph_partial)
         inline std::string get_dot_graph() { return get_dot_graph_partial(); };
 
         /// Get the dot graph of the subgraph corresponding to the node
-        inline std::string get_dot_graph_partial() { return _impl_get_dot_graph_partial(); };
-
-        /// Get the id of the node start in the dot graph
-        inline std::string get_dot_graph_node_start() { return _impl_get_dot_graph_node_start(); };
-        /// Get the id of the node end in the dot graph
-        inline std::string get_dot_graph_node_end() { return _impl_get_dot_graph_node_end(); };
+        inline std::string get_dot_graph_partial() {
+            return dot_graph_from_subgraph(get_subgraph());
+        };
 
         /// Get the TeX of the node
         inline std::string get_tex() { return _impl_get_tex(); };
@@ -196,12 +203,13 @@ namespace shamrock::solvergraph {
         /// get the label of the node
         virtual std::string _impl_get_label() const = 0;
 
-        /// get the dot graph of the node partial
-        virtual std::string _impl_get_dot_graph_partial() const;
-        /// get the dot graph of the node start
-        virtual std::string _impl_get_dot_graph_node_start() const;
-        /// get the dot graph of the node end
-        virtual std::string _impl_get_dot_graph_node_end() const;
+        /// get the free-form key/value metadata of the node (default: none)
+        inline virtual std::vector<std::pair<std::string, std::string>> _impl_get_metadata() const {
+            return {};
+        }
+
+        /// get the structured subgraph description of the node
+        virtual NodeSubgraph _impl_get_subgraph() const;
 
         /// get the tex of the node
         virtual std::string _impl_get_tex() const = 0;
@@ -241,36 +249,20 @@ namespace shamrock::solvergraph {
         }
     }
 
-    inline std::string INode::_impl_get_dot_graph_partial() const {
-        std::string node_str
-            = sham::format("n_{} [label=\"{}\"];\n", this->get_uuid(), _impl_get_label());
-
-        std::string edge_str = "";
-        for (auto &in : ro_edges) {
-            edge_str += sham::format(
-                "e_{} -> n_{} [style=\"dashed\", color=green];\n",
-                in->get_uuid(),
-                this->get_uuid());
-            edge_str += sham::format(
-                "e_{} [label=\"{}\",shape=rect, style=filled];\n", in->get_uuid(), in->get_label());
-        }
-        for (auto &out : rw_edges) {
-            edge_str += sham::format(
-                "n_{} -> e_{} [style=\"dashed\", color=red];\n", this->get_uuid(), out->get_uuid());
-            edge_str += sham::format(
-                "e_{} [label=\"{}\",shape=rect, style=filled];\n",
-                out->get_uuid(),
-                out->get_label());
-        }
-
-        return sham::format("{}{}", node_str, edge_str);
-    };
-
-    inline std::string INode::_impl_get_dot_graph_node_start() const {
-        return sham::format("n_{}", this->get_uuid());
-    }
-    inline std::string INode::_impl_get_dot_graph_node_end() const {
-        return sham::format("n_{}", this->get_uuid());
+    inline NodeSubgraph INode::_impl_get_subgraph() const {
+        NodeSubgraph sg;
+        sg.uuid             = get_uuid();
+        sg.label            = _impl_get_label();
+        sg.ro_edges         = ro_edges;
+        sg.rw_edges         = rw_edges;
+        sg.metadata         = _impl_get_metadata();
+        sg.is_meta          = false;
+        sg.meta_info        = {};
+        sg.dot_shape        = "";
+        sg.dot_start_id     = sham::format("n_{}", get_uuid());
+        sg.dot_end_id       = sg.dot_start_id;
+        sg.draws_own_anchor = true;
+        return sg;
     }
 
 } // namespace shamrock::solvergraph

--- a/src/shamsolvergraph/include/shamsolvergraph/node/NodeSubgraph.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/node/NodeSubgraph.hpp
@@ -1,0 +1,86 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2026 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#pragma once
+
+/**
+ * @file NodeSubgraph.hpp
+ * @author Timothée David--Cléris (tim.shamrock@proton.me)
+ * @brief Structured (non-string) description of an INode's structure, for introspection
+ *
+ */
+
+#include "shambase/aliases_int.hpp"
+#include "shamsolvergraph/edge/IEdge.hpp"
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace shamrock::solvergraph {
+
+    class NodeSubgraph;
+
+    /// A structural connection between two dot-graph anchor ids (not a data edge) - e.g.
+    /// OperationSequence's evaluation order, or OperationIf's branch links.
+    struct SubgraphConnection {
+        /// dot node id this connection starts from
+        std::string from_id;
+        /// dot node id this connection points to
+        std::string to_id;
+        /// optional label, e.g. "true" / "false" for OperationIf branches
+        std::string label;
+        /// rendered as a dashed/placeholder edge (e.g. an absent optional branch)
+        bool dashed = false;
+    };
+
+    /// Extra structure carried only by "meta" (composite/group) nodes.
+    struct SubgraphMetaInfo {
+        /// recursively-built subgraphs of the nested nodes
+        std::vector<NodeSubgraph> children;
+        /// structural connections between the children (and/or the meta node's own anchor)
+        std::vector<SubgraphConnection> connections;
+    };
+
+    /// Structured description of one node and, if it is a meta node, everything nested under it.
+    class NodeSubgraph {
+        public:
+        /// uuid of the described node
+        u64 uuid;
+        /// label of the described node
+        std::string label;
+        /// read only edges of the described node
+        std::vector<std::shared_ptr<IEdge>> ro_edges;
+        /// read write edges of the described node
+        std::vector<std::shared_ptr<IEdge>> rw_edges;
+        /// free-form key/value metadata, formatted by the node itself
+        std::vector<std::pair<std::string, std::string>> metadata;
+        /// true if this node is a group of nested nodes (composite/meta node)
+        bool is_meta = false;
+        /// non-null iff is_meta is true
+        std::shared_ptr<SubgraphMetaInfo> meta_info;
+
+        // Rendering-hint fields, needed so `get_dot_graph()` can be losslessly rebuilt from this
+        // struct (see dot_graph_from_subgraph below) - not part of the introspection contract.
+
+        /// graphviz "shape" attribute for the node's own drawn box, "" = default
+        std::string dot_shape;
+        /// dot node id used to connect INTO this (sub)graph from a predecessor
+        std::string dot_start_id;
+        /// dot node id used to connect OUT of this (sub)graph to a successor
+        std::string dot_end_id;
+        /// true if dot_start_id/dot_end_id refer to a node this subgraph draws itself (false when
+        /// they are only an alias into a child's ids, e.g. OperationSequence)
+        bool draws_own_anchor = true;
+    };
+
+    /// Render a NodeSubgraph tree to a Graphviz DOT fragment.
+    std::string dot_graph_from_subgraph(const NodeSubgraph &sg);
+
+} // namespace shamrock::solvergraph

--- a/src/shamsolvergraph/include/shamsolvergraph/node/OperationIf.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/node/OperationIf.hpp
@@ -55,14 +55,7 @@ namespace shamrock::solvergraph {
 
         inline std::string _impl_get_label() const { return name; }
 
-        std::string _impl_get_dot_graph_partial() const;
-
-        inline virtual std::string _impl_get_dot_graph_node_start() const {
-            return sham::format("n_{}", get_uuid());
-        }
-        inline virtual std::string _impl_get_dot_graph_node_end() const {
-            return sham::format("n_{}_end", get_uuid());
-        }
+        NodeSubgraph _impl_get_subgraph() const;
 
         std::string _impl_get_tex() const;
     };

--- a/src/shamsolvergraph/include/shamsolvergraph/node/OperationSequence.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/node/OperationSequence.hpp
@@ -36,14 +36,7 @@ namespace shamrock::solvergraph {
 
         inline std::string _impl_get_label() const { return name; }
 
-        std::string _impl_get_dot_graph_partial() const;
-
-        inline virtual std::string _impl_get_dot_graph_node_start() const {
-            return nodes[0]->get_dot_graph_node_start();
-        }
-        inline virtual std::string _impl_get_dot_graph_node_end() const {
-            return nodes[nodes.size() - 1]->get_dot_graph_node_end();
-        }
+        NodeSubgraph _impl_get_subgraph() const;
 
         std::string _impl_get_tex() const;
     };

--- a/src/shamsolvergraph/src/NodeSubgraph.cpp
+++ b/src/shamsolvergraph/src/NodeSubgraph.cpp
@@ -1,0 +1,102 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2026 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+/**
+ * @file NodeSubgraph.cpp
+ * @author Timothée David--Cléris (tim.shamrock@proton.me)
+ * @brief
+ *
+ */
+
+#include "shamsolvergraph/node/NodeSubgraph.hpp"
+#include "sham/format/format.hpp"
+#include <sstream>
+
+namespace {
+
+    using namespace shamrock::solvergraph;
+
+    void render_ro_rw_edges(
+        std::stringstream &ss,
+        const std::string &attach_id,
+        const std::vector<std::shared_ptr<IEdge>> &ro_edges,
+        const std::vector<std::shared_ptr<IEdge>> &rw_edges) {
+        for (auto &in : ro_edges) {
+            ss << sham::format(
+                "e_{} -> {} [style=\"dashed\", color=green];\n", in->get_uuid(), attach_id);
+            ss << sham::format(
+                "e_{} [label=\"{}\",shape=rect, style=filled];\n", in->get_uuid(), in->get_label());
+        }
+        for (auto &out : rw_edges) {
+            ss << sham::format(
+                "{} -> e_{} [style=\"dashed\", color=red];\n", attach_id, out->get_uuid());
+            ss << sham::format(
+                "e_{} [label=\"{}\",shape=rect, style=filled];\n",
+                out->get_uuid(),
+                out->get_label());
+        }
+    }
+
+    void render_node(std::stringstream &ss, const NodeSubgraph &sg) {
+        if (!sg.is_meta) {
+            std::string shape_attr
+                = sg.dot_shape.empty() ? "" : sham::format(", shape={}", sg.dot_shape);
+            ss << sham::format("{} [label=\"{}\"{}];\n", sg.dot_start_id, sg.label, shape_attr);
+            render_ro_rw_edges(ss, sg.dot_start_id, sg.ro_edges, sg.rw_edges);
+            return;
+        }
+
+        const SubgraphMetaInfo &mi = *sg.meta_info;
+
+        ss << "subgraph cluster_" << sg.uuid << " {\n";
+
+        if (sg.draws_own_anchor) {
+            std::string shape_attr
+                = sg.dot_shape.empty() ? "" : sham::format(", shape={}", sg.dot_shape);
+            ss << sham::format("{} [label=\"{}\"{}];\n", sg.dot_start_id, sg.label, shape_attr);
+            if (sg.dot_end_id != sg.dot_start_id) {
+                ss << sham::format("{} [label=\"\", shape=point, width=0.15];\n", sg.dot_end_id);
+            }
+            render_ro_rw_edges(ss, sg.dot_start_id, sg.ro_edges, sg.rw_edges);
+        }
+
+        for (auto &child : mi.children) {
+            render_node(ss, child);
+        }
+
+        for (auto &conn : mi.connections) {
+            std::string label_attr
+                = conn.label.empty() ? "" : sham::format("label=\"{}\"", conn.label);
+            std::string style_attr = conn.dashed ? "style=dashed" : "";
+            std::string attrs;
+            if (!label_attr.empty() && !style_attr.empty()) {
+                attrs = sham::format(" [{}, {}]", label_attr, style_attr);
+            } else if (!label_attr.empty()) {
+                attrs = sham::format(" [{}]", label_attr);
+            } else if (!style_attr.empty()) {
+                attrs = sham::format(" [{}]", style_attr);
+            }
+            ss << sham::format("{} -> {}{};\n", conn.from_id, conn.to_id, attrs);
+        }
+
+        ss << sham::format("label = \"{}\";\n", sg.label);
+        ss << "}\n";
+    }
+
+} // namespace
+
+namespace shamrock::solvergraph {
+
+    std::string dot_graph_from_subgraph(const NodeSubgraph &sg) {
+        std::stringstream ss;
+        render_node(ss, sg);
+        return ss.str();
+    }
+
+} // namespace shamrock::solvergraph

--- a/src/shamsolvergraph/src/OperationIf.cpp
+++ b/src/shamsolvergraph/src/OperationIf.cpp
@@ -29,50 +29,58 @@ namespace shamrock::solvergraph {
         }
     }
 
-    std::string OperationIf::_impl_get_dot_graph_partial() const {
+    NodeSubgraph OperationIf::_impl_get_subgraph() const {
+        NodeSubgraph sg;
+        sg.uuid             = get_uuid();
+        sg.label            = _impl_get_label();
+        sg.metadata         = _impl_get_metadata();
+        sg.is_meta          = true;
+        sg.dot_shape        = "diamond";
+        sg.dot_start_id     = sham::format("n_{}", get_uuid());
+        sg.dot_end_id       = sham::format("n_{}_end", get_uuid());
+        sg.draws_own_anchor = true;
+        sg.ro_edges         = get_ro_edges();
+        sg.rw_edges         = get_rw_edges();
 
-        std::stringstream ss;
-
-        ss << "subgraph cluster_" + std::to_string(get_uuid()) + " {\n";
-        ss << sham::format("n_{} [label=\"{}\", shape=diamond];\n", get_uuid(), _impl_get_label());
+        auto mi = std::make_shared<SubgraphMetaInfo>();
 
         if (then_node) {
-            ss << then_node->get_dot_graph_partial();
-            ss << sham::format(
-                "n_{} -> {} [label=\"true\"];\n",
-                get_uuid(),
-                then_node->get_dot_graph_node_start());
-            ss << then_node->get_dot_graph_node_end() << " -> "
-               << sham::format("n_{}_end", get_uuid()) << ";\n";
+            NodeSubgraph then_sg = then_node->get_subgraph();
+            mi->connections.push_back(
+                SubgraphConnection{
+                    .from_id = sg.dot_start_id, .to_id = then_sg.dot_start_id, .label = "true"});
+            mi->connections.push_back(
+                SubgraphConnection{.from_id = then_sg.dot_end_id, .to_id = sg.dot_end_id});
+            mi->children.push_back(std::move(then_sg));
         } else {
-            ss << sham::format(
-                "n_{} -> n_{}_end [label=\"true\", style=dashed];\n", get_uuid(), get_uuid());
+            mi->connections.push_back(
+                SubgraphConnection{
+                    .from_id = sg.dot_start_id,
+                    .to_id   = sg.dot_end_id,
+                    .label   = "true",
+                    .dashed  = true});
         }
 
         if (else_node) {
-            ss << else_node->get_dot_graph_partial();
-            ss << sham::format(
-                "n_{} -> {} [label=\"false\"];\n",
-                get_uuid(),
-                else_node->get_dot_graph_node_start());
-            ss << else_node->get_dot_graph_node_end() << " -> "
-               << sham::format("n_{}_end", get_uuid()) << ";\n";
+            NodeSubgraph else_sg = else_node->get_subgraph();
+            mi->connections.push_back(
+                SubgraphConnection{
+                    .from_id = sg.dot_start_id, .to_id = else_sg.dot_start_id, .label = "false"});
+            mi->connections.push_back(
+                SubgraphConnection{.from_id = else_sg.dot_end_id, .to_id = sg.dot_end_id});
+            mi->children.push_back(std::move(else_sg));
         } else {
-            ss << sham::format(
-                "n_{} -> n_{}_end [label=\"false\", style=dashed];\n", get_uuid(), get_uuid());
+            mi->connections.push_back(
+                SubgraphConnection{
+                    .from_id = sg.dot_start_id,
+                    .to_id   = sg.dot_end_id,
+                    .label   = "false",
+                    .dashed  = true});
         }
 
-        ss << sham::format("n_{}_end [label=\"\", shape=point, width=0.15];\n", get_uuid());
-        ss << sham::format("label = \"{}\";\n", _impl_get_label());
-        ss << "}\n";
+        sg.meta_info = mi;
 
-        auto &cond = get_ro_edge_base(0);
-        ss << sham::format(
-            "e_{} -> n_{} [style=\"dashed\", color=green];\n", cond.get_uuid(), get_uuid());
-        ss << sham::format(
-            "e_{} [label=\"{}\",shape=rect, style=filled];\n", cond.get_uuid(), cond.get_label());
-
-        return ss.str();
+        return sg;
     }
 
     std::string OperationIf::_impl_get_tex() const {

--- a/src/shamsolvergraph/src/OperationSequence.cpp
+++ b/src/shamsolvergraph/src/OperationSequence.cpp
@@ -25,24 +25,33 @@ namespace shamrock::solvergraph {
         }
     }
 
-    std::string OperationSequence::_impl_get_dot_graph_partial() const {
+    NodeSubgraph OperationSequence::_impl_get_subgraph() const {
+        NodeSubgraph sg;
+        sg.uuid             = get_uuid();
+        sg.label            = _impl_get_label();
+        sg.metadata         = _impl_get_metadata();
+        sg.is_meta          = true;
+        sg.draws_own_anchor = false;
 
-        std::stringstream ss;
-
-        ss << "subgraph cluster_" + std::to_string(get_uuid()) + " {\n";
+        auto mi = std::make_shared<SubgraphMetaInfo>();
         for (auto &node : nodes) {
-            ss << node->get_dot_graph_partial();
+            mi->children.push_back(node->get_subgraph());
         }
 
-        for (int i = 0; i < nodes.size() - 1; i++) {
-            ss << nodes[i]->get_dot_graph_node_end() << " -> "
-               << nodes[i + 1]->get_dot_graph_node_start() << " [weight=3];\n";
+        for (size_t i = 0; i + 1 < mi->children.size(); i++) {
+            mi->connections.push_back(
+                SubgraphConnection{
+                    .from_id = mi->children[i].dot_end_id,
+                    .to_id   = mi->children[i + 1].dot_start_id,
+                    .label   = "",
+                    .dashed  = false});
         }
 
-        ss << sham::format("label = \"{}\";\n", _impl_get_label());
-        ss << "}\n";
+        sg.dot_start_id = mi->children.front().dot_start_id;
+        sg.dot_end_id   = mi->children.back().dot_end_id;
+        sg.meta_info    = mi;
 
-        return ss.str();
+        return sg;
     }
 
     std::string OperationSequence::_impl_get_tex() const {

--- a/src/tests/shamsolvergraph/node/NodeSubgraph_tests.cpp
+++ b/src/tests/shamsolvergraph/node/NodeSubgraph_tests.cpp
@@ -1,0 +1,142 @@
+// -------------------------------------------------------//
+//
+// SHAMROCK code for hydrodynamics
+// Copyright (c) 2021-2026 Timothée David--Cléris <tim.shamrock@proton.me>
+// SPDX-License-Identifier: CeCILL Free Software License Agreement v2.1
+// Shamrock is licensed under the CeCILL 2.1 License, see LICENSE for more information
+//
+// -------------------------------------------------------//
+
+#include "shamsolvergraph/edge/IDataEdge.hpp"
+#include "shamsolvergraph/node/INode.hpp"
+#include "shamsolvergraph/node/OperationIf.hpp"
+#include "shamsolvergraph/node/OperationSequence.hpp"
+#include "shamtest/shamtest.hpp"
+#include <memory>
+#include <string>
+
+namespace {
+
+#define DUMMY_NODE_EDGES(X_RO, X_RW)                                                               \
+    X_RO(shamrock::solvergraph::IDataEdge<u32>, in)                                                \
+    X_RW(shamrock::solvergraph::IDataEdge<u32>, out)
+
+    class DummyNode : public shamrock::solvergraph::INode {
+        std::string label;
+
+        public:
+        explicit DummyNode(std::string label) : label(std::move(label)) {}
+
+        EXPAND_NODE_EDGES(DUMMY_NODE_EDGES)
+
+        void _impl_evaluate_internal() override {}
+
+        std::string _impl_get_label() const override { return label; }
+        std::string _impl_get_tex() const override { return ""; }
+    };
+
+#undef DUMMY_NODE_EDGES
+
+} // namespace
+
+NEW_TEST(Unittest, "shamsolvergraph/node/NodeSubgraph:leaf", 1) {
+    using namespace shamrock::solvergraph;
+
+    auto in_edge  = IDataEdge<u32>::make_shared("in", "i");
+    auto out_edge = IDataEdge<u32>::make_shared("out", "o");
+
+    auto node = std::make_shared<DummyNode>("Dummy");
+    node->set_edges(in_edge, out_edge);
+
+    NodeSubgraph sg = node->get_subgraph();
+
+    REQUIRE_EQUAL(sg.is_meta, false);
+    REQUIRE_EQUAL(bool(sg.meta_info), false);
+    REQUIRE_EQUAL(sg.label, std::string("Dummy"));
+    REQUIRE_EQUAL(sg.ro_edges.size(), size_t(1));
+    REQUIRE_EQUAL(sg.rw_edges.size(), size_t(1));
+    REQUIRE_EQUAL(sg.ro_edges[0]->get_uuid(), in_edge->get_uuid());
+    REQUIRE_EQUAL(sg.rw_edges[0]->get_uuid(), out_edge->get_uuid());
+}
+
+NEW_TEST(Unittest, "shamsolvergraph/node/NodeSubgraph:operation_sequence", 1) {
+    using namespace shamrock::solvergraph;
+
+    auto n1 = std::make_shared<DummyNode>("n1");
+    auto n2 = std::make_shared<DummyNode>("n2");
+    auto n3 = std::make_shared<DummyNode>("n3");
+
+    std::vector<std::shared_ptr<INode>> nodes{n1, n2, n3};
+    OperationSequence seq("seq", std::move(nodes));
+
+    NodeSubgraph sg = seq.get_subgraph();
+
+    REQUIRE_EQUAL(sg.is_meta, true);
+    REQUIRE_EQUAL(bool(sg.meta_info), true);
+    REQUIRE_EQUAL(sg.meta_info->children.size(), size_t(3));
+    REQUIRE_EQUAL(sg.meta_info->connections.size(), size_t(2));
+
+    REQUIRE_EQUAL(sg.meta_info->connections[0].from_id, sg.meta_info->children[0].dot_end_id);
+    REQUIRE_EQUAL(sg.meta_info->connections[0].to_id, sg.meta_info->children[1].dot_start_id);
+    REQUIRE_EQUAL(sg.meta_info->connections[1].from_id, sg.meta_info->children[1].dot_end_id);
+    REQUIRE_EQUAL(sg.meta_info->connections[1].to_id, sg.meta_info->children[2].dot_start_id);
+}
+
+NEW_TEST(Unittest, "shamsolvergraph/node/NodeSubgraph:operation_if", 1) {
+    using namespace shamrock::solvergraph;
+
+    auto make_condition = []() {
+        return IDataEdge<bool>::make_shared("cond", "cond");
+    };
+
+    {
+        // both branches present
+        auto then_node = std::make_shared<DummyNode>("then");
+        auto else_node = std::make_shared<DummyNode>("else");
+
+        OperationIf node("if", then_node, else_node);
+        node.set_edges(make_condition());
+
+        NodeSubgraph sg = node.get_subgraph();
+
+        REQUIRE_EQUAL(sg.is_meta, true);
+        REQUIRE_EQUAL(bool(sg.meta_info), true);
+        REQUIRE_EQUAL(sg.ro_edges.size(), size_t(1));
+        REQUIRE_EQUAL(sg.meta_info->children.size(), size_t(2));
+        REQUIRE_EQUAL(sg.meta_info->connections.size(), size_t(4));
+
+        bool found_true  = false;
+        bool found_false = false;
+        for (auto &conn : sg.meta_info->connections) {
+            if (conn.label == "true") {
+                found_true = true;
+                REQUIRE_EQUAL(conn.dashed, false);
+            }
+            if (conn.label == "false") {
+                found_false = true;
+                REQUIRE_EQUAL(conn.dashed, false);
+            }
+        }
+        REQUIRE_EQUAL(found_true, true);
+        REQUIRE_EQUAL(found_false, true);
+    }
+
+    {
+        // both branches absent
+        OperationIf node("if_empty");
+        node.set_edges(make_condition());
+
+        NodeSubgraph sg = node.get_subgraph();
+
+        REQUIRE_EQUAL(sg.is_meta, true);
+        REQUIRE_EQUAL(bool(sg.meta_info), true);
+        REQUIRE_EQUAL(sg.meta_info->children.size(), size_t(0));
+        REQUIRE_EQUAL(sg.meta_info->connections.size(), size_t(2));
+
+        for (auto &conn : sg.meta_info->connections) {
+            REQUIRE_EQUAL(conn.dashed, true);
+            REQUIRE_EQUAL(conn.from_id, sg.dot_start_id);
+            REQUIRE_EQUAL(conn.to_id, sg.dot_end_id);
+        }
+    }
+}


### PR DESCRIPTION
Expose each node's ro/rw edges, free-form metadata, and (for meta/composite nodes like OperationSequence and OperationIf) their nested children and structural connections as a plain NodeSubgraph struct, instead of only a DOT string. get_dot_graph() is rewritten to render from get_subgraph(), making it the single source of truth for both DOT export and future non-Graphviz consumers (e.g. graph viewer tooling).

Assisted-by: Claude Code