### PR TITLE
[Base] WithUUID: delete copy, invalidate uuid on move

### DIFF
--- a/src/shambase/include/shambase/WithUUID.hpp
+++ b/src/shambase/include/shambase/WithUUID.hpp
@@ -16,6 +16,7 @@
  */
 
 #include <atomic>
+#include <limits>
 
 namespace shambase {
 
@@ -32,6 +33,9 @@ namespace shambase {
      *    ...
      *    std::cout << "Instance1 UUID: " << A1{}.get_uuid() << std::endl;
      * @endcode
+     *
+     * Copy is deleted (would duplicate the uuid). Move transfers the uuid and invalidates the
+     * source, so check `is_alive()` rather than assuming a moved-from instance still has one.
      */
     template<typename T, class Tint, bool thread_safe = true>
     class WithUUID {
@@ -43,12 +47,22 @@ namespace shambase {
         Tint uuid;
 
         public:
+        /// Sentinel marking an invalidated/moved-from instance (0 is a valid uuid, so max is used
+        /// instead).
+        static constexpr Tint invalid_uuid = std::numeric_limits<Tint>::max();
+
         /**
          * @brief Get the uuid of the class
          *
          * @return The uuid of the class
          */
         inline Tint get_uuid() const { return uuid; }
+
+        /// Whether this instance still holds a valid uuid (false once moved from).
+        inline bool is_alive() const { return uuid != invalid_uuid; }
+
+        /// Marks this instance's uuid as invalid, e.g. to give up identity outside of a move.
+        inline void invalidate() { uuid = invalid_uuid; }
 
         /**
          * @brief Constructor of the class
@@ -67,6 +81,21 @@ namespace shambase {
                 static Tint _uuid = 0;
                 uuid              = _uuid++;
             }
+        }
+
+        WithUUID(const WithUUID &)            = delete; ///< would duplicate the uuid
+        WithUUID &operator=(const WithUUID &) = delete; ///< would duplicate the uuid
+
+        /// Move constructor: transfers the uuid to `this` and invalidates `other`.
+        inline WithUUID(WithUUID &&other) noexcept : uuid(other.uuid) { other.invalidate(); }
+
+        /// Move assignment: transfers the uuid to `this` and invalidates `other`.
+        inline WithUUID &operator=(WithUUID &&other) noexcept {
+            if (this != &other) {
+                uuid = other.uuid;
+                other.invalidate();
+            }
+            return *this;
         }
     };
 

--- a/src/shamrock/include/shamrock/solvergraph/IPatchDataLayerRefs.hpp
+++ b/src/shamrock/include/shamrock/solvergraph/IPatchDataLayerRefs.hpp
@@ -31,7 +31,8 @@ namespace shamrock::solvergraph {
         public:
         using IEdgeNamed::IEdgeNamed;
 
-        virtual ~IPatchDataLayerRefs() = default;
+        // No destructor here on purpose: IEdge's is already virtual, and declaring one would
+        // suppress implicit move generation, leaving this (and PatchDataLayerRefs) unmovable.
 
         virtual patch::PatchDataLayer &get(u64 id_patch)             = 0;
         virtual const patch::PatchDataLayer &get(u64 id_patch) const = 0;

--- a/src/shamsolvergraph/include/shamsolvergraph/edge/IDataEdge.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/edge/IDataEdge.hpp
@@ -35,7 +35,8 @@ namespace shamrock::solvergraph {
 
         inline virtual void free_alloc() { data = {}; }
 
-        virtual ~IDataEdge() {}
+        // No destructor here on purpose: IEdge's is already virtual, and declaring one would
+        // suppress implicit move generation, leaving IDataEdge neither movable nor copyable.
 
         static std::shared_ptr<IDataEdge<T>> make_shared(std::string name, std::string texsymbol) {
             return std::make_shared<IDataEdge<T>>(name, texsymbol);

--- a/src/shamsolvergraph/include/shamsolvergraph/edge/IEdge.hpp
+++ b/src/shamsolvergraph/include/shamsolvergraph/edge/IEdge.hpp
@@ -27,6 +27,16 @@ namespace shamrock::solvergraph {
 
     class IEdge : public shambase::WithUUID<IEdge, u64>, public IFreeable {
         public:
+        IEdge() = default;
+
+        IEdge(const IEdge &)            = delete; /// would duplicate the uuid
+        IEdge &operator=(const IEdge &) = delete; /// would duplicate the uuid
+
+        /// Declared explicitly: the destructor below would otherwise suppress implicit move
+        /// generation, and copy is deleted, leaving IEdge neither movable nor copyable.
+        IEdge(IEdge &&) noexcept            = default;
+        IEdge &operator=(IEdge &&) noexcept = default;
+
         inline std::string get_label() const { return _impl_get_dot_label(); }
         inline std::string get_tex_symbol() const { return _impl_get_tex_symbol(); }
 

--- a/src/tests/shambase/WithUUID_tests.cpp
+++ b/src/tests/shambase/WithUUID_tests.cpp
@@ -15,9 +15,11 @@
 
 #include "shambase/WithUUID.hpp"
 #include "shamtest/shamtest.hpp"
+#include <type_traits>
 #include <unordered_set>
 #include <mutex>
 #include <thread>
+#include <utility>
 
 template<bool thread_safe>
 void test() {
@@ -71,6 +73,56 @@ void test() {
     }
 }
 
-NEW_TEST(Unittest, "shambase/WithUUID(t-unsafe)", 1) { test<false>(); }
+template<bool thread_safe>
+void test_move_invalidate() {
 
-NEW_TEST(Unittest, "shambase/WithUUID(safe)", 1) { test<true>(); }
+    class B1 : public shambase::WithUUID<B1, u32, thread_safe> {};
+
+    // Copying would duplicate the uuid across two live instances, so it must be disallowed
+    // entirely rather than merely discouraged.
+    static_assert(!std::is_copy_constructible_v<B1>, "WithUUID must not be copy-constructible");
+    static_assert(!std::is_copy_assignable_v<B1>, "WithUUID must not be copy-assignable");
+
+    B1 a;
+    u32 a_uuid = a.get_uuid();
+    REQUIRE(a.is_alive());
+    REQUIRE(a_uuid != decltype(a)::invalid_uuid);
+
+    // Move construction transfers the uuid to the destination and invalidates the source.
+    B1 b(std::move(a));
+    REQUIRE(b.get_uuid() == a_uuid);
+    REQUIRE(b.is_alive());
+    // NOLINTBEGIN(bugprone-use-after-move): checking the moved-from state is the point here.
+    REQUIRE(a.is_alive() == false);
+    REQUIRE(a.get_uuid() == decltype(a)::invalid_uuid);
+    // NOLINTEND(bugprone-use-after-move)
+
+    // Move assignment does the same: transfers the uuid over, invalidates the source, on top of
+    // whatever uuid the destination held before (which is simply discarded here -- WithUUID
+    // itself has no notion of "this uuid is going away", that is up to classes built on top of
+    // it, e.g. LifetimeTracker).
+    B1 c;
+    REQUIRE(c.is_alive());
+    c = std::move(b);
+    REQUIRE(c.get_uuid() == a_uuid);
+    REQUIRE(c.is_alive());
+    // NOLINTBEGIN(bugprone-use-after-move): checking the moved-from state is the point here.
+    REQUIRE(b.is_alive() == false);
+    REQUIRE(b.get_uuid() == decltype(b)::invalid_uuid);
+    // NOLINTEND(bugprone-use-after-move)
+
+    // Self move-assignment must not invalidate the only instance holding the uuid.
+    c = std::move(c);
+    REQUIRE(c.is_alive());
+    REQUIRE(c.get_uuid() == a_uuid);
+}
+
+NEW_TEST(Unittest, "shambase/WithUUID(t-unsafe)", 1) {
+    test<false>();
+    test_move_invalidate<false>();
+}
+
+NEW_TEST(Unittest, "shambase/WithUUID(safe)", 1) {
+    test<true>();
+    test_move_invalidate<true>();
+}


### PR DESCRIPTION
make WithUUID move compatible without duplicating the uuid