### PR TITLE
[CI] Add mergify[bot] to the author blacklist

### DIFF
--- a/tools/update_authors.py
+++ b/tools/update_authors.py
@@ -33,6 +33,7 @@ AUTH_BLACKLIST = [
     "autofix-ci[bot]",
     "gemini-code-assist[bot]",
     "github-actions[bot]",
+    "mergify[bot]",
     "pre-commit-ci[bot]",
 ]
 


### PR DESCRIPTION
Excludes the mergify bot from generated @author doxygen headers, same as the other CI bots already in the list.