### PR TITLE
[CI] Remove macos-15-intel from CI env tests matrix

### DIFF
--- a/.github/workflows/env_tests.yml
+++ b/.github/workflows/env_tests.yml
@@ -141,15 +141,6 @@ jobs:
             },
             {
               "machine": "macos-generic.acpp",
-              "runson": "[\"macos-15-intel\"]",
-              "imagename": "MacOS-15 (intel)",
-              "runtest": true,
-              "runtest_rscript": true,
-              "mpiargs": "--oversubscribe",
-              "ccache-key-extra": "macos15-intel"
-            },
-            {
-              "machine": "macos-generic.acpp",
               "runson": "[\"macos-26\"]",
               "imagename": "MacOS-26",
               "runtest": true,


### PR DESCRIPTION
Homebrew moved x86_64 macOS to tier 3 as of September 2026, which forces a full gcc rebuild on that runner and is too costly to run in CI.