### PR TITLE
[shamalgs] rename sort_by_key to sort_by_key_pow2_len

### DIFF
--- a/src/shamalgs/include/shamalgs/details/algorithm/algorithm.hpp
+++ b/src/shamalgs/include/shamalgs/details/algorithm/algorithm.hpp
@@ -31,6 +31,8 @@ namespace shamalgs::algorithm {
     /**
      * @brief Sort the buffer according to the key order
      *
+     * @note len must be a power of 2
+     *
      * @tparam T
      * @param q
      * @param buf_key
@@ -38,18 +40,18 @@ namespace shamalgs::algorithm {
      * @param len
      */
     template<class Tkey, class Tval>
-    void sort_by_key(
+    void sort_by_key_pow2_len(
         sycl::queue &q, sycl::buffer<Tkey> &buf_key, sycl::buffer<Tval> &buf_values, u32 len) {
-        shamalgs::primitives::sort_by_key(q, buf_key, buf_values, len);
+        shamalgs::primitives::sort_by_key_pow2_len(q, buf_key, buf_values, len);
     }
 
     template<class Tkey, class Tval>
-    void sort_by_key(
+    void sort_by_key_pow2_len(
         const sham::DeviceScheduler_ptr &sched,
         sham::DeviceBuffer<Tkey> &buf_key,
         sham::DeviceBuffer<Tval> &buf_values,
         u32 len) {
-        shamalgs::primitives::sort_by_key(sched, buf_key, buf_values, len);
+        shamalgs::primitives::sort_by_key_pow2_len(sched, buf_key, buf_values, len);
     }
 
     /**

--- a/src/shamalgs/include/shamalgs/primitives/sort_by_keys.hpp
+++ b/src/shamalgs/include/shamalgs/primitives/sort_by_keys.hpp
@@ -18,13 +18,10 @@
  * based on the key values. The algorithms are optimized for GPU execution
  * using sycl::buffers or USM.
  *
- * The sorting functions come in two variants:
- * - `sort_by_key_pow2_len`: Optimized for power-of-2 buffer lengths
- * - `sort_by_key`: General case
+ * `sort_by_key_pow2_len` only supports buffer lengths that are a power of 2
+ * (callers must round up beforehand, e.g. with `shambase::roundup_pow2`).
  */
 
-#include "shambase/exception.hpp"
-#include "shambase/integer.hpp"
 #include "shambackends/DeviceBuffer.hpp"
 #include "shambackends/DeviceQueue.hpp"
 
@@ -90,80 +87,5 @@ namespace shamalgs::primitives {
         sham::DeviceBuffer<Tkey> &buf_key,
         sham::DeviceBuffer<Tval> &buf_values,
         u32 len);
-
-    /**
-     * @brief Sort key-value pairs using sycl::buffers
-     *
-     * Performs an in-place parallel sort of key-value pairs where the values
-     * are reordered according to the sorted order of their corresponding keys.
-     *
-     * @tparam Tkey Key type - must be comparable (supports < operator)
-     * @tparam Tval Value type - can be any copyable type
-     * @param q sycl::queue for device execution
-     * @param buf_key Buffer containing the keys to sort by
-     * @param buf_values Buffer containing the values to reorder
-     * @param len Length of both buffers
-     *
-     * @throws std::invalid_argument if len is not a power of 2
-     *
-     * @note The function modifies both buffers in-place
-     * @note This function currently only supports powers of 2
-     *
-     * @code
-     * // Example: Sort data by keys
-     * sycl::queue q;
-     * sycl::buffer<double> keys(input_keys, N);
-     * sycl::buffer<DataType> values(input_values, N);
-     *
-     * // Sort values according to key order
-     * sort_by_key(q, keys, values, N);
-     * @endcode
-     */
-    template<class Tkey, class Tval>
-    void sort_by_key(
-        sycl::queue &q, sycl::buffer<Tkey> &buf_key, sycl::buffer<Tval> &buf_values, u32 len) {
-        if (!shambase::is_pow_of_two(len))
-            shambase::throw_with_loc<std::invalid_argument>("Length must be a power of 2");
-        sort_by_key_pow2_len(q, buf_key, buf_values, len);
-    }
-
-    /**
-     * @brief Sort key-value pairs using USM buffers
-     *
-     * Performs an in-place parallel sort of key-value pairs where the values
-     * are reordered according to the sorted order of their corresponding keys.
-     *
-     * @tparam Tkey Key type - must be comparable (supports < operator)
-     * @tparam Tval Value type - can be any copyable type
-     * @param sched sham::DeviceScheduler_ptr for execution
-     * @param buf_key Device buffer containing the keys to sort by
-     * @param buf_values Device buffer containing the values to reorder
-     * @param len Length of both buffers
-     *
-     * @throws std::invalid_argument if len is not a power of 2
-     *
-     * @note The function modifies both buffers in-place
-     * @note This function currently only supports powers of 2
-     *
-     * @code
-     * // Example: Sort data by keys using USM buffers
-     * auto sched = shamsys::instance::get_compute_scheduler_ptr();
-     * sham::DeviceBuffer<double> keys(input_keys, N);
-     * sham::DeviceBuffer<DataType> values(input_values, N);
-     *
-     * // Sort values according to key order
-     * sort_by_key(sched, keys, values, N);
-     * @endcode
-     */
-    template<class Tkey, class Tval>
-    void sort_by_key(
-        const sham::DeviceScheduler_ptr &sched,
-        sham::DeviceBuffer<Tkey> &buf_key,
-        sham::DeviceBuffer<Tval> &buf_values,
-        u32 len) {
-        if (!shambase::is_pow_of_two(len))
-            shambase::throw_with_loc<std::invalid_argument>("Length must be a power of 2");
-        sort_by_key_pow2_len(sched, buf_key, buf_values, len);
-    }
 
 } // namespace shamalgs::primitives

--- a/src/shamalgs/src/details/numeric/numeric.cpp
+++ b/src/shamalgs/src/details/numeric/numeric.cpp
@@ -287,7 +287,8 @@ namespace shamalgs::numeric {
 
             // how to be a patate? Resize buffers to diligently become powers of 2, and don't update
             // the variable holding their length
-            shamalgs::algorithm::sort_by_key(sched, valid_keys, valid_values, pow2_len_key);
+            shamalgs::algorithm::sort_by_key_pow2_len(
+                sched, valid_keys, valid_values, pow2_len_key);
         }
 
         return {std::move(valid_values), std::move(offsets_bins)};

--- a/src/shamalgs/src/primitives/sort_by_keys.cpp
+++ b/src/shamalgs/src/primitives/sort_by_keys.cpp
@@ -14,15 +14,21 @@
  *
  */
 
-#include "shamalgs/primitives/sort_by_keys.hpp"
+#include "shambase/exception.hpp"
 #include "shamalgs/details/algorithm/bitonicSort.hpp"
 #include "shamalgs/details/algorithm/bitonicSort_updated_usm.hpp"
+#include "shamalgs/primitives/sort_by_keys.hpp"
 
 namespace shamalgs::primitives {
 
     template<class Tkey, class Tval>
     void sort_by_key_pow2_len(
         sycl::queue &q, sycl::buffer<Tkey> &buf_key, sycl::buffer<Tval> &buf_values, u32 len) {
+
+        if (!shambase::is_pow_of_two(len)) {
+            throw shambase::make_except_with_loc<std::invalid_argument>(
+                "Length must be a power of 2");
+        }
 
         if (len < 5e3) {
             shamalgs::algorithm::details::sort_by_key_bitonic_fallback(q, buf_key, buf_values, len);
@@ -38,6 +44,12 @@ namespace shamalgs::primitives {
         sham::DeviceBuffer<Tkey> &buf_key,
         sham::DeviceBuffer<Tval> &buf_values,
         u32 len) {
+
+        if (!shambase::is_pow_of_two(len)) {
+            throw shambase::make_except_with_loc<std::invalid_argument>(
+                "Length must be a power of 2");
+        }
+
         shamalgs::algorithm::details::sort_by_key_bitonic_updated_usm<Tkey, Tval, 16>(
             sched, buf_key, buf_values, len);
     }

--- a/src/shamtree/src/MortonCodeSortedSet.cpp
+++ b/src/shamtree/src/MortonCodeSortedSet.cpp
@@ -37,7 +37,7 @@ namespace shamtree {
         map_morton_id_to_obj_id.resize(morton_count);
         shamalgs::primitives::fill_buffer_index(map_morton_id_to_obj_id, morton_count);
 
-        shamalgs::algorithm::sort_by_key(
+        shamalgs::algorithm::sort_by_key_pow2_len(
             dev_sched, morton_codes_to_sort, map_morton_id_to_obj_id, morton_count);
 
         return MortonCodeSortedSet<Tmorton, Tvec, dim>(

--- a/src/shamtree/src/kernels/key_morton_sort.cpp
+++ b/src/shamtree/src/kernels/key_morton_sort.cpp
@@ -24,7 +24,8 @@ void sycl_sort_morton_key_pair<u32, MultiKernel>(
     std::unique_ptr<sycl::buffer<u32>> &buf_index,
     std::unique_ptr<sycl::buffer<u32>> &buf_morton) {
 
-    shamalgs::algorithm::sort_by_key(queue, *buf_morton, *buf_index, morton_count_rounded_pow);
+    shamalgs::algorithm::sort_by_key_pow2_len(
+        queue, *buf_morton, *buf_index, morton_count_rounded_pow);
 }
 
 template<>
@@ -34,5 +35,6 @@ void sycl_sort_morton_key_pair<u64, MultiKernel>(
     std::unique_ptr<sycl::buffer<u32>> &buf_index,
     std::unique_ptr<sycl::buffer<u64>> &buf_morton) {
 
-    shamalgs::algorithm::sort_by_key(queue, *buf_morton, *buf_index, morton_count_rounded_pow);
+    shamalgs::algorithm::sort_by_key_pow2_len(
+        queue, *buf_morton, *buf_index, morton_count_rounded_pow);
 }

--- a/src/tests/shamalgs/algorithm/algorithmTests.cpp
+++ b/src/tests/shamalgs/algorithm/algorithmTests.cpp
@@ -10,22 +10,22 @@
 #include "shamalgs/algorithm.hpp"
 #include "sortTests.hpp"
 
-NEW_TEST(Unittest, "shamalgs/algorithm/sort_by_key", 1) {
+NEW_TEST(Unittest, "shamalgs/algorithm/sort_by_key_pow2_len", 1) {
     TestSortByKey<u32, u32> test(
-        (TestSortByKey<u32, u32>::vFunctionCall) shamalgs::algorithm::sort_by_key);
+        (TestSortByKey<u32, u32>::vFunctionCall) shamalgs::algorithm::sort_by_key_pow2_len);
     test.check();
 }
 
-NEW_TEST(Unittest, "shamalgs/algorithm/sort_by_key(usm)", 1) {
-    TestSortByKeyUSM<u32, u32> test(
-        (TestSortByKeyUSM<u32, u32>::vFunctionCall) shamalgs::algorithm::sort_by_key<u32, u32>);
+NEW_TEST(Unittest, "shamalgs/algorithm/sort_by_key_pow2_len(usm)", 1) {
+    TestSortByKeyUSM<u32, u32> test((TestSortByKeyUSM<u32, u32>::vFunctionCall)
+                                        shamalgs::algorithm::sort_by_key_pow2_len<u32, u32>);
     test.check();
 }
 
-NEW_TEST(Benchmark, "shamalgs/algorithm/sort_by_key:benchmark", 1) {
+NEW_TEST(Benchmark, "shamalgs/algorithm/sort_by_key_pow2_len:benchmark", 1) {
 
     TestSortByKey<u32, u32> test(
-        (TestSortByKey<u32, u32>::vFunctionCall) shamalgs::algorithm::sort_by_key);
+        (TestSortByKey<u32, u32>::vFunctionCall) shamalgs::algorithm::sort_by_key_pow2_len);
     f64 rate = test.benchmark_one(1U << 24U);
 
     logger::raw_ln("rate =", rate);

--- a/src/tests/shamalgs/algorithm/bitonicSortTests.cpp
+++ b/src/tests/shamalgs/algorithm/bitonicSortTests.cpp
@@ -234,7 +234,7 @@ NEW_TEST(Benchmark, "shamalgs/algorithm/details/bitonicSorts:benchmark", 1) {
     if(false){
         TestSortByKey<u32, u32>test (
         (TestSortByKey<u32, u32>::vFunctionCall)
-            shamalgs::algorithm::sort_by_key
+            shamalgs::algorithm::sort_by_key_pow2_len
         );
 
         auto result = test.benchmark();

--- a/src/tests/shamalgs/algorithm/sortTests.hpp
+++ b/src/tests/shamalgs/algorithm/sortTests.hpp
@@ -223,7 +223,7 @@ struct TestIndexRemap {
             shamalgs::random::mock_buffer<u32>(0x111, len, 0, 1U << 7U));
 
         sycl::buffer<u32> buf_index_map = shamalgs::algorithm::gen_buffer_index(q, len);
-        shamalgs::algorithm::sort_by_key(q, *buf_key, buf_index_map, len);
+        shamalgs::algorithm::sort_by_key_pow2_len(q, *buf_key, buf_index_map, len);
 
         sycl::buffer<u32> remaped_key = fct(q, *buf_key_dup, buf_index_map, len);
 
@@ -271,7 +271,7 @@ struct TestIndexRemapUSM {
 
         sham::DeviceBuffer<u32> buf_index_map = shamalgs::primitives::gen_buffer_index(sched, len);
 
-        shamalgs::algorithm::sort_by_key(sched, buf_key, buf_index_map, len);
+        shamalgs::algorithm::sort_by_key_pow2_len(sched, buf_key, buf_index_map, len);
 
         sham::DeviceBuffer<u32> remaped_key(len, sched);
         fct(sched, buf_key_dup, remaped_key, buf_index_map, len);


### PR DESCRIPTION
sort_by_key only ever worked on power-of-2 lengths (it just guarded sort_by_key_pow2_len with a runtime check before forwarding to it), and every real call site already rounds up its length beforehand. Drop the redundant generic-named wrapper and propagate the pow2_len suffix through shamalgs::primitives, shamalgs::algorithm, and their callers so the constraint is visible at every call site instead of hidden behind an indirection.

Assisted-by: Claude