### PR TITLE
[Agents] update commit guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,8 @@ before pushing (a plain amend re-runs the hook):
 - **Author** = the human who initiated the work. Use `--author`; do not
   change gitconfig.
 - Trailer = `Assisted-by: <agent>` only. No model names. No
-  `Co-authored-by` (`Co-authored-by` is for extra human authors only).
+  `Co-authored-by` (`Co-authored-by` is for extra human authors only). Also
+  no session url.
 
 Check `git log -1 --format='Author: %an <%ae>%n%B'` before push.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,12 +188,6 @@ before pushing (a plain amend re-runs the hook):
   change gitconfig.
 - Trailer = `Assisted-by: <agent>` only. No model names. No
   `Co-authored-by` (`Co-authored-by` is for extra human authors only).
-- **Never** include a link to the assistant session/conversation (e.g. a
-  `Claude-Session:` trailer or any `claude.ai/code/session_...` URL) in the
-  commit message. Session tooling may suggest appending one by default —
-  strip it during the `--no-verify` amend along with any injected
-  `Co-authored-by`/model-name lines. Session links belong in the harness
-  UI, not in permanent git history.
 
 Check `git log -1 --format='Author: %an <%ae>%n%B'` before push.
 
@@ -210,10 +204,6 @@ https://github.com/Shamrock-code/Shamrock/compare/main...<fork-owner>:Shamrock:<
 ```
 
 Replace `<fork-owner>` and `<branch>` with the fork owner and branch name.
-
-PR descriptions follow the same rule as commit messages: no session-link
-trailer (`Claude-Session:` or a `claude.ai/code/session_...` URL). Drop it
-from the body even if the session's default footer suggests adding one.
 
 PR lookups should also target upstream:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,7 @@ upstream `main` on that repo.
 
 ### Commit authorship
 
-Commit-msg hooks can rewrite the author and inject `Co-authored-by` (often)
+Commit-msg hooks can rewrite the author and inject `Co-authored-by` (often
 with a model name). After every `git commit`, amend with `--no-verify`
 before pushing (a plain amend re-runs the hook):
 
@@ -188,6 +188,12 @@ before pushing (a plain amend re-runs the hook):
   change gitconfig.
 - Trailer = `Assisted-by: <agent>` only. No model names. No
   `Co-authored-by` (`Co-authored-by` is for extra human authors only).
+- **Never** include a link to the assistant session/conversation (e.g. a
+  `Claude-Session:` trailer or any `claude.ai/code/session_...` URL) in the
+  commit message. Session tooling may suggest appending one by default —
+  strip it during the `--no-verify` amend along with any injected
+  `Co-authored-by`/model-name lines. Session links belong in the harness
+  UI, not in permanent git history.
 
 Check `git log -1 --format='Author: %an <%ae>%n%B'` before push.
 
@@ -204,6 +210,10 @@ https://github.com/Shamrock-code/Shamrock/compare/main...<fork-owner>:Shamrock:<
 ```
 
 Replace `<fork-owner>` and `<branch>` with the fork owner and branch name.
+
+PR descriptions follow the same rule as commit messages: no session-link
+trailer (`Claude-Session:` or a `claude.ai/code/session_...` URL). Drop it
+from the body even if the session's default footer suggests adding one.
 
 PR lookups should also target upstream:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,15 @@
 @AGENTS.md
 
+## Claude Code: commit and PR attribution
+
+Claude Code sessions (including on the web) may default to appending a
+`Claude-Session:` trailer or a `claude.ai/code/session_...` URL to commit
+messages and PR descriptions. **Never include that link** in either —
+strip it during the `--no-verify` amend described in AGENTS.md's "Commit
+authorship" section, alongside any injected `Co-authored-by`/model-name
+lines. Session links belong in the Claude Code UI, not in permanent git
+history or PR bodies.
+
 ## Claude Code on the web: container setup
 
 This container has no GPU, so AdaptiveCpp is built from source targeting


### PR DESCRIPTION
Codify that Claude sessions must never include a Claude-Session trailer or claude.ai/code/session_... URL in commit messages or PR descriptions, stripping it during the existing --no-verify amend step alongside injected Co-authored-by/model-name lines.