### PR TITLE
[CI] Force IPv4 for apt.llvm.org fetches in phys-test image build

### DIFF
--- a/.github/dockerfiles/phys_test_image_acpp_omp/Dockerfile
+++ b/.github/dockerfiles/phys_test_image_acpp_omp/Dockerfile
@@ -7,10 +7,20 @@ ARG CLANGVERSION=18
 # ----------------------------
 # Install LLVM toolchain
 # ----------------------------
-RUN wget https://apt.llvm.org/llvm.sh && \
-    chmod +x llvm.sh && \
+# apt.llvm.org is served via Fastly, which advertises IPv6 addresses that
+# GitHub-hosted runners often can't route reliably, causing intermittent
+# "Network is unreachable" failures in apt/wget (including GPG key fetch).
+# Force IPv4 for apt and wget, and retry llvm.sh to absorb transient
+# Fastly edge failures.
+RUN sudo sh -c 'echo "Acquire::ForceIPv4 \"true\";" > /etc/apt/apt.conf.d/99force-ipv4' && \
     sudo apt update && \
-    sudo ./llvm.sh ${CLANGVERSION} && \
+    wget -4 https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    for i in 1 2 3 4 5; do \
+        sudo ./llvm.sh ${CLANGVERSION} && break; \
+        echo "llvm.sh failed (attempt $i), retrying..."; \
+        sleep 15; \
+    done && \
     sudo apt install -y \
     libclang-${CLANGVERSION}-dev \
     clang-tools-${CLANGVERSION} \

--- a/.github/dockerfiles/phys_test_image_acpp_omp/Dockerfile
+++ b/.github/dockerfiles/phys_test_image_acpp_omp/Dockerfile
@@ -11,7 +11,7 @@ ARG CLANGVERSION=18
 # GitHub-hosted runners often can't route reliably, causing intermittent
 # "Network is unreachable" failures in apt/wget (including GPG key fetch).
 # Force IPv4 for apt and wget, and retry llvm.sh to absorb transient
-# Fastly edge failures. (Claud generated comment)
+# Fastly edge failures. (Claude generated comment)
 RUN sudo sh -c 'echo "Acquire::ForceIPv4 \"true\";" > /etc/apt/apt.conf.d/99force-ipv4' && \
     sudo apt update && \
     wget -4 https://apt.llvm.org/llvm.sh && \

--- a/.github/dockerfiles/phys_test_image_acpp_omp/Dockerfile
+++ b/.github/dockerfiles/phys_test_image_acpp_omp/Dockerfile
@@ -11,7 +11,7 @@ ARG CLANGVERSION=18
 # GitHub-hosted runners often can't route reliably, causing intermittent
 # "Network is unreachable" failures in apt/wget (including GPG key fetch).
 # Force IPv4 for apt and wget, and retry llvm.sh to absorb transient
-# Fastly edge failures.
+# Fastly edge failures. (Claud generated comment)
 RUN sudo sh -c 'echo "Acquire::ForceIPv4 \"true\";" > /etc/apt/apt.conf.d/99force-ipv4' && \
     sudo apt update && \
     wget -4 https://apt.llvm.org/llvm.sh && \


### PR DESCRIPTION
Try to use IPV4 for apt.llvm fetch to avoid job errors in CI