### PR TITLE
[shamalgs] pass dev_sched by const reference in sparse exchange helpers

### DIFF
--- a/src/shamalgs/include/shamalgs/collective/sparseXchg.hpp
+++ b/src/shamalgs/include/shamalgs/collective/sparseXchg.hpp
@@ -73,19 +73,19 @@ namespace shamalgs::collective {
     };
 
     void sparse_comm_debug_infos(
-        std::shared_ptr<sham::DeviceScheduler> dev_sched,
+        const std::shared_ptr<sham::DeviceScheduler> &dev_sched,
         const std::vector<SendPayload> &message_send,
         std::vector<RecvPayload> &message_recv,
         const SparseCommTable &comm_table);
 
     void sparse_comm_isend_probe_count_irecv(
-        std::shared_ptr<sham::DeviceScheduler> dev_sched,
+        const std::shared_ptr<sham::DeviceScheduler> &dev_sched,
         const std::vector<SendPayload> &message_send,
         std::vector<RecvPayload> &message_recv,
         const SparseCommTable &comm_table);
 
     void sparse_comm_allgather_isend_irecv(
-        std::shared_ptr<sham::DeviceScheduler> dev_sched,
+        const std::shared_ptr<sham::DeviceScheduler> &dev_sched,
         const std::vector<SendPayload> &message_send,
         std::vector<RecvPayload> &message_recv,
         const SparseCommTable &comm_table);

--- a/src/shamalgs/include/shamalgs/collective/sparse_exchange.hpp
+++ b/src/shamalgs/include/shamalgs/collective/sparse_exchange.hpp
@@ -62,7 +62,7 @@ namespace shamalgs::collective {
 
     template<sham::USMKindTarget target>
     void sparse_exchange(
-        std::shared_ptr<sham::DeviceScheduler> dev_sched,
+        const std::shared_ptr<sham::DeviceScheduler> &dev_sched,
         std::vector<std::unique_ptr<sham::DeviceBuffer<u8, target>>> &bytebuffer_send,
         std::vector<std::unique_ptr<sham::DeviceBuffer<u8, target>>> &bytebuffer_recv,
         const CommTable &comm_table);

--- a/src/shamalgs/src/collective/sparseXchg.cpp
+++ b/src/shamalgs/src/collective/sparseXchg.cpp
@@ -235,7 +235,7 @@ const u64 SHAM_SPARSE_COMM_INFLIGHT_LIM = get_SHAM_SPARSE_COMM_INFLIGHT_LIM();
 
 namespace shamalgs::collective {
     void sparse_comm_debug_infos(
-        std::shared_ptr<sham::DeviceScheduler> dev_sched,
+        const std::shared_ptr<sham::DeviceScheduler> &dev_sched,
         const std::vector<SendPayload> &message_send,
         std::vector<RecvPayload> &message_recv,
         const SparseCommTable &comm_table) {
@@ -307,7 +307,7 @@ namespace shamalgs::collective {
     }
 
     void sparse_comm_isend_probe_count_irecv(
-        std::shared_ptr<sham::DeviceScheduler> dev_sched,
+        const std::shared_ptr<sham::DeviceScheduler> &dev_sched,
         const std::vector<SendPayload> &message_send,
         std::vector<RecvPayload> &message_recv,
         const SparseCommTable &comm_table) {
@@ -395,7 +395,7 @@ namespace shamalgs::collective {
     }
 
     void sparse_comm_allgather_isend_irecv(
-        std::shared_ptr<sham::DeviceScheduler> dev_sched,
+        const std::shared_ptr<sham::DeviceScheduler> &dev_sched,
         const std::vector<SendPayload> &message_send,
         std::vector<RecvPayload> &message_recv,
         const SparseCommTable &comm_table) {

--- a/src/shamalgs/src/collective/sparse_exchange.cpp
+++ b/src/shamalgs/src/collective/sparse_exchange.cpp
@@ -245,7 +245,7 @@ namespace shamalgs::collective {
     }
 
     void sparse_exchange(
-        std::shared_ptr<sham::DeviceScheduler> dev_sched,
+        const std::shared_ptr<sham::DeviceScheduler> &dev_sched,
         const std::vector<const u8 *> &bytebuffer_send,
         const std::vector<u8 *> &bytebuffer_recv,
         const CommTable &comm_table) {
@@ -294,7 +294,7 @@ namespace shamalgs::collective {
 
     template<sham::USMKindTarget target>
     void sparse_exchange(
-        std::shared_ptr<sham::DeviceScheduler> dev_sched,
+        const std::shared_ptr<sham::DeviceScheduler> &dev_sched,
         std::vector<std::unique_ptr<sham::DeviceBuffer<u8, target>>> &bytebuffer_send,
         std::vector<std::unique_ptr<sham::DeviceBuffer<u8, target>>> &bytebuffer_recv,
         const CommTable &comm_table) {
@@ -382,13 +382,13 @@ namespace shamalgs::collective {
 
     // template instantiations
     template void sparse_exchange<sham::device>(
-        std::shared_ptr<sham::DeviceScheduler> dev_sched,
+        const std::shared_ptr<sham::DeviceScheduler> &dev_sched,
         std::vector<std::unique_ptr<sham::DeviceBuffer<u8, sham::device>>> &bytebuffer_send,
         std::vector<std::unique_ptr<sham::DeviceBuffer<u8, sham::device>>> &bytebuffer_recv,
         const CommTable &comm_table);
 
     template void sparse_exchange<sham::host>(
-        std::shared_ptr<sham::DeviceScheduler> dev_sched,
+        const std::shared_ptr<sham::DeviceScheduler> &dev_sched,
         std::vector<std::unique_ptr<sham::DeviceBuffer<u8, sham::host>>> &bytebuffer_send,
         std::vector<std::unique_ptr<sham::DeviceBuffer<u8, sham::host>>> &bytebuffer_recv,
         const CommTable &comm_table);


### PR DESCRIPTION
Fixes clang-tidy performance-unnecessary-value-param warnings on `std::shared_ptr<sham::DeviceScheduler>`