### PR TITLE
[shammath] Remove useless lambdas in Riemann solvers

### DIFF
--- a/src/shammath/include/shammath/riemann_hll.hpp
+++ b/src/shammath/include/shammath/riemann_hll.hpp
@@ -40,29 +40,25 @@ namespace shammath {
         const auto fluxR = hydro_flux_x(primR, gamma);
 
         // Equation (10.26) from Toro 3rd Edition , Springer 2009
-        auto hll_flux = [=]() {
-            // const auto S_L_upwind = sham::min(S_L, 0.0);
-            // const auto S_R_upwind = sham::max(S_R, 0.0);
-            // const auto S_norm     = 1.0 / (S_R_upwind - S_L_upwind);
-            // return (fluxL * S_R_upwind - fluxR * S_L_upwind
-            //         + (consR - consL) * S_R_upwind * S_L_upwind)
-            //        * S_norm;
+        // const auto S_L_upwind = sham::min(S_L, 0.0);
+        // const auto S_R_upwind = sham::max(S_R, 0.0);
+        // const auto S_norm     = 1.0 / (S_R_upwind - S_L_upwind);
+        // return (fluxL * S_R_upwind - fluxR * S_L_upwind
+        //         + (consR - consL) * S_R_upwind * S_L_upwind)
+        //        * S_norm;
 
-            if (S_L >= 0)
-                return fluxL;
-            else if (S_R <= 0)
-                return fluxR;
-            else {
-                // Only the intermediate (star) state needs the conservative form, so it is
-                // formed here rather than at the call site (which only has primitives).
-                const auto consL  = prim_to_cons(primL, gamma);
-                const auto consR  = prim_to_cons(primR, gamma);
-                const auto S_norm = 1.0 / (S_R - S_L);
-                return (fluxL * S_R - fluxR * S_L + (consR - consL) * S_R * S_L) * S_norm;
-            }
-        };
-
-        return hll_flux();
+        if (S_L >= 0)
+            return fluxL;
+        else if (S_R <= 0)
+            return fluxR;
+        else {
+            // Only the intermediate (star) state needs the conservative form, so it is
+            // formed here rather than at the call site (which only has primitives).
+            const auto consL  = prim_to_cons(primL, gamma);
+            const auto consR  = prim_to_cons(primR, gamma);
+            const auto S_norm = 1.0 / (S_R - S_L);
+            return (fluxL * S_R - fluxR * S_L + (consR - consL) * S_R * S_L) * S_norm;
+        }
     }
 
     template<class Tprim>

--- a/src/shammath/include/shammath/riemann_hllc.hpp
+++ b/src/shammath/include/shammath/riemann_hllc.hpp
@@ -132,18 +132,14 @@ namespace shammath {
         Tcons FR_star = FR + SR * (cR_star - cR);
 
         // HLLC flux
-        auto hllc_flux = [=]() {
-            if (SL >= 0) {
-                return FL;
-            } else if (S_star >= 0) {
-                return FL_star;
-            } else if (SR >= 0) {
-                return FR_star;
-            } else
-                return FR;
-        };
-
-        return hllc_flux();
+        if (SL >= 0) {
+            return FL;
+        } else if (S_star >= 0) {
+            return FL_star;
+        } else if (SR >= 0) {
+            return FR_star;
+        } else
+            return FR;
     }
 
     /**
@@ -264,18 +260,14 @@ namespace shammath {
         Tcons FR_star = FR + SR * (cR_star - cR);
 
         // HLLC flux
-        auto hllc_flux = [=]() {
-            if (SL >= 0) {
-                return FL;
-            } else if (S_star >= 0) {
-                return FL_star;
-            } else if (SR >= 0) {
-                return FR_star;
-            } else
-                return FR;
-        };
-
-        return hllc_flux();
+        if (SL >= 0) {
+            return FL;
+        } else if (S_star >= 0) {
+            return FL_star;
+        } else if (SR >= 0) {
+            return FR_star;
+        } else
+            return FR;
     }
 
     /**


### PR DESCRIPTION
The HLL and HLLC flux selection was wrapped in an immediately-invoked lambda that added no value; inline the if/else chain as direct returns.